### PR TITLE
Add otherParams (from currencyPlugin) to EdgeTransaction

### DIFF
--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -523,13 +523,13 @@ export function combineTxWithFile (
     ourReceiveAddresses: tx.ourReceiveAddresses,
     signedTx: tx.signedTx,
     txid: tx.txid,
+    otherParams: { ...tx.otherParams, unfilteredIndex },
 
     amountSatoshi: Number(tx.nativeAmount[currencyCode]),
     nativeAmount: tx.nativeAmount[currencyCode],
     networkFee: tx.networkFee[currencyCode],
     currencyCode,
-    wallet,
-    otherParams: { unfilteredIndex }
+    wallet
   }
 
   // These are our fallback values:

--- a/src/core/currency/wallet/currency-wallet-reducer.js
+++ b/src/core/currency/wallet/currency-wallet-reducer.js
@@ -40,6 +40,7 @@ export type MergedTransaction = {
   ourReceiveAddresses: Array<string>,
   signedTx: string,
   txid: string,
+  otherParams?: Object,
 
   nativeAmount: { [currencyCode: string]: string },
   networkFee: { [currencyCode: string]: string }
@@ -325,6 +326,7 @@ export function mergeTx (
     ourReceiveAddresses: tx.ourReceiveAddresses,
     signedTx: tx.signedTx,
     txid: tx.txid,
+    otherParams: tx.otherParams,
 
     nativeAmount: { ...oldTx.nativeAmount },
     networkFee: { ...oldTx.networkFee }


### PR DESCRIPTION
Allow currency-plugins to add data to `otherParam` that pass through to core (and GUI), specifically for debugging info (inputs, outputs, satoshis, etc)