### PR TITLE
Fix missing transactions for first query to getTransactions

### DIFF
--- a/src/modules/currency/wallet/currency-wallet-api.js
+++ b/src/modules/currency/wallet/currency-wallet-api.js
@@ -210,10 +210,11 @@ export function makeCurrencyWalletApi (
     async getTransactions (
       opts: EdgeGetTransactionsOptions = {}
     ): Promise<Array<EdgeTransaction>> {
-      const state = input.props.selfState
+      let state = input.props.selfState
       if (!state.gotTxs) {
         const txs = await engine.getTransactions(opts)
         fakeCallbacks.onTransactionsChanged(txs)
+        state = input.props.selfState
       }
 
       const defaultCurrency = plugin.currencyInfo.currencyCode


### PR DESCRIPTION
Re-read state to get updated values after onTransactionsChanged()