### PR TITLE
William/prefer edge metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-node": "^6.0.0",
     "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-standard": "^3.0.1",
-    "flow-bin": "^0.62.0",
+    "flow-bin": "^0.76.0",
     "husky": "^0.14.3",
     "import-sort-cli": "^4.2.0",
     "import-sort-parser-babylon": "^4.2.0",

--- a/src/edge-core-index.js
+++ b/src/edge-core-index.js
@@ -13,18 +13,7 @@ export { makeFakeIos } from './io/fake/fake-io.js'
 export { makeNodeIo } from './io/node/node-io.js'
 export { makeReactNativeIo } from './io/react-native/react-native-io.js'
 export { fakeUser } from './io/fake/fakeUser.js'
-export {
-  DustSpendError,
-  errorNames,
-  InsufficientFundsError,
-  NetworkError,
-  ObsoleteApiError,
-  OtpError,
-  PasswordError,
-  PendingFundsError,
-  SameCurrencyError,
-  UsernameError
-} from './error.js'
+export * from './error.js'
 export {
   makeContext,
   makeEdgeContext,
@@ -167,7 +156,13 @@ export type EdgeContextOptions = {
   io?: EdgeRawIo,
   path?: string, // Only used on node.js
   plugins?: Array<EdgeCorePluginFactory>,
-  shapeshiftKey?: string
+  shapeshiftKey?: string,
+
+  // Used by the fake context:
+  localFakeUser?: boolean,
+
+  // Deprecated. Use appId instead:
+  accountType?: string
 }
 
 export type EdgeContext = {

--- a/src/io/fake/serverSchema.js
+++ b/src/io/fake/serverSchema.js
@@ -39,6 +39,6 @@ export const loginDbColumns = [
 ]
 
 // The v2 account creation endpoint doesn't accept legacy keys:
-export const loginCreateColumns = loginDbColumns.filter(
+export const loginCreateColumns: Array<string> = loginDbColumns.filter(
   item => ['mnemonicBox', 'rootKeyBox', 'syncKeyBox'].indexOf(item) < 0
 )

--- a/src/io/fixIo.js
+++ b/src/io/fixIo.js
@@ -46,9 +46,11 @@ export function fixIo (io: EdgeRawIo): EdgeIo {
   }
 
   // The network interface (used by plugins):
-  if (io.net != null) out.net = io.net
   if (io.Socket != null) out.Socket = io.Socket
   if (io.TLSSocket != null) out.TLSSocket = io.TLSSocket
+
+  // $FlowFixMe This has been deprecated since forever ago.
+  if (io.net != null) out.net = io.net
 
   return out
 }

--- a/src/modules/account/account-state.js
+++ b/src/modules/account/account-state.js
@@ -551,7 +551,7 @@ export class AccountState {
     return newWalletInfo.id
   }
 
-  listSplittableWalletTypes (walletId: string) {
+  listSplittableWalletTypes (walletId: string): Array<string> {
     const allWalletInfos = this.allKeys
 
     // Find the wallet we are going to split:

--- a/src/modules/actions.js
+++ b/src/modules/actions.js
@@ -6,6 +6,10 @@ import type {
   EdgeTokenInfo,
   EdgeWalletInfoFull
 } from '../edge-core-index.js'
+import type {
+  TxFileJsons,
+  TxFileNames
+} from './currency/wallet/currency-wallet-reducer.js'
 import type { ExchangePair } from './exchange/exchange-reducer.js'
 import type {
   StorageWalletState,
@@ -97,10 +101,12 @@ export interface CurrencyWalletFiatChanged {
 export interface CurrencyWalletFileChanged {
   type: 'CURRENCY_WALLET_FILE_CHANGED';
   payload: {
-    json: any,
+    creationDate: number,
+    fileName: string,
+    json: Object,
     txid: string,
-    walletId: string,
-    txFileName: any
+    txidHash: string,
+    walletId: string
   };
 }
 
@@ -110,7 +116,7 @@ export interface CurrencyWalletFileChanged {
 export interface CurrencyWalletFilesLoaded {
   type: 'CURRENCY_WALLET_FILES_LOADED';
   payload: {
-    files: any,
+    files: TxFileJsons,
     walletId: string
   };
 }
@@ -121,7 +127,7 @@ export interface CurrencyWalletFilesLoaded {
 export interface CurrencyWalletFileNamesLoaded {
   type: 'CURRENCY_WALLET_FILE_NAMES_LOADED';
   payload: {
-    txFileNames: any,
+    txFileNames: TxFileNames,
     walletId: string
   };
 }

--- a/src/modules/currency/wallet/currency-wallet-files.js
+++ b/src/modules/currency/wallet/currency-wallet-files.js
@@ -17,6 +17,7 @@ import { getCurrencyMultiplier } from '../currency-selectors.js'
 import { combineTxWithFile } from './currency-wallet-api.js'
 import { forEachListener } from './currency-wallet-callbacks.js'
 import type { CurrencyWalletInput } from './currency-wallet-pixie.js'
+import type { TxFileNames } from './currency-wallet-reducer.js'
 
 const LEGACY_MAP_FILE = 'fixedLegacyFileNames.json'
 const WALLET_NAME_FILE = 'WalletName.json'
@@ -82,6 +83,11 @@ export type LegacyAddressFile = {
   }
 }
 
+// Cache used to quickly look up creation dates for legacy files.
+export type LegacyMapFile = {
+  [fileName: string]: { timestamp: number, txidHash: string }
+}
+
 /**
  * Converts a LegacyTransactionFile to a TransactionFile.
  */
@@ -89,7 +95,7 @@ function fixLegacyFile (
   file: LegacyTransactionFile,
   walletCurrency: string,
   walletFiat: string
-) {
+): TransactionFile {
   const out: TransactionFile = {
     creationDate: file.state.creationDate,
     currencies: {},
@@ -115,17 +121,17 @@ function fixLegacyFile (
 function getTxFile (
   state: RootState,
   keyId: string,
-  date: number,
+  creationDate: number,
   txid: string
 ) {
-  const txidHash = hashStorageWalletFilename(state, keyId, txid)
-  const timestamp = date.toFixed(0)
-  const fileName = `${timestamp}-${txidHash}.json`
+  const txidHash: string = hashStorageWalletFilename(state, keyId, txid)
+  const fileName: string = `${creationDate.toFixed(0)}-${txidHash}.json`
   return {
-    txFileName: { txidHash, timestamp, fileName },
-    txFile: getStorageWalletFolder(state, keyId)
+    diskletFile: getStorageWalletFolder(state, keyId)
       .folder('transaction')
-      .file(fileName)
+      .file(fileName),
+    fileName,
+    txidHash
   }
 }
 
@@ -293,13 +299,17 @@ export async function loadTxFiles (
  * If they in the legacy format, convert them to the new format
  * and cache them on disk
  */
-async function getLegacyFileNames (state: RootState, walletId: string, folder) {
-  const newFormatFileNames = {}
+async function getLegacyFileNames (
+  state: RootState,
+  walletId: string,
+  folder
+): Promise<TxFileNames> {
+  const newFormatFileNames: TxFileNames = {}
   // Get the non encrypted folder
   const localFolder = getStorageWalletLocalFolder(state, walletId)
   const fixedNamesFile = localFolder.file(LEGACY_MAP_FILE)
-  const legacyFileNames = []
-  let legacyMap = {}
+  const legacyFileNames: Array<string> = []
+  let legacyMap: LegacyMapFile = {}
   try {
     // Get the real legacy file names
     await mapFiles(folder, (file, name) => legacyFileNames.push(name))
@@ -316,7 +326,7 @@ async function getLegacyFileNames (state: RootState, walletId: string, folder) {
     // If we haven't converted it, then open the legacy file and convert it to the new format
     if (fileNameMap) {
       const { timestamp, txidHash } = fileNameMap
-      newFormatFileNames[txidHash] = { timestamp, fileName }
+      newFormatFileNames[txidHash] = { creationDate: timestamp, fileName }
     } else {
       missingLegacyFiles.push(fileName)
     }
@@ -328,15 +338,14 @@ async function getLegacyFileNames (state: RootState, walletId: string, folder) {
       .then(txText => {
         const legacyFile = JSON.parse(txText)
         const { creationDate, malleableTxId } = legacyFile.state
-        const timestamp = creationDate
         const fileName = legacyFileName
         const txidHash = hashStorageWalletFilename(
           state,
           walletId,
           malleableTxId
         )
-        newFormatFileNames[txidHash] = { timestamp, fileName }
-        legacyMap[fileName] = { timestamp, txidHash }
+        newFormatFileNames[txidHash] = { creationDate, fileName }
+        legacyMap[fileName] = { timestamp: creationDate, txidHash }
       })
       .catch(e => null)
   )
@@ -357,15 +366,13 @@ async function getLegacyFileNames (state: RootState, walletId: string, folder) {
 async function loadTxFileNames (input: CurrencyWalletInput, folder) {
   const walletId = input.props.id
   const { dispatch, state } = input.props
-  const txFileNames = {}
+  const txFileNames: TxFileNames = {}
   // New transactions files:
   await mapFiles(folder.folder('transaction'), (file, fileName) => {
     const prefix = fileName.split('.json')[0]
-    const [timestamp, txidHash] = prefix.split('-')
-    txFileNames[txidHash] = {
-      fileName,
-      timestamp: parseInt(timestamp)
-    }
+    const split: Array<string> = prefix.split('-')
+    const [creationDate, txidHash] = split
+    txFileNames[txidHash] = { creationDate: parseInt(creationDate), fileName }
   })
 
   // Legacy transactions files:
@@ -450,21 +457,26 @@ export function setCurrencyWalletTxMetadata (
 
   const files = input.props.selfState.files
   // Get the txidHash for this txid
-  let txidHash = ''
+  let oldTxidHash = ''
   for (const hash of Object.keys(files)) {
     if (files[hash].txid === txid) {
-      txidHash = hash
+      oldTxidHash = hash
       break
     }
   }
 
   // Load the old file:
-  const oldFile = input.props.selfState.files[txidHash]
+  const oldFile = input.props.selfState.files[oldTxidHash]
   const creationDate =
     oldFile == null ? Date.now() / 1000 : oldFile.creationDate
 
   // Set up the new file:
-  const { txFileName, txFile } = getTxFile(state, walletId, creationDate, txid)
+  const { diskletFile, fileName, txidHash } = getTxFile(
+    state,
+    walletId,
+    creationDate,
+    txid
+  )
   const newFile: TransactionFile = {
     txid,
     internal: false,
@@ -474,15 +486,15 @@ export function setCurrencyWalletTxMetadata (
   newFile.currencies[currencyCode] = {
     metadata
   }
-  const file = mergeDeeply(oldFile, newFile)
+  const json = mergeDeeply(oldFile, newFile)
 
   // Save the new file:
   dispatch({
     type: 'CURRENCY_WALLET_FILE_CHANGED',
-    payload: { json: file, txid, walletId, txFileName }
+    payload: { creationDate, fileName, json, txid, txidHash, walletId }
   })
-  return txFile.setText(JSON.stringify(file)).then(() => {
-    const callbackTx = combineTxWithFile(input, tx, file, currencyCode)
+  return diskletFile.setText(JSON.stringify(json)).then(() => {
+    const callbackTx = combineTxWithFile(input, tx, json, currencyCode)
     forEachListener(input, ({ onTransactionsChanged }) => {
       if (onTransactionsChanged) {
         onTransactionsChanged(walletId, [callbackTx])
@@ -498,20 +510,21 @@ export function setupNewTxMetadata (input: CurrencyWalletInput, tx: any) {
   const { dispatch, state } = input.props
 
   const txid = tx.txid
-  const { txFileName, txFile } = getTxFile(
+  const creationDate = Date.now() / 1000
+  const { diskletFile, fileName, txidHash } = getTxFile(
     state,
     walletId,
-    Date.now() / 1000,
+    creationDate,
     txid
   )
   const currencyInfo = input.props.selfState.currencyInfo
   const fiatCurrency: string = input.props.selfState.fiat || 'iso:USD'
 
   // Basic file template:
-  const file: TransactionFile = {
+  const json: TransactionFile = {
     txid,
     internal: true,
-    creationDate: Date.now() / 1000,
+    creationDate,
     currencies: {}
   }
 
@@ -530,13 +543,13 @@ export function setupNewTxMetadata (input: CurrencyWalletInput, tx: any) {
 
     const metadata = { exchangeAmount: {} }
     metadata.exchangeAmount[fiatCurrency] = rate * nativeAmount
-    file.currencies[currency] = { metadata, nativeAmount }
+    json.currencies[currency] = { metadata, nativeAmount }
   }
 
   // Save the new file:
   dispatch({
     type: 'CURRENCY_WALLET_FILE_CHANGED',
-    payload: { json: file, txid, walletId, txFileName }
+    payload: { creationDate, fileName, json, txid, txidHash, walletId }
   })
-  return txFile.setText(JSON.stringify(file)).then(() => void 0)
+  return diskletFile.setText(JSON.stringify(json)).then(() => void 0)
 }

--- a/src/modules/currency/wallet/currency-wallet-files.js
+++ b/src/modules/currency/wallet/currency-wallet-files.js
@@ -366,7 +366,14 @@ async function getLegacyFileNames (
 async function loadTxFileNames (input: CurrencyWalletInput, folder) {
   const walletId = input.props.id
   const { dispatch, state } = input.props
-  const txFileNames: TxFileNames = {}
+
+  // Legacy transactions files:
+  const txFileNames: TxFileNames = await getLegacyFileNames(
+    state,
+    walletId,
+    folder.folder('Transactions')
+  )
+
   // New transactions files:
   await mapFiles(folder.folder('transaction'), (file, fileName) => {
     const prefix = fileName.split('.json')[0]
@@ -374,14 +381,6 @@ async function loadTxFileNames (input: CurrencyWalletInput, folder) {
     const [creationDate, txidHash] = split
     txFileNames[txidHash] = { creationDate: parseInt(creationDate), fileName }
   })
-
-  // Legacy transactions files:
-  const legacyFileNames = await getLegacyFileNames(
-    state,
-    walletId,
-    folder.folder('Transactions')
-  )
-  Object.assign(txFileNames, legacyFileNames)
 
   dispatch({
     type: 'CURRENCY_WALLET_FILE_NAMES_LOADED',

--- a/src/modules/currency/wallet/currency-wallet-pixie.js
+++ b/src/modules/currency/wallet/currency-wallet-pixie.js
@@ -158,7 +158,7 @@ export default combinePixies({
 
   syncTimer (input: CurrencyWalletInput) {
     const ai: ApiInput = (input: any) // Safe, since input extends ApiInput
-    let timeout: number | void
+    let timeout: *
 
     function startTimer () {
       // Bail out if either the wallet or the repo aren't ready:

--- a/src/modules/currency/wallet/currency-wallet-reducer.js
+++ b/src/modules/currency/wallet/currency-wallet-reducer.js
@@ -174,11 +174,13 @@ export function sortTxs (txidHashes: TxIdHash, newHashes: TxIdHash) {
       txidHashes[newTxidHash] = newTime
     }
   }
-  const sortedList = Object.keys(txidHashes).sort((txidHash1, txidHash2) => {
-    if (txidHashes[txidHash1] > txidHashes[txidHash2]) return -1
-    if (txidHashes[txidHash1] < txidHashes[txidHash2]) return 1
-    return 0
-  })
+  const sortedList: Array<string> = Object.keys(txidHashes).sort(
+    (txidHash1, txidHash2) => {
+      if (txidHashes[txidHash1] > txidHashes[txidHash2]) return -1
+      if (txidHashes[txidHash1] < txidHashes[txidHash2]) return 1
+      return 0
+    }
+  )
   return { sortedList, txidHashes }
 }
 

--- a/src/modules/currency/wallet/currency-wallet-reducer.js
+++ b/src/modules/currency/wallet/currency-wallet-reducer.js
@@ -4,24 +4,41 @@ import { buildReducer, filterReducer, memoizeReducer } from 'redux-keto'
 
 import type {
   EdgeCurrencyInfo,
+  EdgeTransaction,
   EdgeWalletInfo
 } from '../../../edge-core-index.js'
 import type { RootAction } from '../../actions.js'
 import type { RootState } from '../../root-reducer.js'
 import { getCurrencyInfo } from '../currency-selectors.js'
 
-export type TxIdHash = {
-  [txidHash: string]: number
+/** Maps from txid hash to file creation date & path. */
+export type TxFileNames = {
+  [txidHash: string]: {
+    creationDate: number,
+    fileName: string
+  }
 }
 
-export type TxFileName = {
-  timestamp: number,
-  fileName: string
-}
+/** Maps from txid hash to file contents (in JSON). */
+export type TxFileJsons = { [txidHash: string]: Object }
+
+/** Maps from txid hash to creation date. */
+export type TxidHashes = { [txidHash: string]: number }
 
 export type SortedTransactions = {
   sortedList: Array<string>,
-  txidHashes: TxIdHash
+  txidHashes: TxidHashes
+}
+
+export type MergedTransaction = {
+  blockHeight: number,
+  date: number,
+  ourReceiveAddresses: Array<string>,
+  signedTx: string,
+  txid: string,
+
+  nativeAmount: { [currencyCode: string]: string },
+  networkFee: { [currencyCode: string]: string }
 }
 
 export interface CurrencyWalletState {
@@ -29,15 +46,15 @@ export interface CurrencyWalletState {
   engineFailure: Error | null;
   fiat: string;
   fiatLoaded: boolean;
-  files: { [txidHash: string]: Object };
-  fileNames: { [txidHash: string]: TxFileName };
+  files: TxFileJsons;
+  fileNames: TxFileNames;
   fileNamesLoaded: boolean;
   sortedTransactions: SortedTransactions;
   name: string | null;
   nameLoaded: boolean;
   walletInfo: EdgeWalletInfo;
   txids: Array<string>;
-  txs: { [txid: string]: Object };
+  txs: { [txid: string]: MergedTransaction };
 }
 
 export interface CurrencyWalletNext {
@@ -66,11 +83,10 @@ const currencyWalletReducer = buildReducer({
     return action.type === 'CURRENCY_WALLET_FIAT_CHANGED' ? true : state
   },
 
-  files (state = {}, action: RootAction) {
+  files (state: TxFileJsons = {}, action: RootAction) {
     switch (action.type) {
       case 'CURRENCY_WALLET_FILE_CHANGED': {
-        const { json, txFileName } = action.payload
-        const { txidHash } = txFileName
+        const { json, txidHash } = action.payload
         const out = { ...state }
         out[txidHash] = json
         return out
@@ -86,8 +102,12 @@ const currencyWalletReducer = buildReducer({
     return state
   },
 
-  sortedTransactions (state = {}, action: RootAction, next: CurrencyWalletNext) {
-    const { txidHashes = {} } = state
+  sortedTransactions (
+    state: SortedTransactions = { txidHashes: {}, sortedList: [] },
+    action: RootAction,
+    next: CurrencyWalletNext
+  ) {
+    const { txidHashes } = state
     switch (action.type) {
       case 'CURRENCY_ENGINE_CHANGED_TXS': {
         return sortTxs(txidHashes, action.payload.txidHashes)
@@ -96,7 +116,7 @@ const currencyWalletReducer = buildReducer({
         const { txFileNames } = action.payload
         const newTxidHashes = {}
         Object.keys(txFileNames).map(txidHash => {
-          newTxidHashes[txidHash] = txFileNames[txidHash].timestamp
+          newTxidHashes[txidHash] = txFileNames[txidHash].creationDate
         })
         return sortTxs(txidHashes, newTxidHashes)
       }
@@ -104,7 +124,7 @@ const currencyWalletReducer = buildReducer({
     return state
   },
 
-  fileNames (state = {}, action: RootAction) {
+  fileNames (state: TxFileNames = {}, action: RootAction) {
     switch (action.type) {
       case 'CURRENCY_WALLET_FILE_NAMES_LOADED': {
         const { txFileNames } = action.payload
@@ -114,10 +134,9 @@ const currencyWalletReducer = buildReducer({
         }
       }
       case 'CURRENCY_WALLET_FILE_CHANGED': {
-        const { txFileName } = action.payload
-        const { txidHash, timestamp, fileName } = txFileName
-        if (!state[txidHash] || timestamp < state[txidHash].timestamp) {
-          state[txidHash] = { timestamp, fileName }
+        const { fileName, creationDate, txidHash } = action.payload
+        if (!state[txidHash] || creationDate < state[txidHash].creationDate) {
+          state[txidHash] = { creationDate, fileName }
         }
         return state
       }
@@ -167,7 +186,7 @@ const currencyWalletReducer = buildReducer({
   }
 })
 
-export function sortTxs (txidHashes: TxIdHash, newHashes: TxIdHash) {
+export function sortTxs (txidHashes: TxidHashes, newHashes: TxidHashes) {
   for (const newTxidHash in newHashes) {
     const newTime = newHashes[newTxidHash]
     if (!txidHashes[newTxidHash] || newTime < txidHashes[newTxidHash]) {
@@ -193,10 +212,25 @@ export default filterReducer(
   }
 )
 
+const defaultTx: MergedTransaction = {
+  blockHeight: 0,
+  date: 0,
+  ourReceiveAddresses: [],
+  signedTx: '',
+  txid: '',
+  nativeAmount: {},
+  networkFee: {},
+  providerFee: {}
+}
+
 /**
  * Merges a new incoming transaction with an existing transaction.
  */
-export function mergeTx (tx: any, defaultCurrency: string, oldTx: any = {}) {
+export function mergeTx (
+  tx: EdgeTransaction,
+  defaultCurrency: string,
+  oldTx: MergedTransaction = defaultTx
+): MergedTransaction {
   const out = {
     blockHeight: tx.blockHeight,
     date: tx.date,
@@ -205,8 +239,7 @@ export function mergeTx (tx: any, defaultCurrency: string, oldTx: any = {}) {
     txid: tx.txid,
 
     nativeAmount: { ...oldTx.nativeAmount },
-    networkFee: { ...oldTx.networkFee },
-    providerFee: { ...oldTx.providerFee }
+    networkFee: { ...oldTx.networkFee }
   }
 
   const currencyCode =
@@ -214,8 +247,6 @@ export function mergeTx (tx: any, defaultCurrency: string, oldTx: any = {}) {
   out.nativeAmount[currencyCode] = tx.nativeAmount
   out.networkFee[currencyCode] =
     tx.networkFee != null ? tx.networkFee.toString() : '0'
-  out.providerFee[currencyCode] =
-    tx.providerFee != null ? tx.providerFee.toString() : '0'
 
   return out
 }

--- a/src/modules/currency/wallet/currency-wallet-reducer.js
+++ b/src/modules/currency/wallet/currency-wallet-reducer.js
@@ -211,8 +211,7 @@ export function mergeTx (tx: any, defaultCurrency: string, oldTx: any = {}) {
 
   const currencyCode =
     tx.currencyCode != null ? tx.currencyCode : defaultCurrency
-  out.nativeAmount[currencyCode] =
-    tx.amountSatoshi != null ? tx.amountSatoshi.toString() : tx.nativeAmount
+  out.nativeAmount[currencyCode] = tx.nativeAmount
   out.networkFee[currencyCode] =
     tx.networkFee != null ? tx.networkFee.toString() : '0'
   out.providerFee[currencyCode] =

--- a/src/modules/exchange/exchange-pixie.js
+++ b/src/modules/exchange/exchange-pixie.js
@@ -30,7 +30,7 @@ export default combinePixies({
   },
 
   update (input: PixieInput<RootProps>) {
-    let timeout: number | void
+    let timeout: * // Infer the proper timer type
 
     function doFetch (): Promise<void> {
       // Bail out if we have no plugins:

--- a/src/modules/login/lobby.js
+++ b/src/modules/login/lobby.js
@@ -76,7 +76,7 @@ class ObservableLobby {
   onReply: (reply: Object) => void
   period: number
   replyCount: number
-  timeout: number
+  timeout: * // Infer the proper timer type.
 
   constructor (ai: ApiInput, lobbyId: string, keypair) {
     this.ai = ai

--- a/yarn.lock
+++ b/yarn.lock
@@ -2164,9 +2164,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.62.0:
-  version "0.62.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.62.0.tgz#14bca669a6e3f95c0bc0c2d1eb55ec4e98cb1d83"
+flow-bin@^0.76.0:
+  version "0.76.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.76.0.tgz#eb00036991c3abc106743fcbc7ee321f02aa4faa"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This isn't a perfect fix, but it solves the immediate problem.

A more correct solution would intelligently handle the "internal" and "external" metadata separation as well. If we are going to re-write the transaction loading logic to handle that, I would like to include the txid list optimization as well.