### PR TITLE
Fix missing transactions on calls to getTransactions

### DIFF
--- a/src/modules/actions.js
+++ b/src/modules/actions.js
@@ -181,6 +181,11 @@ export type CurrencyEngineChangedTxs = {
   }
 }
 
+export type CurrencyEngineGotTxs = {
+  type: 'CURRENCY_ENGINE_GOT_TXS',
+  payload: {}
+}
+
 /**
  * Called when a currency engine is wiped out.
  */
@@ -383,6 +388,7 @@ export type RootAction =
   | CurrencyEngineChangedSeeds
   | CurrencyEngineChangedSyncRatio
   | CurrencyEngineChangedTxs
+  | CurrencyEngineGotTxs
   | CurrencyEngineCleared
   | CurrencyEngineFailed
   | CurrencyPluginsFailed

--- a/src/modules/currency/wallet/currency-wallet-api.js
+++ b/src/modules/currency/wallet/currency-wallet-api.js
@@ -214,6 +214,10 @@ export function makeCurrencyWalletApi (
       if (!state.gotTxs) {
         const txs = await engine.getTransactions(opts)
         fakeCallbacks.onTransactionsChanged(txs)
+        input.props.dispatch({
+          type: 'CURRENCY_ENGINE_GOT_TXS',
+          payload: {}
+        })
         state = input.props.selfState
       }
 

--- a/src/modules/currency/wallet/currency-wallet-reducer.js
+++ b/src/modules/currency/wallet/currency-wallet-reducer.js
@@ -228,7 +228,11 @@ const currencyWallet = buildReducer({
   },
 
   gotTxs (state = false, action: RootAction): boolean {
-    return action.type === 'CURRENCY_ENGINE_CHANGED_TXS' ? true : state
+    if (action.type === 'CURRENCY_ENGINE_GOT_TXS') {
+      return true
+    } else {
+      return state
+    }
   },
 
   walletInfo (state, action, next: CurrencyWalletNext) {


### PR DESCRIPTION
Change getTransactions to dispatch it's own GOT_TXS action once it has queried the plugin. Otherwise an incoming network tx would cause onTransactionsChanged to set gotTxs = true and getTransactions wouldn't further call the plugin->getTransactions when needed.