### PR TITLE
Save OTP keys from the server

### DIFF
--- a/src/core/fake/fake-db.js
+++ b/src/core/fake/fake-db.js
@@ -10,6 +10,7 @@ export const loginReplyColumns = [
   'loginAuthBox',
   'loginId',
   // Login methods:
+  'otpKey',
   'otpResetDate',
   'otpTimeout',
   'passwordAuthBox',
@@ -34,7 +35,6 @@ export const loginReplyColumns = [
 export const loginDbColumns = [
   ...loginReplyColumns,
   'loginAuth',
-  'otpKey',
   'passwordAuth',
   'pin2Auth',
   'pin2Id',

--- a/src/core/login/login.js
+++ b/src/core/login/login.js
@@ -79,6 +79,7 @@ function applyLoginReplyInner(stash, loginKey, loginReply) {
     'loginId',
     'loginAuthBox',
     'userId',
+    'otpKey',
     'otpResetDate',
     'otpTimeout',
     'parentBox',
@@ -95,7 +96,6 @@ function applyLoginReplyInner(stash, loginKey, loginReply) {
   // Preserve client-only data:
   if (stash.username != null) out.username = stash.username
   if (stash.userId != null) out.userId = stash.userId
-  if (stash.otpKey != null) out.otpKey = stash.otpKey
 
   // Store the pin key unencrypted:
   if (loginReply.pin2KeyBox != null) {


### PR DESCRIPTION
This will be useful once the auth server has been updated to return the OTP secret with successful logins. With that in place, enabling OTP on one phone will enable it for the other phones that can log in with PIN or fingerprint.