### PR TITLE
added new prop needsKYCWarning

### DIFF
--- a/src/modules/account/plugin-api.js
+++ b/src/modules/account/plugin-api.js
@@ -81,6 +81,10 @@ export class SwapConfig extends Bridgeable<EdgeSwapConfig> {
     const account = this._ai.props.state.accounts[this._accountId]
     return account.swapTools[this._pluginName].needsActivation
   }
+  get needsKYCWarning (): boolean {
+    const account = this._ai.props.state.accounts[this._accountId]
+    return account.swapTools[this._pluginName].needsKYCWarning
+  }
 
   get swapInfo (): EdgeSwapInfo {
     const selfState = this._ai.props.state.accounts[this._accountId]

--- a/src/modules/swap/changelly-plugin.js
+++ b/src/modules/swap/changelly-plugin.js
@@ -85,7 +85,7 @@ function makeChangellyTools (env): EdgeSwapTools {
   }
   const { apiKey } = env.initOptions
   const secret = utf8.parse(env.initOptions.secret)
-
+  let userSettings = env.userSettings
   async function call (json: any) {
     const body = JSON.stringify(json)
     const sign = base16
@@ -110,8 +110,13 @@ function makeChangellyTools (env): EdgeSwapTools {
   const out: EdgeSwapTools = {
     needsActivation: false,
 
-    async changeUserSettings (userSettings: Object): Promise<mixed> {},
+    get needsKYCWarning (): boolean {
+      return userSettings == null || userSettings.accessToken == null
+    },
 
+    async changeUserSettings (settings: Object): Promise<mixed> {
+      userSettings = settings
+    },
     async fetchCurrencies (): Promise<Array<string>> {
       const reply = await call({
         jsonrpc: '2.0',

--- a/src/modules/swap/changenow-plugin.js
+++ b/src/modules/swap/changenow-plugin.js
@@ -80,7 +80,7 @@ function makeChangeNowTools (env): EdgeSwapTools {
     throw new Error('No ChangeNow apiKey or secret provided.')
   }
   const { apiKey } = env.initOptions
-
+  let userSettings = env.userSettings
   async function call (json: any) {
     const body = JSON.stringify(json.body)
     env.io.console.info('changenow call fixed :', json)
@@ -104,8 +104,15 @@ function makeChangeNowTools (env): EdgeSwapTools {
   }
   const out: EdgeSwapTools = {
     needsActivation: false,
+    // needsKYCWarning: true,
+    get needsKYCWarning (): boolean {
+      return userSettings == null || userSettings.accessToken == null
+    },
 
-    async changeUserSettings (userSettings: Object): Promise<mixed> {},
+    async changeUserSettings (settings: Object): Promise<mixed> {
+      userSettings = settings
+    },
+    // async changeUserSettings (userSettings: Object): Promise<mixed> {},
 
     async fetchCurrencies (): Promise<Array<string>> {
       const reply = await get('market-info/fixed-rate/' + apiKey)

--- a/src/modules/swap/shapeshift-plugin.js
+++ b/src/modules/swap/shapeshift-plugin.js
@@ -133,6 +133,7 @@ function makeShapeshiftTools (env: EdgePluginEnvironment): EdgeSwapTools {
   }
 
   const out: EdgeSwapTools = {
+    needsKYCWarning: false,
     get needsActivation (): boolean {
       return userSettings == null || userSettings.accessToken == null
     },

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -536,7 +536,7 @@ export type EdgeSwapPluginQuote = {
 
 export type EdgeSwapTools = {
   +needsActivation: boolean,
-
+  +needsKYCWarning: boolean,
   changeUserSettings(userSettings: Object): Promise<mixed>,
   fetchCurrencies(): Promise<Array<string>>,
   fetchQuote(opts: EdgeSwapQuoteOptions): Promise<EdgeSwapPluginQuote>
@@ -677,6 +677,7 @@ export type EdgeSwapConfig = {
 
   +enabled: boolean,
   +needsActivation: boolean,
+  +needsKYCWarning: boolean,
   +swapInfo: EdgeSwapInfo,
   +userSettings: Object,
 

--- a/test/modules/account/account.test.js
+++ b/test/modules/account/account.test.js
@@ -153,6 +153,7 @@ describe('account', function () {
     const config1 = account1.swapConfig.shapeshift
     expect(config1.swapInfo.pluginName).equals('shapeshift')
     expect(config1.needsActivation).equals(true)
+    expect(config1.needsKYCWarning).equals(false)
     expect(config1.userSettings).equals(void 0)
 
     // Change the settings:
@@ -163,12 +164,14 @@ describe('account', function () {
     await config1.changeUserSettings(settings)
     expect(config1.userSettings).deep.equals(settings)
     expect(config1.needsActivation).equals(false)
+    expect(config1.needsKYCWarning).equals(false)
 
     // Log in again, and the setting should still be there:
     const account2 = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
     const config2 = account2.swapConfig.shapeshift
     expect(config2.userSettings).deep.equals(settings)
     expect(config1.needsActivation).equals(false)
+    expect(config1.needsKYCWarning).equals(false)
   })
 
   it('disable swap plugin', async function () {


### PR DESCRIPTION
This adds a new property `needsKYCWarning` to swapConfig. Since we need to show the user a modal letting them know there may be a KYC event this does not tie directly into device token. There is similar functionality. Rather than block a quote this just alerts a user once, that the KYC warning needs to be seen. 