### PR TITLE
William/yaob update

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "scrypt-js": "^2.0.3",
     "utf8": "^3.0.0",
     "ws": "^5.1.1",
-    "yaob": "^0.3.3"
+    "yaob": "^0.3.4"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/src/io/react-native/react-native-webview.js
+++ b/src/io/react-native/react-native-webview.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react'
 import { Platform, StyleSheet, View } from 'react-native'
 import RNFS from 'react-native-fs'
 import { WebView } from 'react-native-webview'
-import { Bridge, bridgifyObject } from 'yaob'
+import { Bridge, bridgifyObject, onMethod } from 'yaob'
 
 import { type EdgeNativeIo } from '../../types/types.js'
 import { makeClientIo } from './react-native-io.js'
@@ -19,16 +19,100 @@ type Props = {
   nativeIo?: EdgeNativeIo
 }
 
+type WebViewCallbacks = {
+  onMessage: Function,
+  setRef: Function
+}
+
+/**
+ * Sets up a YAOB bridge for use with a React Native WebView.
+ * The returned callbacks should be passed to the `onMessage` and `ref`
+ * properties of the WebView. Handles WebView reloads and related
+ * race conditions.
+ * @param {*} onRoot Called when the inner HTML sends a root object.
+ * May be called multiple times if the inner HTML reloads.
+ * @param {*} debug Set to true to enable logging.
+ */
+function makeOuterWebViewBridge<Root> (
+  onRoot: (root: Root) => mixed,
+  debug: boolean = false
+): WebViewCallbacks {
+  let bridge: Bridge | void
+  let gatedRoot: Root | void
+  let webview: WebView | void
+
+  // Gate the root object on the webview being ready:
+  const tryReleasingRoot = () => {
+    if (gatedRoot != null && webview != null) {
+      onRoot(gatedRoot)
+      gatedRoot = void 0
+    }
+  }
+
+  // Feed incoming messages into the YAOB bridge (if any):
+  const onMessage = event => {
+    const message = JSON.parse(event.nativeEvent.data)
+    if (debug) console.info('edge-core →', message)
+
+    // This is a terrible hack. We are using our inside knowledge
+    // of YAOB's message format to determine when the client has restarted.
+    if (
+      bridge != null &&
+      message.events != null &&
+      message.events.find(event => event.localId === 0)
+    ) {
+      bridge.close(new Error('edge-core: The WebView has been unmounted.'))
+      bridge = void 0
+    }
+
+    // If we have no bridge, start one:
+    if (bridge == null) {
+      let firstMessage = true
+      bridge = new Bridge({
+        sendMessage: message => {
+          if (debug) console.info('edge-core ←', message)
+          if (webview == null) return
+
+          const js = `if (window.bridge != null) {${
+            firstMessage
+              ? 'window.gotFirstMessage = true;'
+              : 'window.gotFirstMessage && '
+          } window.bridge.handleMessage(${JSON.stringify(message)})}`
+          firstMessage = false
+          webview.injectJavaScript(js)
+        }
+      })
+
+      // Use our inside knowledge of YAOB to directly
+      // subscribe to the root object appearing:
+      onMethod.call(bridge._state, 'root', root => {
+        gatedRoot = root
+        tryReleasingRoot()
+      })
+    }
+
+    // Finally, pass the message to the bridge:
+    bridge.handleMessage(message)
+  }
+
+  // Listen for the webview component to mount:
+  const setRef = element => {
+    webview = element
+    tryReleasingRoot()
+  }
+
+  return { onMessage, setRef }
+}
+
 /**
  * Launches the Edge core worker in a WebView and returns its API.
  */
 export class EdgeCoreBridge extends Component<Props> {
-  onMessage: Function
-  setWebview: Function
+  callbacks: WebViewCallbacks
 
   constructor (props: Props) {
     super(props)
-    const { nativeIo = {} } = props
+    const { nativeIo = {}, debug = false } = props
 
     // Set up the native IO objects:
     const nativeIoPromise = makeClientIo().then(coreIo => {
@@ -39,43 +123,14 @@ export class EdgeCoreBridge extends Component<Props> {
       return bridgedIo
     })
 
-    // Listen for the webview component to mount:
-    let webview
-    const webviewReady = new Promise(resolve => {
-      this.setWebview = element => {
-        console.log(
-          'edge-core WebView.ref called with ' +
-            (element == null ? 'null' : 'non-null')
-        )
-        webview = element
-        if (element != null) resolve()
-      }
-    })
-
-    // Create a yaob bridge:
-    const bridge = new Bridge({
-      sendMessage: message => {
-        if (webview == null) {
-          return setTimeout(() => {
-            throw new Error('The edge-core worker has been unmounted.')
-          }, 1000)
-        }
-        if (props.debug) console.info('edge-core ←', message)
-        webview.injectJavaScript(
-          `window.bridge.handleMessage(${JSON.stringify(message)})`
-        )
-      }
-    })
-    this.onMessage = event => {
-      const message = JSON.parse(event.nativeEvent.data)
-      if (props.debug) console.info('edge-core →', message)
-      bridge.handleMessage(message)
-    }
-
-    // Fire our callback once everything is ready:
-    Promise.all([nativeIoPromise, bridge.getRoot(), webviewReady])
-      .then(([nativeIo, root]) => props.onLoad(nativeIo, root))
-      .catch(error => props.onError(error))
+    // Set up the YAOB bridge:
+    this.callbacks = makeOuterWebViewBridge(
+      (root: WorkerApi) =>
+        nativeIoPromise
+          .then(nativeIo => props.onLoad(nativeIo, root))
+          .catch(error => props.onError(error)),
+      debug
+    )
   }
 
   render () {
@@ -92,9 +147,9 @@ export class EdgeCoreBridge extends Component<Props> {
       <View style={this.props.debug ? styles.debug : styles.hidden}>
         <WebView
           allowFileAccess
-          onMessage={this.onMessage}
+          onMessage={this.callbacks.onMessage}
           originWhitelist={['file://*']}
-          ref={this.setWebview}
+          ref={this.callbacks.setRef}
           source={{ uri }}
         />
       </View>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6721,10 +6721,10 @@ yallist@^3.0.0, yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
-yaob@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/yaob/-/yaob-0.3.3.tgz#39f6190d1109207f340d5cf7e9e63efedf67ccee"
-  integrity sha512-qNCO9MbgsaweqGGOJG30TFpvnlmXx7BwQacqI2LtMRQhx/WaDDqp6NzGwkWCkoYwbzfXIR1pMCAEZwX3MEnPJg==
+yaob@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/yaob/-/yaob-0.3.4.tgz#b47433264622bebb14821b5835480d250c22c0d6"
+  integrity sha512-oSMZPHAJcsqZgqsYgg3tmTnTWlTkSeq1BBaln4kiIkBbu4NQOQZDHqoBZ5kZXRkyBxMXKgchBFaWUze0KyLDBQ==
   dependencies:
     rfc4648 "^1.1.0"
 


### PR DESCRIPTION
This solidifies the core state machine around the React Native WebView mounting / unmounting. If the WebView dies for any reason, we will cleanly shut down the core. This will reject any pending message calls and emit a `close` event on every core object.

The GUI can react by taking the user back to the login screen or such.