### PR TITLE
Attempt to solve webview crash issues

### DIFF
--- a/src/io/react-native/react-native-types.js
+++ b/src/io/react-native/react-native-types.js
@@ -21,8 +21,6 @@ export type ClientIo = {
 }
 
 export type WorkerApi = {
-  closeEdge(): mixed,
-
   makeEdgeContext(
     nativeIo: EdgeNativeIo,
     opts: EdgeContextOptions

--- a/src/io/react-native/react-native-worker.js
+++ b/src/io/react-native/react-native-worker.js
@@ -7,7 +7,6 @@ import { Bridge, bridgifyObject } from 'yaob'
 
 import {
   addEdgeCorePlugins,
-  closeEdge,
   lockEdgeCorePlugins,
   makeContext,
   makeFakeWorld
@@ -41,10 +40,6 @@ function makeIo (nativeIo: EdgeNativeIo): EdgeIo {
 }
 
 const workerApi: WorkerApi = bridgifyObject({
-  closeEdge () {
-    closeEdge()
-  },
-
   makeEdgeContext (nativeIo, opts) {
     return makeContext(makeIo(nativeIo), nativeIo, opts)
   },


### PR DESCRIPTION
I cannot reproduce the error, so I am guessing:

- Do not return the worker API until we have received back the webview ref.
- Do not issue any method calls when the webview is going away.
- In all other cases, throw a more explicit exception.