### PR TITLE
Throttle callbacks on a global level

### DIFF
--- a/src/core/currency/wallet/currency-wallet-callbacks.js
+++ b/src/core/currency/wallet/currency-wallet-callbacks.js
@@ -9,6 +9,10 @@ import {
 } from '../../../types/types.js'
 import { compare } from '../../../util/compare.js'
 import {
+  pushUpdate,
+  enableTestMode
+} from '../../../util/updateQueue.js'
+import {
   getStorageWalletLastChanges,
   hashStorageWalletFilename
 } from '../../storage/storage-selectors.js'
@@ -73,6 +77,7 @@ export function makeCurrencyWalletCallbacks (
   // If this is a unit test, lower throttling to something testable:
   if (walletId === 'narfavJN4rp9ZzYigcRj1i0vrU2OAGGp4+KksAksj54=') {
     throttleRateLimitMs = 25
+    enableTestMode()
   }
 
   const throtteldOnTxChanged = makeThrottledTxCallback(
@@ -101,23 +106,41 @@ export function makeCurrencyWalletCallbacks (
 
   return {
     onAddressesChecked (ratio: number) {
-      input.props.dispatch({
-        type: 'CURRENCY_ENGINE_CHANGED_SYNC_RATIO',
-        payload: { ratio, walletId }
+      pushUpdate({
+        id: walletId,
+        action: 'onAddressesChecked',
+        updateFunc: () => {
+          input.props.dispatch({
+            type: 'CURRENCY_ENGINE_CHANGED_SYNC_RATIO',
+            payload: { ratio, walletId }
+          })
+        }
       })
     },
 
     onBalanceChanged (currencyCode: string, balance: string) {
-      input.props.dispatch({
-        type: 'CURRENCY_ENGINE_CHANGED_BALANCE',
-        payload: { balance, currencyCode, walletId }
+      pushUpdate({
+        id: walletId + '==' + currencyCode,
+        action: 'onBalanceChanged',
+        updateFunc: () => {
+          input.props.dispatch({
+            type: 'CURRENCY_ENGINE_CHANGED_BALANCE',
+            payload: { balance, currencyCode, walletId }
+          })
+        }
       })
     },
 
     onBlockHeightChanged (height: number) {
-      input.props.dispatch({
-        type: 'CURRENCY_ENGINE_CHANGED_HEIGHT',
-        payload: { height, walletId }
+      pushUpdate({
+        id: walletId,
+        action: 'onBlockHeightChanged',
+        updateFunc: () => {
+          input.props.dispatch({
+            type: 'CURRENCY_ENGINE_CHANGED_HEIGHT',
+            payload: { height, walletId }
+          })
+        }
       })
     },
 

--- a/src/util/updateQueue.js
+++ b/src/util/updateQueue.js
@@ -1,0 +1,62 @@
+// @flow
+
+// How often to run jobs from the queue
+let QUEUE_RUN_DELAY = 500
+
+// How many jobs to run from the queue on each cycle
+let QUEUE_JOBS_PER_RUN = 3
+
+type UpdateQueue = {
+  id: string,
+  action: string,
+  updateFunc: Function
+}
+
+const updateQueue: Array<UpdateQueue> = []
+
+export function enableTestMode () {
+  QUEUE_JOBS_PER_RUN = 99
+  QUEUE_RUN_DELAY = 1
+}
+
+export function pushUpdate (update: UpdateQueue) {
+  let didUpdate = false
+  for (const u of updateQueue) {
+    if (u.id === update.id && u.action === update.action) {
+      u.updateFunc = update.updateFunc
+      didUpdate = true
+      break
+    }
+  }
+  if (!didUpdate) {
+    updateQueue.push(update)
+  }
+}
+
+export function removeIdFromQueue (id: string) {
+  for (let i = 0; i < updateQueue.length; i++) {
+    const update = updateQueue[i]
+    if (id === update.id) {
+      updateQueue.splice(i, 1)
+      break
+    }
+  }
+}
+
+function startQueue () {
+  setTimeout(() => {
+    const numJobs =
+      QUEUE_JOBS_PER_RUN < updateQueue.length
+        ? QUEUE_JOBS_PER_RUN
+        : updateQueue.length
+    for (let i = 0; i < numJobs; i++) {
+      if (updateQueue.length) {
+        const u = updateQueue.shift()
+        u.updateFunc()
+      }
+    }
+    startQueue()
+  }, QUEUE_RUN_DELAY)
+}
+
+startQueue()


### PR DESCRIPTION
This ensures that multiple wallets do not hammer the GUI with simultaneous callbacks, especially at startup.