### PR TITLE
Simulate `onTransactionsChanged` in `getTransactions`

### DIFF
--- a/src/modules/currency/wallet/currency-wallet-reducer.js
+++ b/src/modules/currency/wallet/currency-wallet-reducer.js
@@ -60,7 +60,8 @@ export type CurrencyWalletState = {
   +nameLoaded: boolean,
   +walletInfo: EdgeWalletInfo,
   +txids: Array<string>,
-  +txs: { [txid: string]: MergedTransaction }
+  +txs: { [txid: string]: MergedTransaction },
+  +gotTxs: boolean
 }
 
 export type CurrencyWalletNext = {
@@ -224,6 +225,10 @@ const currencyWallet = buildReducer({
     }
 
     return state
+  },
+
+  gotTxs (state = false, action: RootAction): boolean {
+    return action.type === 'CURRENCY_ENGINE_CHANGED_TXS' ? true : state
   },
 
   walletInfo (state, action, next: CurrencyWalletNext) {


### PR DESCRIPTION
If we have never received an `onTransactionsChanged` for this wallet, call `getTransactions` followed by a simulated `onTransactionsChanged` inside our public-facing `getTransactions`. This should work together with a performance optimization some plugins will be doing. If the plugins don't implement this optimization, this commit should be harmless.