### PR TITLE
Add unfilteredId to getTransactions to fix TxList Missing Transactions

### DIFF
--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -40,7 +40,6 @@ import {
   setCurrencyWalletTxMetadata
 } from './currency-wallet-files.js'
 import { type CurrencyWalletInput } from './currency-wallet-pixie.js'
-import { type MergedTransaction } from './currency-wallet-reducer.js'
 
 const fakeMetadata = {
   bizId: 0,
@@ -499,16 +498,16 @@ function fixMetadata (metadata: EdgeMetadata, fiat: string) {
 
 export function combineTxWithFile (
   input: CurrencyWalletInput,
-  tx: MergedTransaction,
+  tx: any,
   file: TransactionFile,
   currencyCode: string
-): EdgeTransaction {
+): any {
   const wallet = input.props.selfOutput.api
   const walletCurrency = input.props.selfState.currencyInfo.currencyCode
   const walletFiat = input.props.selfState.fiat
 
   // Copy the tx properties to the output:
-  const out: EdgeTransaction = {
+  const out: any = {
     blockHeight: tx.blockHeight,
     date: tx.date,
     ourReceiveAddresses: tx.ourReceiveAddresses,

--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -21,8 +21,7 @@ import {
   type EdgeReceiveAddress,
   type EdgeSpendInfo,
   type EdgeTokenInfo,
-  type EdgeTransaction,
-  type EdgeTransactionWithUnfilteredIndex
+  type EdgeTransaction
 } from '../../../types/types.js'
 import { filterObject, mergeDeeply } from '../../../util/util.js'
 import { type ApiInput } from '../../root-pixie.js'
@@ -503,13 +502,13 @@ export function combineTxWithFile (
   tx: MergedTransaction,
   file: TransactionFile,
   currencyCode: string
-): EdgeTransactionWithUnfilteredIndex {
+): EdgeTransaction {
   const wallet = input.props.selfOutput.api
   const walletCurrency = input.props.selfState.currencyInfo.currencyCode
   const walletFiat = input.props.selfState.fiat
 
   // Copy the tx properties to the output:
-  const out: EdgeTransactionWithUnfilteredIndex = {
+  const out: EdgeTransaction = {
     blockHeight: tx.blockHeight,
     date: tx.date,
     ourReceiveAddresses: tx.ourReceiveAddresses,


### PR DESCRIPTION
The purpose of this task is to implement an index with core transactions to help the GUI keep track of which transactions have already been loaded in the GUI's transactionList.

Related Asana Task: https://app.asana.com/0/361770107085503/1110186891351600/f