### PR TITLE
Fix bugs in lazy tx loading

### DIFF
--- a/src/modules/actions.js
+++ b/src/modules/actions.js
@@ -183,7 +183,9 @@ export type CurrencyEngineChangedTxs = {
 
 export type CurrencyEngineGotTxs = {
   type: 'CURRENCY_ENGINE_GOT_TXS',
-  payload: {}
+  payload: {
+    walletId: string
+  }
 }
 
 /**

--- a/src/modules/currency/wallet/currency-wallet-api.js
+++ b/src/modules/currency/wallet/currency-wallet-api.js
@@ -212,11 +212,15 @@ export function makeCurrencyWalletApi (
     ): Promise<Array<EdgeTransaction>> {
       let state = input.props.selfState
       if (!state.gotTxs) {
-        const txs = await engine.getTransactions(opts)
+        const txs = await engine.getTransactions({
+          currencyCode: opts.currencyCode
+        })
         fakeCallbacks.onTransactionsChanged(txs)
         input.props.dispatch({
           type: 'CURRENCY_ENGINE_GOT_TXS',
-          payload: {}
+          payload: {
+            walletId: input.props.id
+          }
         })
         state = input.props.selfState
       }


### PR DESCRIPTION
* Add walletId to payload of GOT_TXS action so it doesn't get filtered out
* Only send the currencyCode opts to getTransactions to make sure we get all transactions from the currency plugin