### PR TITLE
Work around metadata bugs in bitcoin plugin

### DIFF
--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -46,7 +46,8 @@ import {
   loadTxFiles,
   renameCurrencyWallet,
   setCurrencyWalletFiat,
-  setCurrencyWalletTxMetadata
+  setCurrencyWalletTxMetadata,
+  setupNewTxMetadata
 } from './currency-wallet-files.js'
 import { type CurrencyWalletInput } from './currency-wallet-pixie.js'
 import { type MergedTransaction } from './currency-wallet-reducer.js'
@@ -468,6 +469,7 @@ export function makeCurrencyWalletApi(
     },
 
     async saveTx(tx: EdgeTransaction): Promise<void> {
+      await setupNewTxMetadata(input, tx)
       await engine.saveTx(tx)
       fakeCallbacks.onTransactionsChanged([tx])
     },

--- a/src/core/currency/wallet/currency-wallet-callbacks.js
+++ b/src/core/currency/wallet/currency-wallet-callbacks.js
@@ -181,7 +181,9 @@ export function makeCurrencyWalletCallbacks(
 
         // Ensure the transaction has metadata:
         const txidHash = hashStorageWalletFilename(state, walletId, txid)
-        const isNew = fileNamesLoaded && fileNames[txidHash] == null
+        const isNew =
+          tx.spendTargets != null ||
+          (fileNamesLoaded && fileNames[txidHash] == null)
         if (isNew) {
           setupNewTxMetadata(input, tx).catch(e => input.props.onError(e))
         }


### PR DESCRIPTION
The bitcoin plugin strips off metadata when it calls our `onTransactionsChanged` callback, so we don't write anything to disk. Work around this by saving metadata *before* letting the plugin mess stuff up.