### PR TITLE
William/swap plugins

### DIFF
--- a/src/core/account/account-api.js
+++ b/src/core/account/account-api.js
@@ -61,14 +61,14 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
 
   // Plugin config API's:
   const currencyConfigs: EdgePluginMap<EdgeCurrencyConfig> = {}
-  for (const pluginName in ai.props.state.plugins.currency) {
-    const api = new CurrencyConfig(ai, accountId, pluginName)
-    currencyConfigs[pluginName] = api
+  for (const pluginId in ai.props.state.plugins.currency) {
+    const api = new CurrencyConfig(ai, accountId, pluginId)
+    currencyConfigs[pluginId] = api
   }
   const swapConfigs: EdgePluginMap<EdgeSwapConfig> = {}
-  for (const pluginName in ai.props.state.plugins.swap) {
-    const api = new SwapConfig(ai, accountId, pluginName)
-    swapConfigs[pluginName] = api
+  for (const pluginId in ai.props.state.plugins.swap) {
+    const api = new SwapConfig(ai, accountId, pluginId)
+    swapConfigs[pluginId] = api
   }
 
   // Specialty API's:

--- a/src/core/account/account-api.js
+++ b/src/core/account/account-api.js
@@ -17,6 +17,7 @@ import {
   type EdgeSwapConfig,
   type EdgeSwapQuote,
   type EdgeSwapRequest,
+  type EdgeSwapRequestOptions,
   type EdgeWalletInfoFull,
   type EdgeWalletStates,
   type EthereumTransaction,
@@ -338,8 +339,11 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
       return signEthereumTransaction(walletInfo.keys.ethereumKey, transaction)
     },
 
-    async fetchSwapQuote(request: EdgeSwapRequest): Promise<EdgeSwapQuote> {
-      return fetchSwapQuote(ai, accountId, request)
+    async fetchSwapQuote(
+      request: EdgeSwapRequest,
+      opts?: EdgeSwapRequestOptions
+    ): Promise<EdgeSwapQuote> {
+      return fetchSwapQuote(ai, accountId, request, opts)
     },
 
     // Deprecated names:

--- a/src/core/account/account-files.js
+++ b/src/core/account/account-files.js
@@ -218,7 +218,7 @@ export async function changeWalletStates(
 export async function changePluginUserSettings(
   ai: ApiInput,
   accountId: string,
-  pluginName: string,
+  pluginId: string,
   userSettings: JsonObject
 ) {
   const { accountWalletInfo } = ai.props.state.accounts[accountId]
@@ -230,7 +230,7 @@ export async function changePluginUserSettings(
   // Write the new state to disk:
   const json: PluginSettingsFile = await getJson(file)
   json.userSettings = { ...ai.props.state.accounts[accountId].userSettings }
-  json.userSettings[pluginName] = userSettings
+  json.userSettings[pluginId] = userSettings
   await file.setText(JSON.stringify(json))
 
   // Update Redux:
@@ -238,7 +238,7 @@ export async function changePluginUserSettings(
     type: 'ACCOUNT_PLUGIN_SETTINGS_CHANGED',
     payload: {
       accountId,
-      pluginName,
+      pluginId,
       userSettings: { ...userSettings }
     }
   })
@@ -250,7 +250,7 @@ export async function changePluginUserSettings(
 export async function changeSwapSettings(
   ai: ApiInput,
   accountId: string,
-  pluginName: string,
+  pluginId: string,
   swapSettings: SwapSettings
 ) {
   const { accountWalletInfo } = ai.props.state.accounts[accountId]
@@ -262,13 +262,13 @@ export async function changeSwapSettings(
   // Write the new state to disk:
   const json: PluginSettingsFile = await getJson(file)
   json.swapSettings = { ...ai.props.state.accounts[accountId].swapSettings }
-  json.swapSettings[pluginName] = swapSettings
+  json.swapSettings[pluginId] = swapSettings
   await file.setText(JSON.stringify(json))
 
   // Update Redux:
   ai.props.dispatch({
     type: 'ACCOUNT_SWAP_SETTINGS_CHANGED',
-    payload: { accountId, pluginName, swapSettings }
+    payload: { accountId, pluginId, swapSettings }
   })
 }
 

--- a/src/core/account/account-pixie.js
+++ b/src/core/account/account-pixie.js
@@ -171,11 +171,11 @@ const accountPixie: TamePixie<AccountProps> = combinePixies({
         if (selfOutput.api != null) {
           // TODO: Put this back once we solve the race condition:
           // update(selfOutput.api)
-          for (const pluginName in selfOutput.api.currencyConfig) {
-            update(selfOutput.api.currencyConfig[pluginName])
+          for (const pluginId in selfOutput.api.currencyConfig) {
+            update(selfOutput.api.currencyConfig[pluginId])
           }
-          for (const pluginName in selfOutput.api.swapConfig) {
-            update(selfOutput.api.swapConfig[pluginName])
+          for (const pluginId in selfOutput.api.swapConfig) {
+            update(selfOutput.api.swapConfig[pluginId])
           }
         }
       }

--- a/src/core/account/account-reducer.js
+++ b/src/core/account/account-reducer.js
@@ -241,9 +241,9 @@ const account = buildReducer({
         return action.payload.swapSettings
 
       case 'ACCOUNT_SWAP_SETTINGS_CHANGED': {
-        const { pluginName, swapSettings } = action.payload
+        const { pluginId, swapSettings } = action.payload
         const out = { ...state }
-        out[pluginName] = swapSettings
+        out[pluginId] = swapSettings
         return out
       }
     }
@@ -253,9 +253,9 @@ const account = buildReducer({
   userSettings(state = {}, action: RootAction): EdgePluginMap<JsonObject> {
     switch (action.type) {
       case 'ACCOUNT_PLUGIN_SETTINGS_CHANGED': {
-        const { pluginName, userSettings } = action.payload
+        const { pluginId, userSettings } = action.payload
         const out = { ...state }
-        out[pluginName] = userSettings
+        out[pluginId] = userSettings
         return out
       }
 

--- a/src/core/account/account-selectors.js
+++ b/src/core/account/account-selectors.js
@@ -1,16 +1,12 @@
 // @flow
 
-import { type EdgePluginMap } from '../../types/types.js'
 import { type SwapSettings } from './account-reducer.js'
 
 /**
  * Determines whether or not a swap plugin is enabled,
  * with various fallbacks in case the settings are missing.
  */
-export function swapPluginEnabled(
-  swapSettings: EdgePluginMap<SwapSettings>,
-  pluginName: string
-): boolean {
-  const { enabled = true } = swapSettings[pluginName] || {}
+export function swapPluginEnabled(swapSettings: SwapSettings = {}): boolean {
+  const { enabled = true } = swapSettings
   return enabled
 }

--- a/src/core/account/plugin-api.js
+++ b/src/core/account/plugin-api.js
@@ -24,17 +24,17 @@ import { swapPluginEnabled } from './account-selectors.js'
 export class CurrencyConfig extends Bridgeable<EdgeCurrencyConfig> {
   _ai: ApiInput
   _accountId: string
-  _pluginName: string
+  _pluginId: string
 
   otherMethods: EdgeOtherMethods
 
-  constructor(ai: ApiInput, accountId: string, pluginName: string) {
+  constructor(ai: ApiInput, accountId: string, pluginId: string) {
     super()
     this._ai = ai
     this._accountId = accountId
-    this._pluginName = pluginName
+    this._pluginId = pluginId
 
-    const { otherMethods } = ai.props.state.plugins.currency[pluginName]
+    const { otherMethods } = ai.props.state.plugins.currency[pluginId]
     if (otherMethods != null) {
       bridgifyObject(otherMethods)
       this.otherMethods = otherMethods
@@ -44,19 +44,19 @@ export class CurrencyConfig extends Bridgeable<EdgeCurrencyConfig> {
   }
 
   get currencyInfo(): EdgeCurrencyInfo {
-    return this._ai.props.state.plugins.currency[this._pluginName].currencyInfo
+    return this._ai.props.state.plugins.currency[this._pluginId].currencyInfo
   }
 
   get userSettings(): JsonObject {
     const selfState = this._ai.props.state.accounts[this._accountId]
-    return selfState.userSettings[this._pluginName]
+    return selfState.userSettings[this._pluginId]
   }
 
   async changeUserSettings(settings: JsonObject): Promise<mixed> {
     await changePluginUserSettings(
       this._ai,
       this._accountId,
-      this._pluginName,
+      this._pluginId,
       settings
     )
   }
@@ -74,42 +74,42 @@ export class CurrencyConfig extends Bridgeable<EdgeCurrencyConfig> {
 export class SwapConfig extends Bridgeable<EdgeSwapConfig> {
   _ai: ApiInput
   _accountId: string
-  _pluginName: string
+  _pluginId: string
 
-  constructor(ai: ApiInput, accountId: string, pluginName: string) {
+  constructor(ai: ApiInput, accountId: string, pluginId: string) {
     super()
     this._ai = ai
     this._accountId = accountId
-    this._pluginName = pluginName
+    this._pluginId = pluginId
   }
 
   get enabled(): boolean {
     const account = this._ai.props.state.accounts[this._accountId]
-    return swapPluginEnabled(account.swapSettings, this._pluginName)
+    return swapPluginEnabled(account.swapSettings[this._pluginId])
   }
 
   get needsActivation(): boolean {
-    const plugin = this._ai.props.state.plugins.swap[this._pluginName]
+    const plugin = this._ai.props.state.plugins.swap[this._pluginId]
     if (plugin.checkSettings == null) return false
 
     const selfState = this._ai.props.state.accounts[this._accountId]
-    const settings = selfState.userSettings[this._pluginName] || {}
+    const settings = selfState.userSettings[this._pluginId] || {}
     return !!plugin.checkSettings(settings).needsActivation
   }
 
   get swapInfo(): EdgeSwapInfo {
-    return this._ai.props.state.plugins.swap[this._pluginName].swapInfo
+    return this._ai.props.state.plugins.swap[this._pluginId].swapInfo
   }
 
   get userSettings(): JsonObject {
     const selfState = this._ai.props.state.accounts[this._accountId]
-    return selfState.userSettings[this._pluginName]
+    return selfState.userSettings[this._pluginId]
   }
 
   async changeEnabled(enabled: boolean): Promise<mixed> {
     const account = this._ai.props.state.accounts[this._accountId]
-    return changeSwapSettings(this._ai, this._accountId, this._pluginName, {
-      ...account.swapSettings[this._pluginName],
+    return changeSwapSettings(this._ai, this._accountId, this._pluginId, {
+      ...account.swapSettings[this._pluginId],
       enabled
     })
   }
@@ -118,7 +118,7 @@ export class SwapConfig extends Bridgeable<EdgeSwapConfig> {
     await changePluginUserSettings(
       this._ai,
       this._accountId,
-      this._pluginName,
+      this._pluginId,
       settings
     )
   }

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -53,7 +53,7 @@ export type RootAction =
       type: 'ACCOUNT_PLUGIN_SETTINGS_CHANGED',
       payload: {
         accountId: string,
-        pluginName: string,
+        pluginId: string,
         userSettings: JsonObject
       }
     }
@@ -71,7 +71,7 @@ export type RootAction =
       type: 'ACCOUNT_SWAP_SETTINGS_CHANGED',
       payload: {
         accountId: string,
-        pluginName: string,
+        pluginId: string,
         swapSettings: SwapSettings
       }
     }
@@ -176,7 +176,7 @@ export type RootAction =
       // Called when the core finishes loading currency tools:
       type: 'CURRENCY_TOOLS_LOADED',
       payload: {
-        pluginName: string,
+        pluginId: string,
         tools: Promise<EdgeCurrencyTools>
       }
     }

--- a/src/core/currency/currency-reducer.js
+++ b/src/core/currency/currency-reducer.js
@@ -66,8 +66,8 @@ export const currency = buildReducer({
     (state: RootState) => state.plugins.currency,
     (plugins: EdgePluginMap<EdgeCurrencyPlugin>) => {
       const out: EdgeCurrencyInfo[] = []
-      for (const pluginName in plugins) {
-        out.push(plugins[pluginName].currencyInfo)
+      for (const pluginId in plugins) {
+        out.push(plugins[pluginId].currencyInfo)
       }
       return out
     }

--- a/src/core/currency/wallet/currency-wallet-pixie.js
+++ b/src/core/currency/wallet/currency-wallet-pixie.js
@@ -79,8 +79,8 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
       const ai: ApiInput = (input: any) // Safe, since input extends ApiInput
       await addStorageWallet(ai, walletInfo)
       const { selfState, state } = input.props
-      const { accountId, pluginName } = selfState
-      const userSettings = state.accounts[accountId].userSettings[pluginName]
+      const { accountId, pluginId } = selfState
+      const userSettings = state.accounts[accountId].userSettings[pluginId]
 
       const walletLocalDisklet = getStorageWalletLocalDisklet(
         state,
@@ -294,8 +294,8 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
       }
 
       // Update engine settings:
-      const { accountId, pluginName } = selfState
-      const userSettings = state.accounts[accountId].userSettings[pluginName]
+      const { accountId, pluginId } = selfState
+      const userSettings = state.accounts[accountId].userSettings[pluginId]
       if (lastSettings !== userSettings) {
         lastSettings = userSettings
         const engine = selfOutput.engine

--- a/src/core/currency/wallet/currency-wallet-reducer.js
+++ b/src/core/currency/wallet/currency-wallet-reducer.js
@@ -49,7 +49,7 @@ export type MergedTransaction = {
 
 export type CurrencyWalletState = {
   +accountId: string,
-  +pluginName: string,
+  +pluginId: string,
 
   +currencyInfo: EdgeCurrencyInfo,
   +displayPrivateSeed: string | null,
@@ -92,7 +92,7 @@ const currencyWallet = buildReducer({
     throw new Error(`Cannot find account for walletId ${next.id}`)
   },
 
-  pluginName: memoizeReducer(
+  pluginId: memoizeReducer(
     next => next.root.login.walletInfos[next.id].type,
     next => next.root.plugins.currency,
     (walletType: string, plugins): string => {

--- a/src/core/exchange/exchange-pixie.js
+++ b/src/core/exchange/exchange-pixie.js
@@ -34,8 +34,8 @@ export const exchange: TamePixie<RootProps> = filterPixie(
 
     function doFetch() {
       // Quit early if there is nothing to do:
-      const pluginNames = Object.keys(input.props.state.plugins.rate)
-      if (pluginNames.length === 0) return
+      const pluginIds = Object.keys(input.props.state.plugins.rate)
+      if (pluginIds.length === 0) return
 
       const hintPairs = gatherHints()
 
@@ -51,21 +51,21 @@ export const exchange: TamePixie<RootProps> = filterPixie(
       // Initiate all requests:
       let finishedPairs: number = 0
       const timestamp = Date.now() / 1000
-      const promises = pluginNames.map(pluginName => {
-        const plugin = input.props.state.plugins.rate[pluginName]
-        return fetchPluginRates(plugin, hintPairs, pluginName, timestamp)
+      const promises = pluginIds.map(pluginId => {
+        const plugin = input.props.state.plugins.rate[pluginId]
+        return fetchPluginRates(plugin, hintPairs, pluginId, timestamp)
           .then(pairs => {
             if (wait) waitingPairs = [...waitingPairs, ...pairs]
-            else dispatchPairs(pairs, pluginName)
+            else dispatchPairs(pairs, pluginId)
           })
           .catch(error => {
             input.props.log(
-              `Rate provider ${pluginName} failed: ${String(error)}`
+              `Rate provider ${pluginId} failed: ${String(error)}`
             )
           })
           .then(() => {
             // There is no need to keep waiting if all plugins are done:
-            if (wait && ++finishedPairs >= pluginNames.length) {
+            if (wait && ++finishedPairs >= pluginIds.length) {
               clearTimeout(waitTimeout)
               sendWaitingPairs(true)
             }

--- a/src/core/login/keys.js
+++ b/src/core/login/keys.js
@@ -172,7 +172,7 @@ export function getAllWalletInfos(
 /**
  * Upgrades legacy wallet info structures into the new format.
  *
- * Wallets normally have `wallet:pluginName` as their type,
+ * Wallets normally have `wallet:pluginId` as their type,
  * but some legacy wallets also put format information into the wallet type.
  * This routine moves the information out of the wallet type into the keys.
  *

--- a/src/core/plugins/plugins-actions.js
+++ b/src/core/plugins/plugins-actions.js
@@ -32,8 +32,8 @@ export function addEdgeCorePlugins(plugins: EdgeCorePlugins): mixed {
   }
 
   // Save the new plugins:
-  for (const pluginName in plugins) {
-    allPlugins[pluginName] = plugins[pluginName]
+  for (const pluginId in plugins) {
+    allPlugins[pluginId] = plugins[pluginId]
   }
 
   // Update already-booted contexts:
@@ -60,13 +60,13 @@ export function watchPlugins(
   const pluginsAdded = plugins => {
     const out: EdgePluginMap<EdgeCorePlugin> = {}
 
-    for (const pluginName in plugins) {
-      const plugin = plugins[pluginName]
-      const initOptions = pluginsInit[pluginName]
+    for (const pluginId in plugins) {
+      const plugin = plugins[pluginId]
+      const initOptions = pluginsInit[pluginId]
       if (!initOptions) continue
 
       // Figure out what kind of object this is:
-      const log = makeLog(io, pluginName)
+      const log = makeLog(io, pluginId)
       try {
         if (typeof plugin === 'function') {
           const opts: EdgeCorePluginOptions = {
@@ -74,11 +74,11 @@ export function watchPlugins(
             io,
             log,
             nativeIo,
-            pluginDisklet: navigateDisklet(io.disklet, 'plugins/' + pluginName)
+            pluginDisklet: navigateDisklet(io.disklet, 'plugins/' + pluginId)
           }
-          out[pluginName] = plugin(opts)
+          out[pluginId] = plugin(opts)
         } else if (typeof plugin === 'object' && plugin != null) {
-          out[pluginName] = plugin
+          out[pluginId] = plugin
         } else {
           throw new TypeError(
             `Plugins must be functions or objects, got ${typeof plugin}`

--- a/src/core/plugins/plugins-reducer.js
+++ b/src/core/plugins/plugins-reducer.js
@@ -42,14 +42,14 @@ export const plugins = (
         rate: { ...state.rate },
         swap: { ...state.swap }
       }
-      for (const pluginName in action.payload) {
-        const plugin = action.payload[pluginName]
+      for (const pluginId in action.payload) {
+        const plugin = action.payload[pluginId]
         // $FlowFixMe - Flow doesn't see the type refinement here:
-        if (plugin.currencyInfo != null) out.currency[pluginName] = plugin
+        if (plugin.currencyInfo != null) out.currency[pluginId] = plugin
         // $FlowFixMe
-        if (plugin.rateInfo != null) out.rate[pluginName] = plugin
+        if (plugin.rateInfo != null) out.rate[pluginId] = plugin
         // $FlowFixMe
-        if (plugin.swapInfo != null) out.swap[pluginName] = plugin
+        if (plugin.swapInfo != null) out.swap[pluginId] = plugin
       }
       return out
     }
@@ -57,7 +57,7 @@ export const plugins = (
       return { ...state, locked: true }
     case 'CURRENCY_TOOLS_LOADED': {
       const currencyTools = { ...state.currencyTools }
-      currencyTools[action.payload.pluginName] = action.payload.tools
+      currencyTools[action.payload.pluginId] = action.payload.tools
       return { ...state, currencyTools }
     }
     case 'INIT':

--- a/src/core/plugins/plugins-selectors.js
+++ b/src/core/plugins/plugins-selectors.js
@@ -15,9 +15,9 @@ export function findCurrencyPlugin(
   plugins: EdgePluginMap<EdgeCurrencyPlugin>,
   walletType: string
 ): string | void {
-  for (const pluginName in plugins) {
-    const { currencyInfo } = plugins[pluginName]
-    if (walletType === currencyInfo.walletType) return pluginName
+  for (const pluginId in plugins) {
+    const { currencyInfo } = plugins[pluginId]
+    if (walletType === currencyInfo.walletType) return pluginId
   }
 }
 
@@ -28,13 +28,13 @@ export function getCurrencyPlugin(
   state: RootState,
   walletType: string
 ): EdgeCurrencyPlugin {
-  const pluginName = findCurrencyPlugin(state.plugins.currency, walletType)
-  if (pluginName == null) {
+  const pluginId = findCurrencyPlugin(state.plugins.currency, walletType)
+  if (pluginId == null) {
     throw new Error(
       `Cannot find a currency plugin for wallet type ${walletType}`
     )
   }
-  return state.plugins.currency[pluginName]
+  return state.plugins.currency[pluginId]
 }
 
 /**
@@ -47,15 +47,15 @@ export function getCurrencyTools(
 ): Promise<EdgeCurrencyTools> {
   const { dispatch, state } = ai.props
 
-  const pluginName = findCurrencyPlugin(state.plugins.currency, walletType)
-  if (pluginName == null) {
+  const pluginId = findCurrencyPlugin(state.plugins.currency, walletType)
+  if (pluginId == null) {
     throw new Error(
       `Cannot find a currency plugin for wallet type ${walletType}`
     )
   }
 
   // Already loaded / loading:
-  const tools = state.plugins.currencyTools[pluginName]
+  const tools = state.plugins.currencyTools[pluginId]
   if (tools != null) return tools
 
   // Never touched, so start the load:
@@ -63,7 +63,7 @@ export function getCurrencyTools(
   const promise = plugin.makeCurrencyTools()
   dispatch({
     type: 'CURRENCY_TOOLS_LOADED',
-    payload: { pluginName, tools: promise }
+    payload: { pluginId, tools: promise }
   })
   return promise
 }
@@ -78,14 +78,14 @@ export function waitForPlugins(ai: ApiInput) {
     if (!locked) return
 
     const missingPlugins: string[] = []
-    for (const pluginName in init) {
+    for (const pluginId in init) {
       if (
-        !!init[pluginName] &&
-        props.state.plugins.currency[pluginName] == null &&
-        props.state.plugins.rate[pluginName] == null &&
-        props.state.plugins.swap[pluginName] == null
+        !!init[pluginId] &&
+        props.state.plugins.currency[pluginId] == null &&
+        props.state.plugins.rate[pluginId] == null &&
+        props.state.plugins.swap[pluginId] == null
       ) {
-        missingPlugins.push(pluginName)
+        missingPlugins.push(pluginId)
       }
     }
     if (missingPlugins.length > 0) {

--- a/src/core/swap/swap-api.js
+++ b/src/core/swap/swap-api.js
@@ -28,9 +28,11 @@ export async function fetchSwapQuote(
   const swapPlugins = ai.props.state.plugins.swap
 
   const promises: Promise<EdgeSwapPluginQuote>[] = []
-  for (const n in swapPlugins) {
-    if (swapPluginEnabled(swapSettings, n)) {
-      promises.push(swapPlugins[n].fetchSwapQuote(request, userSettings[n]))
+  for (const pluginId in swapPlugins) {
+    if (swapPluginEnabled(swapSettings[pluginId])) {
+      promises.push(
+        swapPlugins[pluginId].fetchSwapQuote(request, userSettings[pluginId])
+      )
     }
   }
 
@@ -52,7 +54,8 @@ export async function fetchSwapQuote(
       }
 
       // Cobble together a URI:
-      const { swapInfo } = swapPlugins[bestQuote.pluginName]
+      const { pluginId = bestQuote.pluginName } = bestQuote
+      const { swapInfo } = swapPlugins[pluginId]
       let quoteUri
       if (bestQuote.quoteId != null && swapInfo.quoteUri != null) {
         quoteUri = swapInfo.quoteUri + bestQuote.quoteId
@@ -60,7 +63,12 @@ export async function fetchSwapQuote(
 
       const { isEstimate = true } = bestQuote
       // $FlowFixMe - Flow wrongly thinks isEstimate might be undefined here:
-      const out: EdgeSwapQuote = { ...bestQuote, quoteUri, isEstimate }
+      const out: EdgeSwapQuote = {
+        ...bestQuote,
+        isEstimate,
+        pluginId,
+        quoteUri
+      }
       bridgifyObject(out)
 
       return out

--- a/src/types/error.js
+++ b/src/types/error.js
@@ -207,12 +207,14 @@ export class SameCurrencyError extends Error {
  */
 export class SwapAboveLimitError extends Error {
   name: string
-  +pluginName: string
+  +pluginId: string
+  +pluginName: string // Deprecated for pluginId
   +nativeMax: string
 
   constructor(swapInfo: EdgeSwapInfo, nativeMax: string) {
     super('Amount is too high')
     this.name = errorNames.SwapAboveLimitError
+    this.pluginId = swapInfo.pluginName
     this.pluginName = swapInfo.pluginName
     this.nativeMax = nativeMax
   }
@@ -224,12 +226,14 @@ export class SwapAboveLimitError extends Error {
  */
 export class SwapBelowLimitError extends Error {
   name: string
-  +pluginName: string
+  +pluginId: string
+  +pluginName: string // Deprecated for pluginId
   +nativeMin: string
 
   constructor(swapInfo: EdgeSwapInfo, nativeMin: string) {
     super('Amount is too low')
     this.name = errorNames.SwapBelowLimitError
+    this.pluginId = swapInfo.pluginName
     this.pluginName = swapInfo.pluginName
     this.nativeMin = nativeMin
   }
@@ -240,7 +244,8 @@ export class SwapBelowLimitError extends Error {
  */
 export class SwapCurrencyError extends Error {
   name: string
-  +pluginName: string
+  +pluginId: string
+  +pluginName: string // Deprecated for pluginId
   +fromCurrency: string
   +toCurrency: string
 
@@ -253,6 +258,7 @@ export class SwapCurrencyError extends Error {
       `${swapInfo.displayName} does not support ${fromCurrency} to ${toCurrency}`
     )
     this.name = errorNames.SwapCurrencyError
+    this.pluginId = swapInfo.pluginName
     this.pluginName = swapInfo.pluginName
     this.fromCurrency = fromCurrency
     this.toCurrency = toCurrency
@@ -274,13 +280,15 @@ type SwapPermissionReason =
  */
 export class SwapPermissionError extends Error {
   name: string
-  +pluginName: string
+  +pluginId: string
+  +pluginName: string // Deprecated for pluginId
   +reason: SwapPermissionReason | void
 
   constructor(swapInfo: EdgeSwapInfo, reason?: SwapPermissionReason) {
     if (reason != null) super(reason)
     else super('You are not allowed to make this trade')
     this.name = errorNames.SwapPermissionError
+    this.pluginId = swapInfo.pluginName
     this.pluginName = swapInfo.pluginName
     this.reason = reason
   }

--- a/src/types/error.js
+++ b/src/types/error.js
@@ -51,7 +51,7 @@ export class DustSpendError extends Error {
  */
 export class InsufficientFundsError extends Error {
   name: string
-  currencyCode: string | void
+  +currencyCode: string | void
 
   constructor(currencyCode?: string) {
     let message
@@ -100,7 +100,7 @@ export class NoAmountSpecifiedError extends Error {
  */
 export class NetworkError extends Error {
   name: string
-  type: string // deprecated
+  +type: string // deprecated
 
   constructor(message: string = 'Cannot reach the network') {
     super(message)
@@ -113,7 +113,7 @@ export class NetworkError extends Error {
  */
 export class ObsoleteApiError extends Error {
   name: string
-  type: string // deprecated
+  +type: string // deprecated
 
   constructor(message: string = 'The application is too old. Please upgrade.') {
     super(message)
@@ -133,9 +133,9 @@ export class ObsoleteApiError extends Error {
  */
 export class OtpError extends Error {
   name: string
-  type: string // deprecated
-  resetToken: string | void
-  resetDate: Date | void
+  +type: string // deprecated
+  +resetToken: string | void
+  +resetDate: Date | void
 
   constructor(resultsJson: any, message: string = 'Invalid OTP token') {
     super(message)
@@ -165,8 +165,8 @@ export class OtpError extends Error {
  */
 export class PasswordError extends Error {
   name: string
-  type: string // deprecated
-  wait: number | void // seconds
+  +type: string // deprecated
+  +wait: number | void // seconds
 
   constructor(resultsJson: any, message: string = 'Invalid password') {
     super(message)
@@ -207,8 +207,8 @@ export class SameCurrencyError extends Error {
  */
 export class SwapAboveLimitError extends Error {
   name: string
-  pluginName: string
-  nativeMax: string
+  +pluginName: string
+  +nativeMax: string
 
   constructor(swapInfo: EdgeSwapInfo, nativeMax: string) {
     super('Amount is too high')
@@ -224,8 +224,8 @@ export class SwapAboveLimitError extends Error {
  */
 export class SwapBelowLimitError extends Error {
   name: string
-  pluginName: string
-  nativeMin: string
+  +pluginName: string
+  +nativeMin: string
 
   constructor(swapInfo: EdgeSwapInfo, nativeMin: string) {
     super('Amount is too low')
@@ -240,9 +240,9 @@ export class SwapBelowLimitError extends Error {
  */
 export class SwapCurrencyError extends Error {
   name: string
-  pluginName: string
-  fromCurrency: string
-  toCurrency: string
+  +pluginName: string
+  +fromCurrency: string
+  +toCurrency: string
 
   constructor(
     swapInfo: EdgeSwapInfo,
@@ -274,8 +274,8 @@ type SwapPermissionReason =
  */
 export class SwapPermissionError extends Error {
   name: string
-  pluginName: string
-  reason: SwapPermissionReason | void
+  +pluginName: string
+  +reason: SwapPermissionReason | void
 
   constructor(swapInfo: EdgeSwapInfo, reason?: SwapPermissionReason) {
     if (reason != null) super(reason)
@@ -296,7 +296,7 @@ export class SwapPermissionError extends Error {
  */
 export class UsernameError extends Error {
   name: string
-  type: string // deprecated
+  +type: string // deprecated
 
   constructor(message: string = 'Invalid username') {
     super(message)

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -38,7 +38,7 @@ export type EdgeOtherMethods = {
 
 /** We frequently index things by pluginId, so provide a helper. */
 export type EdgePluginMap<Value> = {
-  [pluginName: string]: Value
+  [pluginId: string]: Value
 }
 
 // ---------------------------------------------------------------------
@@ -229,7 +229,8 @@ type EdgeObjectTemplate = Array<
 export type EdgeCurrencyInfo = {
   // Basic currency information:
   displayName: string,
-  pluginName: string,
+  +pluginId?: string, // Mandatory in next breaking version
+  pluginName: string, // Deprecated for pluginId
   walletType: string,
 
   // Native token information:
@@ -621,7 +622,8 @@ export type EdgeCurrencyWallet = {
 
 export type EdgeSwapInfo = {
   +displayName: string,
-  +pluginName: string,
+  +pluginId?: string, // Mandatory in next breaking version
+  +pluginName: string, // Deprecated for pluginId
 
   +quoteUri?: string, // The quoteId would be appended to this
   +supportEmail: string
@@ -648,7 +650,8 @@ export type EdgeSwapPluginQuote = {
   +networkFee: EdgeNetworkFee,
   +destinationAddress: string,
 
-  +pluginName: string,
+  +pluginId?: string, // Mandatory in next breaking version
+  +pluginName: string, // Deprecated for pluginId
   +expirationDate?: Date,
   +quoteId?: string,
 
@@ -680,7 +683,8 @@ export type EdgeRateHint = {
 }
 
 export type EdgeRateInfo = {
-  +displayName: string
+  +displayName: string,
+  +pluginId?: string // Mandatory in next breaking version
 }
 
 export type EdgeRatePair = {
@@ -780,6 +784,7 @@ export type EdgeSwapConfig = {
 
 export type EdgeSwapQuote = EdgeSwapPluginQuote & {
   +isEstimate: boolean, // No longer optional at this point
+  +pluginId: string,
   +quoteUri?: string
 }
 

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -788,6 +788,10 @@ export type EdgeSwapQuote = EdgeSwapPluginQuote & {
   +quoteUri?: string
 }
 
+export type EdgeSwapRequestOptions = {
+  preferPluginId?: string
+}
+
 // edge login ----------------------------------------------------------
 
 export type EdgeLoginRequest = {
@@ -913,7 +917,10 @@ export type EdgeAccount = {
   ): Promise<string>,
 
   // Swapping:
-  fetchSwapQuote(request: EdgeSwapRequest): Promise<EdgeSwapQuote>,
+  fetchSwapQuote(
+    request: EdgeSwapRequest,
+    opts?: EdgeSwapRequestOptions
+  ): Promise<EdgeSwapQuote>,
 
   // Deprecated names:
   // eslint-disable-next-line no-use-before-define

--- a/src/util/promise.js
+++ b/src/util/promise.js
@@ -36,8 +36,8 @@ export function timeout<T>(
 /**
  * Waits for a collection of promises.
  * Returns all the promises that manage to resolve within the timeout.
- * If no promises mange to resolve within the timeout, returns the
- * first promise that resolves.
+ * If no promises mange to resolve within the timeout,
+ * returns the first promise that resolves.
  * If all promises reject, rejects an array of errors.
  */
 export function fuzzyTimeout<T>(

--- a/test/fake/fake-currency-plugin.js
+++ b/test/fake/fake-currency-plugin.js
@@ -27,6 +27,7 @@ export const fakeCurrencyInfo: EdgeCurrencyInfo = {
   // Basic currency information:
   currencyCode: 'FAKE',
   displayName: 'Fake Coin',
+  pluginId: 'fakecoin',
   pluginName: 'fakecoin',
   denominations: [
     { multiplier: '10', name: 'SMALL' },

--- a/test/fake/fake-swap-plugin.js
+++ b/test/fake/fake-swap-plugin.js
@@ -13,6 +13,7 @@ import {
 
 const swapInfo: EdgeSwapInfo = {
   displayName: 'Fake Swapper',
+  pluginId: 'fakeswap',
   pluginName: 'fakeswap',
 
   supportEmail: 'support@fakeswap'


### PR DESCRIPTION
This lets us have preferred swap providers.

Also, we've been talking about `pluginId` in our designs for the feature, but the core has been using `pluginName`, which is confusing, and has lead to problems like people trying to show the `pluginName` to the user. Using the "id" terminology should help put a stop to that.