### PR TITLE
Fix swap errors

### DIFF
--- a/src/modules/swap/shapeshift-plugin.js
+++ b/src/modules/swap/shapeshift-plugin.js
@@ -89,8 +89,8 @@ function makeShapeshiftTools (env: EdgePluginEnvironment): EdgeSwapTools {
       // Shapeshift requires KYC:
       if (
         reply.status === 401 &&
-        replyJson.error != null &&
-        replyJson.error.message === 'You must be logged in with a verified user'
+        replyJson &&
+        replyJson.message === 'You must be logged in with a verified user'
       ) {
         throw new SwapPermissionError(swapInfo, 'noVerification')
       }
@@ -242,7 +242,7 @@ function makeShapeshiftTools (env: EdgePluginEnvironment): EdgeSwapTools {
         if (/is greater/.test(e.message)) {
           throw new SwapAboveLimitError(swapInfo, nativeAmount)
         }
-        throw new Error(e)
+        throw e
       }
       if (!quoteData.success) {
         throw new Error('Did not get back successful quote')


### PR DESCRIPTION
* On errors throw the error directly and do not create a new error object. Creating a new error object will remove the error parameters
* Change detection of ShapeShift error for unverified user