### PR TITLE
Add xpubExplorer to EdgeCurrencyInfo type

### DIFF
--- a/src/types/types.js
+++ b/src/types/types.js
@@ -251,6 +251,7 @@ export type EdgeCurrencyInfo = {
   addressExplorer: string,
   blockExplorer?: string,
   transactionExplorer: string,
+  xpubExplorer?: string,
 
   // Images:
   symbolImage?: string,


### PR DESCRIPTION
This PR is a dependency of the edge-react-gui PR that utilizes the change made here: https://github.com/EdgeApp/edge-react-gui/pull/1799