### PR TITLE
Prefer true swap quotes over estimated amounts

### DIFF
--- a/src/core/swap/swap-api.js
+++ b/src/core/swap/swap-api.js
@@ -65,7 +65,9 @@ export async function fetchSwapQuote (
         quoteUri = swapInfo.quoteUri + bestQuote.quoteId
       }
 
-      const out: EdgeSwapQuote = { ...bestQuote, quoteUri }
+      const { isEstimate = true } = bestQuote
+      // $FlowFixMe - Flow wrongly thinks isEstimate might be undefined here:
+      const out: EdgeSwapQuote = { ...bestQuote, quoteUri, isEstimate }
       bridgifyObject(out)
 
       return out

--- a/src/core/swap/swap-api.js
+++ b/src/core/swap/swap-api.js
@@ -47,6 +47,10 @@ export async function fetchSwapQuote (
       let bestQuote = quotes[0]
       for (let i = 1; i < quotes.length; ++i) {
         if (
+          // Prioritize accurate quotes over estimates:
+          // (use `=== false` so `undefined` maps to `true`):
+          (quotes[i].isEstimate === false && bestQuote.isEstimate !== false) ||
+          // Prefer cheaper quotes:
           gt(quotes[i].toNativeAmount, bestQuote.toNativeAmount) ||
           lt(quotes[i].fromNativeAmount, bestQuote.fromNativeAmount)
         ) {

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -550,6 +550,7 @@ export type EdgeSwapRequest = {
 }
 
 export type EdgeSwapPluginQuote = {
+  +isEstimate?: boolean, // Defaults to true. Edge prefers true quotes (not estimates) where possible.
   +fromNativeAmount: string,
   +toNativeAmount: string,
   +networkFee: EdgeNetworkFee,

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -685,6 +685,7 @@ export type EdgeSwapConfig = {
 }
 
 export type EdgeSwapQuote = EdgeSwapPluginQuote & {
+  +isEstimate: boolean,
   +quoteUri?: string
 }
 


### PR DESCRIPTION
TODO:
* Update all swap plugins to set `isEstimate` in the correct way.
* Update the GUI to show a warning when `isEstimate` is set to `true` on the returned quote.