### PR TITLE
Fix getTransactions for tokens in accountbased

### DIFF
--- a/src/modules/actions.js
+++ b/src/modules/actions.js
@@ -134,7 +134,8 @@ export type RootAction =
   | {
       type: 'CURRENCY_ENGINE_GOT_TXS',
       payload: {
-        walletId: string
+        walletId: string,
+        currencyCode: string
       }
     }
   | {

--- a/src/modules/currency/wallet/currency-wallet-api.js
+++ b/src/modules/currency/wallet/currency-wallet-api.js
@@ -204,8 +204,11 @@ export function makeCurrencyWalletApi (
     async getTransactions (
       opts: EdgeGetTransactionsOptions = {}
     ): Promise<Array<EdgeTransaction>> {
+      const defaultCurrency = plugin.currencyInfo.currencyCode
+      const currencyCode = opts.currencyCode || defaultCurrency
+
       let state = input.props.selfState
-      if (!state.gotTxs) {
+      if (!state.gotTxs[currencyCode]) {
         const txs = await engine.getTransactions({
           currencyCode: opts.currencyCode
         })
@@ -213,14 +216,13 @@ export function makeCurrencyWalletApi (
         input.props.dispatch({
           type: 'CURRENCY_ENGINE_GOT_TXS',
           payload: {
-            walletId: input.props.id
+            walletId: input.props.id,
+            currencyCode
           }
         })
         state = input.props.selfState
       }
 
-      const defaultCurrency = plugin.currencyInfo.currencyCode
-      const currencyCode = opts.currencyCode || defaultCurrency
       // Txid array of all txs
       const txids = state.txids
       // Merged tx data from metadata files and blockchain data

--- a/src/modules/currency/wallet/currency-wallet-reducer.js
+++ b/src/modules/currency/wallet/currency-wallet-reducer.js
@@ -61,7 +61,7 @@ export type CurrencyWalletState = {
   +walletInfo: EdgeWalletInfo,
   +txids: Array<string>,
   +txs: { [txid: string]: MergedTransaction },
-  +gotTxs: boolean
+  +gotTxs: { [currencyCode: string]: boolean }
 }
 
 export type CurrencyWalletNext = {
@@ -226,12 +226,11 @@ const currencyWallet = buildReducer({
     return state
   },
 
-  gotTxs (state = false, action: RootAction): boolean {
+  gotTxs (state = {}, action: RootAction): { [currencyCode: string]: boolean } {
     if (action.type === 'CURRENCY_ENGINE_GOT_TXS') {
-      return true
-    } else {
-      return state
+      state[action.payload.currencyCode] = true
     }
+    return state
   },
 
   walletInfo (state, action, next: CurrencyWalletNext) {


### PR DESCRIPTION
state.gotTxs was a single boolean for all tokens in a wallet. This could cause only a single token's transactions to get read from the currency plugin. If a future call to getTransactions is called for a different token, Core won't call getTransactions for that token. This bug was hidden because only the ethereum plugin had tokens and it would always update the Core with all transactions upon boot. accountbased is optimized to only load transactions once getTransactions is called.

Fix is to make state.gotTxs a boolean map by currencyCode