### PR TITLE
If the app crashes, delay the error by one second

### DIFF
--- a/src/io/react-native/react-native-webview.js
+++ b/src/io/react-native/react-native-webview.js
@@ -47,7 +47,9 @@ export class EdgeCoreBridge extends Component<Props> {
     const bridge = new Bridge({
       sendMessage: message => {
         if (webview == null) {
-          throw new Error('The edge-core worker has been unmounted.')
+          return setTimeout(() => {
+            throw new Error('The edge-core worker has been unmounted.')
+          }, 1000)
         }
         if (props.debug) console.info('edge-core ←', message)
         webview.injectJavaScript(


### PR DESCRIPTION
Not tested, so may or may not work.

This is an awful hack, but allows the true error to appear in our crash logs, rather than the core disconnection error (which is a side-effect of the app itself crashing).