### PR TITLE
Add special metadata for swaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "aes-js": "^3.1.0",
     "base-x": "^1.0.4",
     "biggystring": "^3.0.2",
+    "cleaners": "^0.2.0",
     "currency-codes": "^1.1.2",
     "disklet": "^0.4.4",
     "elliptic": "^6.4.0",

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -6,6 +6,7 @@ import {
   type EdgeCurrencyTools,
   type EdgePluginMap,
   type EdgeTokenInfo,
+  type EdgeTransaction,
   type EdgeWalletInfo,
   type EdgeWalletStates,
   type JsonObject
@@ -13,7 +14,8 @@ import {
 import { type SwapSettings } from './account/account-reducer.js'
 import {
   type TxFileJsons,
-  type TxFileNames
+  type TxFileNames,
+  type TxidHashes
 } from './currency/wallet/currency-wallet-reducer.js'
 import { type ExchangePair } from './exchange/exchange-reducer.js'
 import { type LoginStash } from './login/login-types.js'
@@ -131,9 +133,9 @@ export type RootAction =
       // Called when a currency engine fires the onTransactionsChanged callback.
       type: 'CURRENCY_ENGINE_CHANGED_TXS',
       payload: {
-        txs: any[],
+        txs: EdgeTransaction[],
         walletId: string,
-        txidHashes: any
+        txidHashes: TxidHashes
       }
     }
   | {

--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -455,6 +455,7 @@ export function makeCurrencyWalletApi(
 
     async saveTx(tx: EdgeTransaction): Promise<void> {
       await engine.saveTx(tx)
+      fakeCallbacks.onTransactionsChanged([tx])
     },
 
     async resyncBlockchain(): Promise<void> {

--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -517,7 +517,7 @@ function fixMetadata(metadata: EdgeMetadata, fiat: string) {
 export function combineTxWithFile(
   input: CurrencyWalletInput,
   tx: MergedTransaction,
-  file: TransactionFile,
+  file: TransactionFile | void,
   currencyCode: string
 ): EdgeTransaction {
   const wallet = input.props.selfOutput.api

--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -390,6 +390,7 @@ export function makeCurrencyWalletApi(
       } = spendInfo
 
       const cleanTargets: EdgeSpendTarget[] = []
+      const savedTargets = []
       for (const target of spendTargets) {
         const { publicAddress, nativeAmount = '0', otherParams = {} } = target
         if (publicAddress == null) continue
@@ -414,6 +415,12 @@ export function makeCurrencyWalletApi(
           uniqueIdentifier,
           otherParams
         })
+        savedTargets.push({
+          currencyCode,
+          publicAddress,
+          nativeAmount,
+          uniqueIdentifier
+        })
       }
 
       if (cleanTargets.length === 0) {
@@ -432,6 +439,7 @@ export function makeCurrencyWalletApi(
         metadata,
         otherParams
       })
+      tx.spendTargets = savedTargets
       if (metadata != null) tx.metadata = metadata
       return tx
     },
@@ -599,6 +607,15 @@ export function combineTxWithFile(
         ...out.metadata,
         ...unpackMetadata(merged.metadata, walletFiat)
       }
+    }
+
+    if (file.payees != null) {
+      out.spendTargets = file.payees.map(payee => ({
+        currencyCode: payee.currency,
+        nativeAmount: payee.amount,
+        publicAddress: payee.address,
+        uniqueIdentifier: payee.tag
+      }))
     }
   }
 

--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -391,9 +391,29 @@ export function makeCurrencyWalletApi(
 
       const cleanTargets: EdgeSpendTarget[] = []
       for (const target of spendTargets) {
-        const { publicAddress, nativeAmount = '0', otherParams } = target
+        const { publicAddress, nativeAmount = '0', otherParams = {} } = target
         if (publicAddress == null) continue
-        cleanTargets.push({ publicAddress, nativeAmount, otherParams })
+
+        // Handle legacy spenders:
+        let { uniqueIdentifier } = target
+        if (
+          uniqueIdentifier == null &&
+          typeof otherParams.uniqueIdentifier === 'string'
+        ) {
+          uniqueIdentifier = otherParams.uniqueIdentifier
+        }
+
+        // Support legacy currency plugins:
+        if (uniqueIdentifier != null) {
+          otherParams.uniqueIdentifier = uniqueIdentifier
+        }
+
+        cleanTargets.push({
+          publicAddress,
+          nativeAmount,
+          uniqueIdentifier,
+          otherParams
+        })
       }
 
       if (cleanTargets.length === 0) {

--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -32,7 +32,11 @@ import { type ApiInput } from '../../root-pixie.js'
 import { makeStorageWalletApi } from '../../storage/storage-api.js'
 import { getCurrencyMultiplier } from '../currency-selectors.js'
 import { makeCurrencyWalletCallbacks } from './currency-wallet-callbacks.js'
-import { packMetadata, unpackMetadata } from './currency-wallet-cleaners.js'
+import {
+  asTxSwap,
+  packMetadata,
+  unpackMetadata
+} from './currency-wallet-cleaners.js'
 import {
   exportTransactionsToCSVInner,
   exportTransactionsToQBOInner
@@ -386,6 +390,7 @@ export function makeCurrencyWalletApi(
         networkFeeOption = 'standard',
         customNetworkFee,
         metadata,
+        swapData,
         otherParams
       } = spendInfo
 
@@ -441,6 +446,7 @@ export function makeCurrencyWalletApi(
       })
       tx.spendTargets = savedTargets
       if (metadata != null) tx.metadata = metadata
+      if (swapData != null) tx.swapData = asTxSwap(swapData)
       return tx
     },
 
@@ -617,6 +623,8 @@ export function combineTxWithFile(
         uniqueIdentifier: payee.tag
       }))
     }
+
+    if (file.swap != null) out.swapData = asTxSwap(file.swap)
   }
 
   return out

--- a/src/core/currency/wallet/currency-wallet-cleaners.js
+++ b/src/core/currency/wallet/currency-wallet-cleaners.js
@@ -1,0 +1,68 @@
+// @flow
+
+import {
+  type Cleaner,
+  asMap,
+  asNumber,
+  asObject,
+  asOptional,
+  asString
+} from 'cleaners'
+
+import { type EdgeMetadata } from '../../../types/types.js'
+
+/**
+ * The on-disk metadata format,
+ * which has a mandatory `exchangeAmount` table and no `amountFiat`.
+ */
+export type DiskMetadata = {
+  bizId?: number,
+  category?: string,
+  exchangeAmount: { [fiatCurrencyCode: string]: number },
+  name?: string,
+  notes?: string
+}
+
+/**
+ * Turns user-provided metadata into its on-disk format.
+ */
+export function packMetadata(
+  raw: EdgeMetadata,
+  walletFiat: string
+): DiskMetadata {
+  const clean = asDiskMetadata(raw)
+
+  if (typeof raw.amountFiat === 'number') {
+    clean.exchangeAmount[walletFiat] = raw.amountFiat
+  }
+
+  return clean
+}
+
+/**
+ * Turns on-disk metadata into the user-facing format.
+ */
+export function unpackMetadata(
+  raw: DiskMetadata,
+  walletFiat: string
+): EdgeMetadata {
+  const clean = asDiskMetadata(raw)
+  const { exchangeAmount } = clean
+
+  // Delete corrupt amounts that exceed the Javascript number range:
+  for (const currency of Object.keys(exchangeAmount)) {
+    if (/e/.test(String(exchangeAmount[currency]))) {
+      delete exchangeAmount[currency]
+    }
+  }
+
+  return { ...clean, amountFiat: exchangeAmount[walletFiat] }
+}
+
+const asDiskMetadata: Cleaner<DiskMetadata> = asObject({
+  bizId: asOptional(asNumber),
+  category: asOptional(asString),
+  exchangeAmount: asOptional(asMap(asNumber), {}),
+  name: asOptional(asString),
+  notes: asOptional(asString)
+})

--- a/src/core/currency/wallet/currency-wallet-cleaners.js
+++ b/src/core/currency/wallet/currency-wallet-cleaners.js
@@ -2,6 +2,7 @@
 
 import {
   type Cleaner,
+  asBoolean,
   asMap,
   asNumber,
   asObject,
@@ -9,7 +10,7 @@ import {
   asString
 } from 'cleaners'
 
-import { type EdgeMetadata } from '../../../types/types.js'
+import { type EdgeMetadata, type EdgeTxSwap } from '../../../types/types.js'
 
 /**
  * The on-disk metadata format,
@@ -58,6 +59,26 @@ export function unpackMetadata(
 
   return { ...clean, amountFiat: exchangeAmount[walletFiat] }
 }
+
+export const asTxSwap: Cleaner<EdgeTxSwap> = asObject({
+  orderId: asOptional(asString),
+  orderUri: asOptional(asString),
+  isEstimate: asBoolean,
+
+  // The EdgeSwapInfo from the swap plugin:
+  plugin: asObject({
+    pluginId: asString,
+    displayName: asString,
+    supportEmail: asOptional(asString)
+  }),
+
+  // Address information:
+  payoutAddress: asString,
+  payoutCurrencyCode: asString,
+  payoutNativeAmount: asString,
+  payoutWalletId: asString,
+  refundAddress: asOptional(asString)
+})
 
 const asDiskMetadata: Cleaner<DiskMetadata> = asObject({
   bizId: asOptional(asNumber),

--- a/src/core/currency/wallet/currency-wallet-files.js
+++ b/src/core/currency/wallet/currency-wallet-files.js
@@ -3,10 +3,7 @@
 import { number as currencyFromNumber } from 'currency-codes'
 import { type DiskletFile, type DiskletFolder, mapFiles } from 'disklet'
 
-import {
-  type EdgeCurrencyEngineCallbacks,
-  type EdgeMetadata
-} from '../../../types/types.js'
+import { type EdgeCurrencyEngineCallbacks } from '../../../types/types.js'
 import { mergeDeeply } from '../../../util/util.js'
 import { fetchAppIdInfo } from '../../account/lobby-api.js'
 import { getExchangeRate } from '../../exchange/exchange-selectors.js'
@@ -19,6 +16,7 @@ import {
 } from '../../storage/storage-selectors.js'
 import { getCurrencyMultiplier } from '../currency-selectors.js'
 import { combineTxWithFile } from './currency-wallet-api.js'
+import { type DiskMetadata } from './currency-wallet-cleaners.js'
 import { type CurrencyWalletInput } from './currency-wallet-pixie.js'
 import {
   type MergedTransaction,
@@ -35,13 +33,7 @@ export type TransactionFile = {
   creationDate: number,
   currencies: {
     [currencyCode: string]: {
-      metadata: {
-        bizId?: number,
-        category?: string,
-        exchangeAmount?: { [fiatCurrencyCode: string]: number },
-        name?: string,
-        notes?: string
-      },
+      metadata: DiskMetadata,
       nativeAmount?: string,
       providerFeeSent?: string
     }
@@ -457,7 +449,7 @@ export function setCurrencyWalletTxMetadata(
   input: CurrencyWalletInput,
   txid: string,
   currencyCode: string,
-  metadata: EdgeMetadata,
+  metadata: DiskMetadata,
   fakeCallbacks: EdgeCurrencyEngineCallbacks
 ): Promise<void> {
   const walletId = input.props.id
@@ -555,7 +547,7 @@ export function setupNewTxMetadata(
       )
     const nativeAmount = tx.nativeAmount[currency]
 
-    const metadata = { exchangeAmount: {} }
+    const metadata: DiskMetadata = { exchangeAmount: {} }
     metadata.exchangeAmount[fiatCurrency] = rate * Number(nativeAmount)
     json.currencies[currency] = { metadata, nativeAmount }
   }

--- a/src/core/currency/wallet/currency-wallet-files.js
+++ b/src/core/currency/wallet/currency-wallet-files.js
@@ -19,7 +19,7 @@ import {
 } from '../../storage/storage-selectors.js'
 import { getCurrencyMultiplier } from '../currency-selectors.js'
 import { combineTxWithFile } from './currency-wallet-api.js'
-import { type DiskMetadata } from './currency-wallet-cleaners.js'
+import { type DiskMetadata, packMetadata } from './currency-wallet-cleaners.js'
 import { type CurrencyWalletInput } from './currency-wallet-pixie.js'
 import { type TxFileNames } from './currency-wallet-reducer.js'
 
@@ -532,7 +532,10 @@ export function setupNewTxMetadata(
   const exchangeAmount = rate * Number(nativeAmount)
 
   // Set up metadata:
-  const metadata: DiskMetadata = { exchangeAmount: {} }
+  const metadata: DiskMetadata =
+    tx.metadata != null
+      ? packMetadata(tx.metadata, fiat)
+      : { exchangeAmount: {} }
   metadata.exchangeAmount[fiat] = exchangeAmount
 
   // Basic file template:

--- a/src/core/currency/wallet/currency-wallet-files.js
+++ b/src/core/currency/wallet/currency-wallet-files.js
@@ -5,7 +5,8 @@ import { type DiskletFile, type DiskletFolder, mapFiles } from 'disklet'
 
 import {
   type EdgeCurrencyEngineCallbacks,
-  type EdgeTransaction
+  type EdgeTransaction,
+  type EdgeTxSwap
 } from '../../../types/types.js'
 import { mergeDeeply } from '../../../util/util.js'
 import { fetchAppIdInfo } from '../../account/lobby-api.js'
@@ -43,7 +44,8 @@ export type TransactionFile = {
     amount: string,
     currency: string,
     tag?: string
-  }>
+  }>,
+  swap?: EdgeTxSwap
 }
 
 export type LegacyTransactionFile = {
@@ -520,7 +522,7 @@ export function setupNewTxMetadata(
 ): Promise<void> {
   const { dispatch, selfState, state, id: walletId } = input.props
   const { currencyInfo, fiat = 'iso:USD' } = selfState
-  const { currencyCode, spendTargets, txid } = tx
+  const { currencyCode, spendTargets, swapData, txid } = tx
 
   const creationDate = Date.now() / 1000
 
@@ -549,7 +551,8 @@ export function setupNewTxMetadata(
     txid,
     internal: true,
     creationDate,
-    currencies: {}
+    currencies: {},
+    swap: swapData
   }
   json.currencies[currencyCode] = { metadata, nativeAmount }
 

--- a/src/core/currency/wallet/currency-wallet-files.js
+++ b/src/core/currency/wallet/currency-wallet-files.js
@@ -37,7 +37,13 @@ export type TransactionFile = {
       nativeAmount?: string,
       providerFeeSent?: string
     }
-  }
+  },
+  payees?: Array<{
+    address: string,
+    amount: string,
+    currency: string,
+    tag?: string
+  }>
 }
 
 export type LegacyTransactionFile = {
@@ -514,7 +520,7 @@ export function setupNewTxMetadata(
 ): Promise<void> {
   const { dispatch, selfState, state, id: walletId } = input.props
   const { currencyInfo, fiat = 'iso:USD' } = selfState
-  const { currencyCode, txid } = tx
+  const { currencyCode, spendTargets, txid } = tx
 
   const creationDate = Date.now() / 1000
 
@@ -546,6 +552,16 @@ export function setupNewTxMetadata(
     currencies: {}
   }
   json.currencies[currencyCode] = { metadata, nativeAmount }
+
+  // Set up payees:
+  if (spendTargets != null) {
+    json.payees = spendTargets.map(target => ({
+      currency: target.currencyCode,
+      address: target.publicAddress,
+      amount: target.nativeAmount,
+      tag: target.uniqueIdentifier
+    }))
+  }
 
   // Save the new file:
   const { diskletFile, fileName, txidHash } = getTxFile(

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -306,6 +306,7 @@ export type EdgeTransaction = {
 export type EdgeSpendTarget = {
   nativeAmount?: string,
   publicAddress?: string,
+  uniqueIdentifier?: string,
   otherParams?: JsonObject
 }
 

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -279,6 +279,26 @@ export type EdgeNetworkFee = {
   +nativeAmount: string
 }
 
+export type EdgeTxSwap = {
+  orderId?: string,
+  orderUri?: string,
+  isEstimate: boolean,
+
+  // The EdgeSwapInfo from the swap plugin:
+  plugin: {
+    pluginId: string,
+    displayName: string,
+    supportEmail?: string
+  },
+
+  // Address information:
+  payoutAddress: string,
+  payoutCurrencyCode: string,
+  payoutNativeAmount: string,
+  payoutWalletId: string,
+  refundAddress?: string
+}
+
 export type EdgeTransaction = {
   // Amounts:
   currencyCode: string,
@@ -305,6 +325,7 @@ export type EdgeTransaction = {
     +publicAddress: string,
     +uniqueIdentifier?: string
   }>,
+  swapData?: EdgeTxSwap,
   wallet?: EdgeCurrencyWallet, // eslint-disable-line no-use-before-define
   otherParams?: JsonObject
 }
@@ -337,6 +358,7 @@ export type EdgeSpendInfo = {
 
   // Core:
   metadata?: EdgeMetadata,
+  swapData?: EdgeTxSwap,
   otherParams?: JsonObject
 }
 

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -260,11 +260,17 @@ export type EdgeCurrencyInfo = {
 // spending ------------------------------------------------------------
 
 export type EdgeMetadata = {
-  name?: string,
-  category?: string,
-  notes?: string,
-  amountFiat?: number,
   bizId?: number,
+  category?: string,
+  exchangeAmount?: { [fiatCurrencyCode: string]: number },
+  name?: string,
+  notes?: string,
+
+  // Deprecated. Use exchangeAmount instead:
+  amountFiat?: number,
+
+  // Deprecated. The core has never actually written this to disk,
+  // but deleting this type definition would break the GUI:
   miscJson?: string
 }
 

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -299,6 +299,12 @@ export type EdgeTransaction = {
 
   // Core:
   metadata?: EdgeMetadata,
+  spendTargets?: Array<{
+    +currencyCode: string,
+    +nativeAmount: string,
+    +publicAddress: string,
+    +uniqueIdentifier?: string
+  }>,
   wallet?: EdgeCurrencyWallet, // eslint-disable-line no-use-before-define
   otherParams?: JsonObject
 }

--- a/test/core/currency/wallet/currency-wallet.test.js
+++ b/test/core/currency/wallet/currency-wallet.test.js
@@ -245,6 +245,14 @@ describe('currency wallets', function () {
       amountFiat: 1.5,
       ...metadata
     })
+    expect(txs[0].spendTargets).deep.equals([
+      {
+        currencyCode: 'FAKE',
+        nativeAmount: '50',
+        publicAddress: 'somewhere',
+        uniqueIdentifier: undefined
+      }
+    ])
   })
 
   it('can update metadata', async function () {

--- a/test/core/currency/wallet/currency-wallet.test.js
+++ b/test/core/currency/wallet/currency-wallet.test.js
@@ -9,6 +9,7 @@ import {
   type EdgeCurrencyConfig,
   type EdgeCurrencyWallet,
   type EdgeMetadata,
+  type EdgeTxSwap,
   makeFakeEdgeWorld
 } from '../../../../src/index.js'
 import { expectRejection } from '../../../expect-rejection.js'
@@ -219,6 +220,19 @@ describe('currency wallets', function () {
     })
 
     const metadata: EdgeMetadata = { name: 'me' }
+    const swapData: EdgeTxSwap = {
+      orderId: '1234',
+      isEstimate: true,
+      plugin: {
+        pluginId: 'fakeswap',
+        displayName: 'Fake Swap',
+        supportEmail: undefined
+      },
+      payoutAddress: 'get it here',
+      payoutCurrencyCode: 'TOKEN',
+      payoutNativeAmount: '1',
+      payoutWalletId: wallet.id
+    }
     let tx = await wallet.makeSpend({
       currencyCode: 'FAKE',
       spendTargets: [
@@ -227,7 +241,8 @@ describe('currency wallets', function () {
           publicAddress: 'somewhere'
         }
       ],
-      metadata
+      metadata,
+      swapData
     })
     tx = await wallet.signTx(tx)
     await wallet.broadcastTx(tx)
@@ -253,6 +268,11 @@ describe('currency wallets', function () {
         uniqueIdentifier: undefined
       }
     ])
+    expect(txs[0].swapData).deep.equals({
+      orderUri: undefined,
+      refundAddress: undefined,
+      ...swapData
+    })
   })
 
   it('can update metadata', async function () {

--- a/test/core/currency/wallet/currency-wallet.test.js
+++ b/test/core/currency/wallet/currency-wallet.test.js
@@ -173,13 +173,23 @@ describe('currency wallets', function () {
 
     await wallet.makeSpend({
       currencyCode: 'FAKE',
-      spendTargets: [{ nativeAmount: maxSpendable }]
+      spendTargets: [
+        {
+          nativeAmount: maxSpendable,
+          publicAddress: 'somewhere'
+        }
+      ]
     })
 
     await expectRejection(
       wallet.makeSpend({
         currencyCode: 'FAKE',
-        spendTargets: [{ nativeAmount: add(maxSpendable, '1') }]
+        spendTargets: [
+          {
+            nativeAmount: add(maxSpendable, '1'),
+            publicAddress: 'somewhere'
+          }
+        ]
       }),
       'InsufficientFundsError: Insufficient funds'
     )

--- a/test/core/currency/wallet/currency-wallet.test.js
+++ b/test/core/currency/wallet/currency-wallet.test.js
@@ -8,6 +8,7 @@ import { describe, it } from 'mocha'
 import {
   type EdgeCurrencyConfig,
   type EdgeCurrencyWallet,
+  type EdgeMetadata,
   makeFakeEdgeWorld
 } from '../../../../src/index.js'
 import { expectRejection } from '../../../expect-rejection.js'
@@ -205,25 +206,66 @@ describe('currency wallets', function () {
     expect(await wallet.nativeToDenomination('10', 'TOKEN')).equals('0.01')
   })
 
-  // it('can have metadata', function () {
-  //   const store = makeFakeCurrencyStore()
-  //
-  //   return makeFakeCurrencyWallet(store).then(wallet => {
-  //     const tx = { txid: 'a', metadata: { name: 'me' } }
-  //     store.dispatch({
-  //       type: 'SET_TXS',
-  //       payload: [{ txid: 'a', nativeAmount: '25' }]
-  //     })
-  //     return wallet.saveTx(tx).then(() =>
-  //       wallet.getTransactions({}).then(txs => {
-  //         assert.equal(txs.length, 1)
-  //         assert.strictEqual(txs[0].metadata.name, tx.metadata.name)
-  //         assert.strictEqual(txs[0].metadata.amountFiat, 0.75)
-  //         assert.strictEqual(txs[0].amountSatoshi, 25)
-  //         assert.strictEqual(txs[0].nativeAmount, '25')
-  //         return null
-  //       })
-  //     )
-  //   })
-  // })
+  it('can save metadata at spend time', async function () {
+    const log = makeAssertLog()
+    const [wallet, config] = await makeFakeCurrencyWallet()
+    await config.changeUserSettings({ balance: 100 }) // Spending balance
+
+    // Subscribe to new transactions:
+    wallet.on('newTransactions', txs => {
+      const { txid, metadata = {} } = tx
+      const { name = '' } = metadata
+      log('new', txs.map(tx => `${txid} ${name}`).join(' '))
+    })
+
+    const metadata: EdgeMetadata = { name: 'me' }
+    let tx = await wallet.makeSpend({
+      currencyCode: 'FAKE',
+      spendTargets: [
+        {
+          nativeAmount: '50',
+          publicAddress: 'somewhere'
+        }
+      ],
+      metadata
+    })
+    tx = await wallet.signTx(tx)
+    await wallet.broadcastTx(tx)
+    await wallet.saveTx(tx)
+    await log.waitFor(1).assert('new spend me')
+
+    const txs = await wallet.getTransactions({})
+    expect(txs.length).equals(1)
+    expect(txs[0].nativeAmount).equals('50')
+    expect(txs[0].metadata).deep.equals({
+      bizId: undefined,
+      category: undefined,
+      notes: undefined,
+      exchangeAmount: { 'iso:USD': 1.5 },
+      amountFiat: 1.5,
+      ...metadata
+    })
+  })
+
+  it('can update metadata', async function () {
+    const [wallet, config] = await makeFakeCurrencyWallet()
+
+    const metadata: EdgeMetadata = {
+      name: 'me',
+      amountFiat: 0.75
+    }
+    await config.changeUserSettings({ txs: { a: { nativeAmount: '25' } } })
+    await wallet.saveTxMetadata('a', 'FAKE', metadata)
+
+    const txs = await wallet.getTransactions({})
+    expect(txs.length).equals(1)
+    expect(txs[0].nativeAmount).equals('25')
+    expect(txs[0].metadata).deep.equals({
+      bizId: undefined,
+      category: undefined,
+      notes: undefined,
+      exchangeAmount: { 'iso:USD': 0.75 },
+      ...metadata
+    })
+  })
 })

--- a/test/fake/fake-currency-plugin.js
+++ b/test/fake/fake-currency-plugin.js
@@ -260,7 +260,7 @@ class FakeCurrencyEngine {
       otherParams: {},
       ourReceiveAddresses: [],
       signedTx: '',
-      txid: ''
+      txid: 'spend'
     })
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1695,6 +1695,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+cleaners@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/cleaners/-/cleaners-0.2.0.tgz#b1a583878f4c217c8f0bd2e7756dca3eaca91003"
+  integrity sha512-UsCPC3eYtqBgk9kYSh8WbFoXbDD4lr9r7wz57MSsluMLFb78ws3ER6Bs2q+7iUmaeBiwZ/+S02FOQ5gEA2y4Sg==
+
 cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"


### PR DESCRIPTION
# Swap Metadata

Since the Airbitz days, the `EdgeMetatada` structure has only contained user-editable information. Things the user can't edit, like the first-seen date or partner revenue accounting, go directly into the transaction object, not `EdgeMetadata`. This is because we don't want the `saveTxMetadata` function to overwrite these fields.

So, the swap information needs to go somewhere on the transaction other than the `EdgeMetadata` structure. I propose creating a new data structure that exchanges pass as `EdgeSpendInfo.swapData`. The core saves this structure, and then puts it on the `EdgeTransaction` when available. When the transaction details scene sees that `edgeTransaction.swapData != null`, it can display the transaction as a swap and add the extra elements to the UI.

```typescript
type EdgeTxSwap = {
  orderId: string
  orderUri: string
  isEstimate: boolean

  // The EdgeSwapInfo from the swap provider:
  plugin: {
    pluginId: string
    displayName: string
    supportEmail?: string
  }

  // Address information:
  payoutAddress: string
  payoutCurrencyCode: string
  payoutNativeAmount: string
  payoutWalletId: string
  refundAddress: string
}
```

This structure does not contain the exchange receive address. This is relevant to all transactions, not just swaps. Whenever the user sends money, the core should save the `EdgeSpendTarget` fields as `EdgeTransaction.spendTargets`. This would help privacy coins like Monero remember basic information, it would help coins with change remember which addresses were the true destination, and it would help us debug things like the Tezos wrong addresses. The transaction details screen could display this for all transactions that have it, including swaps.

## Original specification

The original specification called for this information to live in `metadata.otherParams.exchange`, but metadata is the wrong location. The new locations is `EdgeTransaction.swapData` & `EdgeSpendInfo.swapData`, as explained above.

The metadata is supposed to contain a `status` property, but there is no information about how to keep this updated. Keeping a background process running to update the metadata seems inefficient. Instead, we could implement a `checkStatus(orderId: string)` method for the transaction details screen to call as needed.

The other fields in the specification have straightforward mappings to the new design:

- status -> `account.swapConfig[pluginId].checkStatus(orderId)`
- orderId -> `tx.swapData.orderId`
- statusUrl -> `tx.swapData.orderUri` (name used in EdgeSwapQuote)
- pluginId -> `tx.swapData.plugin.pluginId`
- supportEmail -> `tx.swapData.plugin.supportEmail`
- pluginName -> `tx.swapData.plugin.displayName`
- sourceCurrencyCode -> `tx.spendTargets[0].currencyCode`
- sourceAmount -> `tx.spendTargets[0].nativeAmount`
- destinationWalletName -> `tx.swapData.payoutWalletId`
- destinationCurrencyCode -> `tx.swapData.payoutCurrencyCode`
- destinationAmount -> `tx.swapData.payoutNativeAmount`
- receiveAddress -> `tx.swapData.payoutAddress`
- refundAddress -> `tx.swapData.refundAddress`
- quoteType -> `tx.swapData.isEstimate`

Some names are different to match what the `EdgeSwapQuote` does, while "destination" and "receive" names now use "payout" to clear up the ambiguity between the exchange or the final wallet.

## This PR

This PR provides everything above except the `checkStatus` method.