### PR TITLE
William/cors fetch

### DIFF
--- a/src/core/fake/fake-server.js
+++ b/src/core/fake/fake-server.js
@@ -1,7 +1,7 @@
 import { checkTotp } from '../../util/crypto/hotp.js'
 import { filterObject, softCat } from '../../util/util.js'
 import { loginCreateColumns } from './fake-db.js'
-import { addRoute, FakeResponse } from './fake-fetch.js'
+import { addRoute } from './fake-fetch.js'
 
 const OTP_RESET_TOKEN = 'Super secret reset token'
 
@@ -25,7 +25,7 @@ function makeResponse(results) {
   if (results != null) {
     reply.results = results
   }
-  return new FakeResponse(JSON.stringify(reply))
+  return { body: JSON.stringify(reply) }
 }
 
 function makeErrorResponse(code, message = '', status = 500) {
@@ -33,7 +33,7 @@ function makeErrorResponse(code, message = '', status = 500) {
     status_code: code,
     message: message || 'Server error'
   }
-  return new FakeResponse(JSON.stringify(body), { status })
+  return { body: JSON.stringify(body), status }
 }
 
 function makeOtpErrorResponse(status = 500) {
@@ -44,7 +44,7 @@ function makeOtpErrorResponse(status = 500) {
       otp_reset_auth: OTP_RESET_TOKEN
     }
   }
-  return new FakeResponse(JSON.stringify(body), { status })
+  return { body: JSON.stringify(body), status }
 }
 
 // Authentication middleware: ----------------------------------------------
@@ -505,7 +505,7 @@ addRoute('POST', '/api/v2/lobby/.*', function(req) {
 addRoute('GET', '/api/v2/lobby/.*', function(req) {
   const pubkey = req.path.split('/')[4]
   if (this.db.lobbies[pubkey] == null) {
-    return new FakeResponse(`Cannot find lobby "${pubkey}"`, { status: 404 })
+    return { body: `Cannot find lobby "${pubkey}"`, status: 404 }
   }
   return makeResponse(this.db.lobbies[pubkey])
 })
@@ -544,7 +544,7 @@ function storeRoute(req) {
 
   const repo = this.repos[syncKey]
   if (repo == null) {
-    return new FakeResponse('Cannot find repo ' + syncKey, { status: 404 })
+    return { body: 'Cannot find repo ' + syncKey, status: 404 }
   }
 
   switch (req.method) {
@@ -553,16 +553,16 @@ function storeRoute(req) {
       for (const change of Object.keys(changes)) {
         repo[change] = changes[change]
       }
-      return new FakeResponse(
-        JSON.stringify({
+      return {
+        body: JSON.stringify({
           changes: repo,
           hash: '1111111111111111111111111111111111111111'
         })
-      )
+      }
     }
 
     case 'GET':
-      return new FakeResponse(JSON.stringify({ changes: repo }))
+      return { body: JSON.stringify({ changes: repo }) }
   }
 }
 

--- a/src/core/fake/fake-world.js
+++ b/src/core/fake/fake-world.js
@@ -92,8 +92,8 @@ export function makeFakeWorld(
       return out
     },
 
-    async goOffline(offline?: boolean): Promise<mixed> {
-      fakeFetch.offline = offline || offline == null
+    async goOffline(offline: boolean = true): Promise<mixed> {
+      fakeFetch.offline = offline
     },
 
     async dumpFakeUser(account: EdgeAccount): Promise<EdgeFakeUser> {

--- a/src/core/login/authServer.js
+++ b/src/core/login/authServer.js
@@ -1,6 +1,7 @@
 // @flow
 
 import {
+  type EdgeFetchOptions,
   NetworkError,
   ObsoleteApiError,
   OtpError,
@@ -52,12 +53,12 @@ export function authRequest(
   const { state, io, log } = ai.props
   const { apiKey, uri } = state.login.server
 
-  const opts: RequestOptions = {
+  const opts: EdgeFetchOptions = {
     method: method,
     headers: {
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-      Authorization: `Token ${
+      'content-type': 'application/json',
+      accept: 'application/json',
+      authorization: `Token ${
         apiKey === '' ? '4248c1bf41e53b840a5fdb2c872dd3ade525e66d' : apiKey
       }`
     }

--- a/src/core/storage/storage-servers.js
+++ b/src/core/storage/storage-servers.js
@@ -1,6 +1,11 @@
 // @flow
 
-import { type EdgeIo, type EdgeLog, NetworkError } from '../../types/types.js'
+import {
+  type EdgeFetchOptions,
+  type EdgeIo,
+  type EdgeLog,
+  NetworkError
+} from '../../types/types.js'
 
 const syncServers = [
   'https://git3.airbitz.co',
@@ -29,11 +34,11 @@ function syncRequestInner(
   body: Object,
   serverIndex: number
 ) {
-  const opts: Object = {
+  const opts: EdgeFetchOptions = {
     method: method,
     headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json'
+      'content-type': 'application/json',
+      accept: 'application/json'
     }
   }
   if (method !== 'GET') {

--- a/src/io/browser/browser-io.js
+++ b/src/io/browser/browser-io.js
@@ -3,7 +3,11 @@
 import { makeLocalStorageDisklet } from 'disklet'
 
 import { fakeConsole } from '../../core/fake/fake-io.js'
-import { type EdgeIo } from '../../types/types.js'
+import {
+  type EdgeFetchOptions,
+  type EdgeFetchResponse,
+  type EdgeIo
+} from '../../types/types.js'
 import { scrypt } from '../../util/crypto/scrypt.js'
 
 /**
@@ -36,7 +40,9 @@ export function makeBrowserIo(): EdgeIo {
     }),
 
     // Networking:
-    fetch: (...rest) => window.fetch(...rest),
+    fetch(uri: string, opts?: EdgeFetchOptions): Promise<EdgeFetchResponse> {
+      return window.fetch(uri, opts)
+    },
     WebSocket: window.WebSocket
   }
 }

--- a/src/io/node/node-io.js
+++ b/src/io/node/node-io.js
@@ -27,6 +27,7 @@ export function makeNodeIo(path: string): EdgeIo {
 
     // Networking:
     fetch,
+    fetchCors: fetch,
     WebSocket
   }
 }

--- a/src/io/react-native/react-native-io.js
+++ b/src/io/react-native/react-native-io.js
@@ -5,26 +5,91 @@ import { NativeModules } from 'react-native'
 import { scrypt } from 'react-native-fast-crypto'
 import { bridgifyObject } from 'yaob'
 
+import { type EdgeFetchOptions, NetworkError } from '../../types/types.js'
+import {
+  type SimpleHeaders,
+  type SimpleResponse
+} from '../../util/fetch-response.js'
 import { type ClientIo } from './react-native-types.js'
 
 const randomBytes = NativeModules.RNRandomBytes.randomBytes
+
+/**
+ * Turns XMLHttpRequest headers into a more JSON-like structure.
+ */
+function extractHeaders(headers: string): SimpleHeaders {
+  const pairs = headers.split('\r\n')
+
+  const out: SimpleHeaders = {}
+  for (const pair of pairs) {
+    const index = pair.indexOf(': ')
+    if (index < 0) continue
+    out[pair.slice(0, index).toLowerCase()] = pair.slice(index + 2)
+  }
+  return out
+}
+
+/**
+ * Fetches data from the React Native side, where CORS doesn't apply.
+ */
+function fetchCors(
+  uri: string,
+  opts: EdgeFetchOptions = {}
+): Promise<SimpleResponse> {
+  const { body, headers = {}, method = 'GET' } = opts
+
+  return new Promise((resolve, reject) => {
+    const xhr = new window.XMLHttpRequest()
+
+    // Event handlers:
+    function handleError() {
+      reject(new NetworkError(`Could not reach ${uri}`))
+    }
+
+    function handleLoad() {
+      const headers = xhr.getAllResponseHeaders()
+      resolve({
+        body: xhr.response,
+        headers: extractHeaders(headers == null ? '' : headers),
+        status: xhr.status
+      })
+    }
+
+    // Set up the request:
+    xhr.open(method, uri, true)
+    xhr.responseType = 'arraybuffer'
+    xhr.onerror = handleError
+    xhr.ontimeout = handleError
+    xhr.onload = handleLoad
+    for (const name of Object.keys(headers)) {
+      xhr.setRequestHeader(name, headers[name])
+    }
+    xhr.send(body)
+  })
+}
 
 export function makeClientIo(): Promise<ClientIo> {
   return new Promise((resolve, reject) => {
     randomBytes(32, (error, base64String) => {
       if (error) return reject(error)
 
-      const out = bridgifyObject({
+      const out: ClientIo = {
+        // Crypto:
+        entropy: base64String,
+        scrypt,
+
+        // Local IO:
         console: bridgifyObject({
           info: (...args) => console.info(...args),
           error: (...args) => console.error(...args),
           warn: (...args) => console.warn(...args)
         }),
         disklet: bridgifyObject(makeReactNativeDisklet()),
-        entropy: base64String,
-        scrypt
-      })
-      resolve(out)
+
+        // Networking:
+        fetchCors
+      }
+      resolve(bridgifyObject(out))
     })
   })
 }

--- a/src/io/react-native/react-native-types.js
+++ b/src/io/react-native/react-native-types.js
@@ -8,16 +8,21 @@ import {
   type EdgeContextOptions,
   type EdgeFakeUser,
   type EdgeFakeWorld,
+  type EdgeFetchOptions,
   type EdgeNativeIo,
   type EdgeScryptFunction
 } from '../../types/types.js'
+import { type SimpleResponse } from '../../util/fetch-response.js'
 
 export type ClientIo = {
   +console: EdgeConsole,
   +disklet: Disklet,
 
   +entropy: string, // base64
-  +scrypt: EdgeScryptFunction
+  +scrypt: EdgeScryptFunction,
+
+  // Networking:
+  fetchCors(url: string, opts: EdgeFetchOptions): Promise<SimpleResponse>
 }
 
 export type WorkerApi = {

--- a/src/io/react-native/react-native-worker.js
+++ b/src/io/react-native/react-native-worker.js
@@ -19,6 +19,7 @@ import {
   type EdgeIo,
   type EdgeNativeIo
 } from '../../types/types.js'
+import { wrapResponse } from '../../util/fetch-response.js'
 import { type ClientIo, type WorkerApi } from './react-native-types.js'
 
 const body = document.body
@@ -54,6 +55,13 @@ function makeIo(nativeIo: EdgeNativeIo): EdgeIo {
     // Networking:
     fetch(uri: string, opts?: EdgeFetchOptions): Promise<EdgeFetchResponse> {
       return window.fetch(uri, opts)
+    },
+
+    fetchCors(
+      uri: string,
+      opts: EdgeFetchOptions = {}
+    ): Promise<EdgeFetchResponse> {
+      return clientIo.fetchCors(uri, opts).then(wrapResponse)
     },
 
     WebSocket: window.WebSocket

--- a/src/io/react-native/react-native-worker.js
+++ b/src/io/react-native/react-native-worker.js
@@ -13,7 +13,12 @@ import {
   makeContext,
   makeFakeWorld
 } from '../../core/core.js'
-import { type EdgeIo, type EdgeNativeIo } from '../../types/types.js'
+import {
+  type EdgeFetchOptions,
+  type EdgeFetchResponse,
+  type EdgeIo,
+  type EdgeNativeIo
+} from '../../types/types.js'
 import { type ClientIo, type WorkerApi } from './react-native-types.js'
 
 const body = document.body
@@ -43,11 +48,15 @@ function makeIo(nativeIo: EdgeNativeIo): EdgeIo {
     console,
     disklet,
 
-    fetch: (...args) => window.fetch(...args),
-    WebSocket: window.WebSocket,
-
     random: bytes => csprng.generate(bytes),
-    scrypt
+    scrypt,
+
+    // Networking:
+    fetch(uri: string, opts?: EdgeFetchOptions): Promise<EdgeFetchResponse> {
+      return window.fetch(uri, opts)
+    },
+
+    WebSocket: window.WebSocket
   }
 }
 

--- a/src/react-native.js
+++ b/src/react-native.js
@@ -10,6 +10,7 @@ import {
   type EdgeContextOptions,
   type EdgeFakeUser,
   type EdgeFakeWorld,
+  type EdgeFetchOptions,
   type EdgeLoginMessages,
   type EdgeNativeIo,
   NetworkError
@@ -96,12 +97,12 @@ export async function fetchLoginMessages(
   }
 
   const uri = 'https://auth.airbitz.co/api/v2/messages'
-  const opts: RequestOptions = {
+  const opts: EdgeFetchOptions = {
     method: 'POST',
     headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-      Authorization: 'Token ' + apiKey
+      'content-type': 'application/json',
+      accept: 'application/json',
+      authorization: 'Token ' + apiKey
     },
     body: JSON.stringify({ loginIds: Object.keys(loginMap) })
   }

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -59,6 +59,48 @@ export type EdgeScryptFunction = (
 ) => Promise<Uint8Array>
 
 /**
+ * The subset of the `fetch` options we guarantee to support.
+ */
+export type EdgeFetchOptions = {
+  method?: string,
+  body?: ArrayBuffer | string,
+  headers?: { [header: string]: string }
+}
+
+/**
+ * The subset of the `Headers` DOM object we guarantee to support.
+ */
+export type EdgeFetchHeaders = {
+  forEach(
+    callback: (value: string, name: string, self: EdgeFetchHeaders) => void,
+    thisArg?: any
+  ): void,
+  get(name: string): string | null,
+  has(name: string): boolean
+}
+
+/**
+ * The subset of the `Response` DOM object we guarantee to support.
+ */
+export type EdgeFetchResponse = {
+  +headers: EdgeFetchHeaders,
+  +ok: boolean,
+  +status: number,
+  arrayBuffer(): Promise<ArrayBuffer>,
+  json(): Promise<any>,
+  text(): Promise<string>
+}
+
+/**
+ * The subset of the `fetch` DOM function we guarantee to support,
+ * especially if we have to emulate `fetch` in weird environments.
+ */
+export type EdgeFetchFunction = (
+  uri: string,
+  opts?: EdgeFetchOptions
+) => Promise<EdgeFetchResponse>
+
+/**
  * Access to platform-specific resources.
  * The core never talks to the outside world on its own,
  * but always goes through this object.
@@ -70,7 +112,7 @@ export type EdgeIo = {
 
   // Local io:
   +disklet: Disklet,
-  +fetch: typeof fetch,
+  +fetch: EdgeFetchFunction,
 
   // Deprecated:
   // eslint-disable-next-line no-use-before-define

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -114,6 +114,9 @@ export type EdgeIo = {
   +disklet: Disklet,
   +fetch: EdgeFetchFunction,
 
+  // This is only present if the platform has some way to avoid CORS:
+  +fetchCors?: EdgeFetchFunction,
+
   // Deprecated:
   // eslint-disable-next-line no-use-before-define
   +console: EdgeConsole,

--- a/src/util/fetch-response.js
+++ b/src/util/fetch-response.js
@@ -1,0 +1,71 @@
+// @flow
+
+import {
+  type EdgeFetchHeaders,
+  type EdgeFetchResponse
+} from '../types/types.js'
+import { utf8 } from './encoding.js'
+
+export type SimpleBody = ArrayBuffer | string
+
+export type SimpleHeaders = { [header: string]: string }
+
+export type SimpleResponse = {
+  body?: SimpleBody | Promise<SimpleBody>,
+  headers?: SimpleHeaders,
+  status?: number
+}
+
+/**
+ * Turns a simple response into a fetch-style Response object.
+ */
+export function wrapResponse(response: SimpleResponse): EdgeFetchResponse {
+  const { body = '', headers = {}, status = 200 } = response
+  const bodyPromise: Promise<SimpleBody> = Promise.resolve(body)
+
+  const out: EdgeFetchResponse = {
+    headers: wrapHeaders(headers),
+    ok: status >= 200 && status < 300,
+    status,
+
+    arrayBuffer(): Promise<ArrayBuffer> {
+      return bodyPromise.then(body =>
+        typeof body === 'string' ? utf8.parse(body).buffer : body
+      )
+    },
+
+    json() {
+      return out.text().then(text => JSON.parse(text))
+    },
+
+    text() {
+      return bodyPromise.then(body =>
+        typeof body === 'string' ? body : utf8.stringify(new Uint8Array(body))
+      )
+    }
+  }
+  return out
+}
+
+/**
+ * Turns a simple key-value map into a fetch-style Headers object.
+ */
+function wrapHeaders(headers: SimpleHeaders): EdgeFetchHeaders {
+  const out: EdgeFetchHeaders = {
+    forEach(callback, thisArg) {
+      Object.keys(headers).forEach(name =>
+        callback.call(thisArg, headers[name], name, out)
+      )
+    },
+
+    get(name) {
+      if (!out.has(name)) return null
+      return headers[name]
+    },
+
+    has(name) {
+      return Object.prototype.hasOwnProperty.call(headers, name)
+    }
+  }
+  return out
+}


### PR DESCRIPTION
This provides a common `fetchCors` io method on platforms that support it (so not Web).

The `fetch` method now has explicit Flow types, rather than just using whatever Flow had built in. This clarifies exactly which features we support and which we do not.