### PR TITLE
Adjust QBO fix to export by allowing raw truncation of MEMO (ofx_memo) field

### DIFF
--- a/src/modules/currency/wallet/currency-wallet-export.js
+++ b/src/modules/currency/wallet/currency-wallet-export.js
@@ -122,22 +122,17 @@ export function exportTransactionsToQBOInner (
     const absFiat = abs(amountFiat.toString())
     const absAmount = abs(TRNAMT)
     const CURRATE = absAmount !== '0' ? div(absFiat, absAmount, 8) : '0'
-    const MEMO_PREFIX = `// Rate=${CURRATE} ${fiatCurrencyCode}=${amountFiat} category="${category}"`
-    const MEMO_PREFIX_LENGTH = MEMO_PREFIX.length
-    const MEMO_SUFFIX = `memo="${notes}"`
-    const MEMO_SUFFIX_LENGTH = MEMO_SUFFIX.length
-    const MEMO_OVERFLOW: number = MEMO_PREFIX_LENGTH + MEMO_SUFFIX_LENGTH - 250
-    if (MEMO_OVERFLOW > 0) {
-      notes = notes.substring(0, notes.length - MEMO_OVERFLOW) + '...'
+    let memo = `// Rate=${CURRATE} ${fiatCurrencyCode}=${amountFiat} category="${category}" memo="${notes}"`
+    if (memo.length > 250) {
+      memo = memo.substring(0, 250) + '...'
     }
-    const MEMO = `${MEMO_PREFIX} memo="${notes}"`
     const qboTxNamed = {
       TRNTYPE,
       DTPOSTED,
       TRNAMT,
       FITID: edgeTx.txid,
       NAME,
-      MEMO,
+      MEMO: memo,
       CURRENCY: {
         CURRATE: CURRATE,
         CURSYM: fiatCurrencyCode
@@ -148,7 +143,7 @@ export function exportTransactionsToQBOInner (
       DTPOSTED,
       TRNAMT,
       FITID: edgeTx.txid,
-      MEMO,
+      MEMO: memo,
       CURRENCY: {
         CURRATE: CURRATE,
         CURSYM: fiatCurrencyCode


### PR DESCRIPTION
The purpose of this task is to truncate the *entire* `ofx_memo` field (what Quickbooks calls it) to less than 255 characters, rather than attempt to try to truncate any extra characters off of the `notes` field specifically.

Asana Task: https://app.asana.com/0/361770107085503/757214370474543/f