### PR TITLE
Do not send rate errors to the GUI

### DIFF
--- a/src/core/exchange/exchange-pixie.js
+++ b/src/core/exchange/exchange-pixie.js
@@ -27,11 +27,11 @@ export const exchange: TamePixie<RootProps> = combinePixies({
           const plugin = input.props.state.plugins.rate[pluginName]
           try {
             return plugin.fetchRates(pairs).catch(e => {
-              input.props.onError(e)
+              // input.props.onError(e) skipped due to noise
               return []
             })
           } catch (e) {
-            input.props.onError(e)
+            // input.props.onError(e) skipped due to noise
             return []
           }
         })


### PR DESCRIPTION
These errors are harmless, so we don't need to create an error pop-down about them.