### PR TITLE
Include the storage wallet instantiation function into distribution files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { makeCurrencyWallet } from './currencyWallets/api.js'
+import { makeStorageWallet } from "./storage/storageApi";
 import { makeContext } from './io/context.js'
 
 // Sub-module exports:
@@ -36,3 +37,8 @@ export function makeABCContext (apiKey, appId, opts) {
  * Creates a new wallet object based on a set of keys.
  */
 export { makeCurrencyWallet }
+
+/**
+ * Creates a new wallet object based on a set of keys.
+ */
+export { makeStorageWallet}


### PR DESCRIPTION
According to the documentation at https://developer.airbitz.co/javascript/#makestoragewallet the makeStorageWallet() function should be available in order to instantiate an ABCStorageWallet, however, the rollup is not including this method on the distribution code during the build process. The specified method was imported to the entry point file so rollup can include it during the build.