### PR TITLE
Fix missing txs - refactor getTransactions

### DIFF
--- a/src/modules/currency/wallet/currency-wallet-api.js
+++ b/src/modules/currency/wallet/currency-wallet-api.js
@@ -253,10 +253,11 @@ export function makeCurrencyWalletApi (
       }
       // we need to make sure that after slicing, the total txs number is equal to opts.startEntries
       // slice, verify txs in files, if some are dropped and missing, do it again recursively
-      const getBulkTx = async (index: number, entries: number, out: any) => {
+      const getBulkTx = async (index: number, out: any = []) => {
         if (out.length === startEntries || index >= sortedTransactions.length) return out
+        const entriesLeft = startEntries - out.length
         const slicedTransactions = slice
-          ? sortedTransactions.slice(index, index + entries)
+          ? sortedTransactions.slice(index, index + entriesLeft)
           : sortedTransactions
         // filter the missing files
         const missingTxIdHashes = slicedTransactions.filter(
@@ -279,11 +280,11 @@ export function makeCurrencyWalletApi (
           out.push(combineTxWithFile(input, tx, file, currencyCode))
         }
         // continue until the required tx number loaded
-        const res = await getBulkTx(index + entries, entries - out.length, out)
+        const res = await getBulkTx(index + entriesLeft, out)
         return res
       }
 
-      const out: Array<EdgeTransaction> = await getBulkTx(startIndex, startEntries, [])
+      const out: Array<EdgeTransaction> = await getBulkTx(startIndex)
       return out
     },
 


### PR DESCRIPTION
The logic of txs slicing and search them in files didn't handle the case that a tx dropped.

Now we make sure that the total txs number is equal to the number the ui requested.
So after slice, verify that all txs in files, if some are dropped and missing, do it again recursively until returning the requested amount of txs.