### PR TITLE
Save a decryption secret with spend transactions

### DIFF
--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -625,6 +625,7 @@ export function combineTxWithFile(
     }
 
     if (file.swap != null) out.swapData = asTxSwap(file.swap)
+    if (typeof file.secret === 'string') out.txSecret = file.secret
   }
 
   return out

--- a/src/core/currency/wallet/currency-wallet-files.js
+++ b/src/core/currency/wallet/currency-wallet-files.js
@@ -45,6 +45,7 @@ export type TransactionFile = {
     currency: string,
     tag?: string
   }>,
+  secret?: string,
   swap?: EdgeTxSwap
 }
 
@@ -565,6 +566,7 @@ export function setupNewTxMetadata(
       tag: target.uniqueIdentifier
     }))
   }
+  if (typeof tx.txSecret === 'string') json.secret = tx.txSecret
 
   // Save the new file:
   const { diskletFile, fileName, txidHash } = getTxFile(

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -325,6 +325,7 @@ export type EdgeTransaction = {
     +publicAddress: string,
     +uniqueIdentifier?: string
   }>,
+  txSecret?: string, // Monero decryption key
   swapData?: EdgeTxSwap,
   wallet?: EdgeCurrencyWallet, // eslint-disable-line no-use-before-define
   otherParams?: JsonObject

--- a/test/core/currency/wallet/currency-wallet.test.js
+++ b/test/core/currency/wallet/currency-wallet.test.js
@@ -219,6 +219,7 @@ describe('currency wallets', function () {
       log('new', txs.map(tx => `${txid} ${name}`).join(' '))
     })
 
+    // Perform the spend:
     const metadata: EdgeMetadata = { name: 'me' }
     const swapData: EdgeTxSwap = {
       orderId: '1234',
@@ -247,8 +248,9 @@ describe('currency wallets', function () {
     tx = await wallet.signTx(tx)
     await wallet.broadcastTx(tx)
     await wallet.saveTx(tx)
-    await log.waitFor(1).assert('new spend me')
 
+    // Validate the result:
+    await log.waitFor(1).assert('new spend me')
     const txs = await wallet.getTransactions({})
     expect(txs.length).equals(1)
     expect(txs[0].nativeAmount).equals('50')
@@ -268,6 +270,7 @@ describe('currency wallets', function () {
         uniqueIdentifier: undefined
       }
     ])
+    expect(txs[0].txSecret).equals('open sesame')
     expect(txs[0].swapData).deep.equals({
       orderUri: undefined,
       refundAddress: undefined,

--- a/test/fake/fake-currency-plugin.js
+++ b/test/fake/fake-currency-plugin.js
@@ -265,6 +265,7 @@ class FakeCurrencyEngine {
   }
 
   signTx(transaction: EdgeTransaction): Promise<EdgeTransaction> {
+    transaction.txSecret = 'open sesame'
     return Promise.resolve(transaction)
   }
 


### PR DESCRIPTION
I don't remember what we agreed to call it, so I just called it "secret". We can change that name pretty easily now that it's working.