### PR TITLE
Remove `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,11 +104,6 @@
     "updot": "^1.1.7",
     "webpack": "^3.5.3"
   },
-  "peerDependencies": {
-    "react-native-fast-crypto": "^1.5.3",
-    "react-native-randombytes": "git://github.com/Airbitz/react-native-randombytes.git#40d02a5f922",
-    "react-native-tcp": "git://github.com/Airbitz/react-native-tcp.git"
-  },
   "husky": {
     "hooks": {
       "pre-commit": "npm run precommit"


### PR DESCRIPTION
The parent project needs to include React Native dependencies directly, or `react-native link` can break in exciting ways. Therefore, we can't have these are normal `dependencies`.

The idea behind `peerDependencies` was that we could declare these dependencies in a programmatic way, but this just makes life annoying for our web users, who don't want or need these packages, but get errors if they don't install them.

It seems like the best we can do is just document what native modules we need in the readme file. If you are doing React Native, you already have to follow the `react-native link` instructions anyhow, so now they include a `yarn add` as well.