### PR TITLE
Work around missing currency plugin callbacks

### DIFF
--- a/src/modules/currency/wallet/currency-wallet-pixie.js
+++ b/src/modules/currency/wallet/currency-wallet-pixie.js
@@ -93,6 +93,19 @@ export default combinePixies({
         }
       })
       input.onOutput(engine)
+
+      // Grab initial state:
+      const { currencyCode } = plugin.currencyInfo
+      const balance = engine.getBalance({ currencyCode })
+      const height = engine.getBlockHeight()
+      input.props.dispatch({
+        type: 'CURRENCY_ENGINE_CHANGED_BALANCE',
+        payload: { balance, currencyCode, walletId: input.props.id }
+      })
+      input.props.dispatch({
+        type: 'CURRENCY_ENGINE_CHANGED_HEIGHT',
+        payload: { height, walletId: input.props.id }
+      })
     } catch (e) {
       input.props.onError(e)
       input.props.dispatch({ type: 'CURRENCY_ENGINE_FAILED', payload: e })
@@ -151,11 +164,8 @@ export default combinePixies({
       return
     }
 
-    const currencyWalletApi = makeCurrencyWalletApi(
-      input,
-      input.props.selfOutput.plugin,
-      input.props.selfOutput.engine
-    )
+    const { plugin, engine } = input.props.selfOutput
+    const currencyWalletApi = makeCurrencyWalletApi(input, plugin, engine)
     input.onOutput(currencyWalletApi)
 
     forEachListener(input, ({ onKeyListChanged }) => {


### PR DESCRIPTION
Currency plugins are supposed to call their callbacks when the engine starts, but not all do. Grab the data anyhow.