### PR TITLE
William/logging

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -1,12 +1,14 @@
 // @flow
 
 import { makeContext, makeFakeWorld } from './core/core.js'
+import { defaultOnLog } from './core/log/log.js'
 import { makeBrowserIo } from './io/browser/browser-io.js'
 import {
   type EdgeContext,
   type EdgeContextOptions,
   type EdgeFakeUser,
-  type EdgeFakeWorld
+  type EdgeFakeWorld,
+  type EdgeFakeWorldOptions
 } from './types/types.js'
 
 export { makeBrowserIo }
@@ -21,11 +23,16 @@ export * from './types/types.js'
 export function makeEdgeContext(
   opts: EdgeContextOptions
 ): Promise<EdgeContext> {
-  return makeContext(makeBrowserIo(), {}, opts)
+  const { onLog = defaultOnLog } = opts
+  return makeContext({ io: makeBrowserIo(), nativeIo: {}, onLog }, opts)
 }
 
 export function makeFakeEdgeWorld(
-  users: EdgeFakeUser[] = []
+  users: EdgeFakeUser[] = [],
+  opts?: EdgeFakeWorldOptions = {}
 ): Promise<EdgeFakeWorld> {
-  return Promise.resolve(makeFakeWorld(makeBrowserIo(), {}, users))
+  const { onLog = defaultOnLog } = opts
+  return Promise.resolve(
+    makeFakeWorld({ io: makeBrowserIo(), nativeIo: {}, onLog }, users)
+  )
 }

--- a/src/core/currency/wallet/currency-wallet-pixie.js
+++ b/src/core/currency/wallet/currency-wallet-pixie.js
@@ -112,7 +112,7 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
       const engine = await plugin.makeCurrencyEngine(mergedWalletInfo, {
         callbacks: makeCurrencyWalletCallbacks(input),
         log: makeLog(
-          input.props.io,
+          input.props.onLog,
           `${plugin.currencyInfo.currencyCode}-${walletInfo.id.slice(0, 2)}`
         ),
         walletLocalDisklet,

--- a/src/core/fake/fake-io.js
+++ b/src/core/fake/fake-io.js
@@ -3,21 +3,11 @@
 import { makeMemoryDisklet } from 'disklet'
 
 import {
-  type EdgeConsole,
   type EdgeFetchFunction,
   type EdgeIo,
   type EdgeRandomFunction
 } from '../../types/types.js'
 import { scrypt } from '../../util/crypto/scrypt.js'
-
-/**
- * Silences all logging.
- */
-export const fakeConsole: EdgeConsole = {
-  info() {},
-  warn() {},
-  error() {}
-}
 
 /**
  * Generates deterministic "random" data for unit-testing.
@@ -53,7 +43,7 @@ export function makeFakeIo(): EdgeIo {
     scrypt,
 
     // Local io:
-    console: fakeConsole,
+    console,
     disklet: makeMemoryDisklet(),
 
     // Networking:

--- a/src/core/plugins/plugins-actions.js
+++ b/src/core/plugins/plugins-actions.js
@@ -9,11 +9,18 @@ import {
   type EdgeCorePlugins,
   type EdgeCorePluginsInit,
   type EdgeIo,
+  type EdgeLogEvent,
   type EdgeNativeIo,
   type EdgePluginMap
 } from '../../types/types.js'
 import { type RootAction } from '../actions.js'
 import { makeLog } from '../log/log.js'
+
+export type PluginIos = {
+  io: EdgeIo,
+  nativeIo: EdgeNativeIo,
+  onLog(event: EdgeLogEvent): void
+}
 
 type PluginsAddedWatcher = (plugins: EdgeCorePlugins) => void
 type PluginsLockedWatcher = () => void
@@ -52,11 +59,12 @@ export function lockEdgeCorePlugins(): void {
  * Subscribes a context object to the core plugin list.
  */
 export function watchPlugins(
-  io: EdgeIo,
-  nativeIo: EdgeNativeIo,
+  ios: PluginIos,
   pluginsInit: EdgeCorePluginsInit,
   dispatch: Dispatch<RootAction>
 ): () => mixed {
+  const { io, nativeIo, onLog } = ios
+
   function pluginsAdded(plugins: EdgeCorePlugins): void {
     const out: EdgePluginMap<EdgeCorePlugin> = {}
 
@@ -66,7 +74,7 @@ export function watchPlugins(
       if (!initOptions) continue
 
       // Figure out what kind of object this is:
-      const log = makeLog(io, pluginId)
+      const log = makeLog(onLog, pluginId)
       try {
         if (typeof plugin === 'function') {
           const opts: EdgeCorePluginOptions = {

--- a/src/core/root-pixie.js
+++ b/src/core/root-pixie.js
@@ -3,7 +3,7 @@
 import { type Dispatch } from 'redux'
 import { type PixieInput, type TamePixie, combinePixies } from 'redux-pixies'
 
-import { type EdgeIo, type EdgeLog } from '../types/types.js'
+import { type EdgeIo, type EdgeLog, type EdgeOnLog } from '../types/types.js'
 import { type AccountOutput, accounts } from './account/account-pixie.js'
 import { type RootAction } from './actions.js'
 import { type ContextOutput, context } from './context/context-pixie.js'
@@ -27,6 +27,7 @@ export type RootProps = {
   +io: EdgeIo,
   +log: EdgeLog,
   +onError: (e: Error) => mixed,
+  +onLog: EdgeOnLog,
   +output: RootOutput,
   +state: RootState
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,12 +3,14 @@
 import { makeLocalBridge } from 'yaob'
 
 import { makeContext, makeFakeWorld } from './core/core.js'
+import { defaultOnLog } from './core/log/log.js'
 import { makeNodeIo } from './io/node/node-io.js'
 import {
   type EdgeContext,
   type EdgeContextOptions,
   type EdgeFakeUser,
-  type EdgeFakeWorld
+  type EdgeFakeWorld,
+  type EdgeFakeWorldOptions
 } from './types/types.js'
 
 export { makeNodeIo }
@@ -23,16 +25,19 @@ export * from './types/types.js'
 export function makeEdgeContext(
   opts: EdgeContextOptions
 ): Promise<EdgeContext> {
-  const { path = './edge' } = opts
-  return makeContext(makeNodeIo(path), {}, opts)
+  const { onLog = defaultOnLog, path = './edge' } = opts
+  return makeContext({ io: makeNodeIo(path), nativeIo: {}, onLog }, opts)
 }
 
 export function makeFakeEdgeWorld(
-  users: EdgeFakeUser[] = []
+  users: EdgeFakeUser[] = [],
+  opts?: EdgeFakeWorldOptions = {}
 ): Promise<EdgeFakeWorld> {
+  const { onLog = defaultOnLog } = opts
   return Promise.resolve(
-    makeLocalBridge(makeFakeWorld(makeNodeIo('.'), {}, users), {
-      cloneMessage: message => JSON.parse(JSON.stringify(message))
-    })
+    makeLocalBridge(
+      makeFakeWorld({ io: makeNodeIo('.'), nativeIo: {}, onLog }, users),
+      { cloneMessage: message => JSON.parse(JSON.stringify(message)) }
+    )
   )
 }

--- a/src/io/browser/browser-io.js
+++ b/src/io/browser/browser-io.js
@@ -2,7 +2,6 @@
 
 import { makeLocalStorageDisklet } from 'disklet'
 
-import { fakeConsole } from '../../core/fake/fake-io.js'
 import {
   type EdgeFetchOptions,
   type EdgeFetchResponse,
@@ -31,7 +30,7 @@ export function makeBrowserIo(): EdgeIo {
     scrypt,
 
     // Local io:
-    console: typeof console !== 'undefined' ? console : fakeConsole,
+    console,
     disklet: makeLocalStorageDisklet(window.localStorage, {
       prefix: 'airbitz'
     }),

--- a/src/io/react-native/react-native-io.js
+++ b/src/io/react-native/react-native-io.js
@@ -5,7 +5,11 @@ import { NativeModules } from 'react-native'
 import { scrypt } from 'react-native-fast-crypto'
 import { bridgifyObject } from 'yaob'
 
-import { type EdgeFetchOptions, NetworkError } from '../../types/types.js'
+import {
+  type EdgeFetchOptions,
+  type EdgeOnLog,
+  NetworkError
+} from '../../types/types.js'
 import {
   type HttpHeaders,
   type HttpResponse
@@ -68,7 +72,7 @@ function fetchCors(
   })
 }
 
-export function makeClientIo(): Promise<ClientIo> {
+export function makeClientIo(onLog: EdgeOnLog): Promise<ClientIo> {
   return new Promise((resolve, reject) => {
     randomBytes(32, (error, base64String) => {
       if (error != null) return reject(error)
@@ -79,12 +83,8 @@ export function makeClientIo(): Promise<ClientIo> {
         scrypt,
 
         // Local IO:
-        console: bridgifyObject({
-          info: (...args) => console.info(...args),
-          error: (...args) => console.error(...args),
-          warn: (...args) => console.warn(...args)
-        }),
         disklet: bridgifyObject(makeReactNativeDisklet()),
+        onLog,
 
         // Networking:
         fetchCors

--- a/src/io/react-native/react-native-types.js
+++ b/src/io/react-native/react-native-types.js
@@ -3,20 +3,20 @@
 import { type Disklet } from 'disklet'
 
 import {
-  type EdgeConsole,
   type EdgeContext,
   type EdgeContextOptions,
   type EdgeFakeUser,
   type EdgeFakeWorld,
   type EdgeFetchOptions,
   type EdgeNativeIo,
+  type EdgeOnLog,
   type EdgeScryptFunction
 } from '../../types/types.js'
 import { type HttpResponse } from '../../util/http/http-types.js'
 
 export type ClientIo = {
-  +console: EdgeConsole,
   +disklet: Disklet,
+  +onLog: EdgeOnLog,
 
   +entropy: string, // base64
   +scrypt: EdgeScryptFunction,

--- a/src/io/react-native/react-native-webview.js
+++ b/src/io/react-native/react-native-webview.js
@@ -8,7 +8,7 @@ import RNFS from 'react-native-fs'
 import { WebView } from 'react-native-webview'
 import { Bridge, bridgifyObject, onMethod } from 'yaob'
 
-import { type EdgeNativeIo } from '../../types/types.js'
+import { type EdgeLogEvent, type EdgeNativeIo } from '../../types/types.js'
 import { makeClientIo } from './react-native-io.js'
 import { type WorkerApi } from './react-native-types.js'
 
@@ -16,6 +16,7 @@ type Props = {
   debug?: boolean,
   onError(e: any): mixed,
   onLoad(nativeIo: EdgeNativeIo, root: WorkerApi): Promise<mixed>,
+  onLog(event: EdgeLogEvent): void,
   nativeIo?: EdgeNativeIo
 }
 
@@ -112,10 +113,10 @@ export class EdgeCoreBridge extends Component<Props> {
 
   constructor(props: Props) {
     super(props)
-    const { nativeIo = {}, debug = false } = props
+    const { nativeIo = {}, onLog, debug = false } = props
 
     // Set up the native IO objects:
-    const nativeIoPromise = makeClientIo().then(coreIo => {
+    const nativeIoPromise = makeClientIo(onLog).then(coreIo => {
       const bridgedIo: EdgeNativeIo = { 'edge-core': coreIo }
       for (const n in nativeIo) {
         bridgedIo[n] = bridgifyObject(nativeIo[n])

--- a/src/react-native.js
+++ b/src/react-native.js
@@ -3,6 +3,7 @@
 import { makeReactNativeDisklet } from 'disklet'
 import React, { type Node } from 'react'
 
+import { defaultOnLog } from './core/log/log.js'
 import { parseReply } from './core/login/login-fetch.js'
 import { EdgeCoreBridge } from './io/react-native/react-native-webview.js'
 import {
@@ -13,6 +14,7 @@ import {
   type EdgeFetchOptions,
   type EdgeLoginMessages,
   type EdgeNativeIo,
+  type EdgeOnLog,
   NetworkError
 } from './types/types.js'
 import { timeout } from './util/promise.js'
@@ -29,9 +31,16 @@ export function MakeEdgeContext(props: {
   nativeIo?: EdgeNativeIo,
   onError?: (e: any) => mixed,
   onLoad: (context: EdgeContext) => mixed,
+  onLog?: EdgeOnLog,
   options: EdgeContextOptions
 }): Node {
-  const { debug, nativeIo, onError = onErrorDefault, onLoad } = props
+  const {
+    debug,
+    nativeIo,
+    onError = onErrorDefault,
+    onLoad,
+    onLog = defaultOnLog
+  } = props
   if (onLoad == null) {
     throw new TypeError('No onLoad passed to MakeEdgeContext')
   }
@@ -44,6 +53,7 @@ export function MakeEdgeContext(props: {
       onLoad={(nativeIo, root) =>
         root.makeEdgeContext(nativeIo, props.options).then(onLoad)
       }
+      onLog={onLog}
     />
   )
 }
@@ -53,9 +63,16 @@ export function MakeFakeEdgeWorld(props: {
   nativeIo?: EdgeNativeIo,
   onError?: (e: any) => mixed,
   onLoad: (world: EdgeFakeWorld) => mixed,
+  onLog?: EdgeOnLog,
   users?: EdgeFakeUser[]
 }): Node {
-  const { debug, nativeIo, onError = onErrorDefault, onLoad } = props
+  const {
+    debug,
+    nativeIo,
+    onError = onErrorDefault,
+    onLoad,
+    onLog = defaultOnLog
+  } = props
   if (onLoad == null) {
     throw new TypeError('No onLoad passed to MakeFakeEdgeWorld')
   }
@@ -68,6 +85,7 @@ export function MakeFakeEdgeWorld(props: {
       onLoad={(nativeIo, root) =>
         root.makeFakeEdgeWorld(nativeIo, props.users).then(onLoad)
       }
+      onLog={onLog}
     />
   )
 }

--- a/src/types/exports.js
+++ b/src/types/exports.js
@@ -6,9 +6,11 @@ import {
   type EdgeCorePlugins,
   type EdgeFakeUser,
   type EdgeFakeWorld,
+  type EdgeFakeWorldOptions,
   type EdgeIo,
   type EdgeLoginMessages,
-  type EdgeNativeIo
+  type EdgeNativeIo,
+  type EdgeOnLog
 } from './types.js'
 
 const hack: any = null
@@ -27,7 +29,8 @@ export const makeEdgeContext = (
 ): Promise<EdgeContext> => hack
 
 export const makeFakeEdgeWorld = (
-  users?: EdgeFakeUser[]
+  users?: EdgeFakeUser[],
+  opts?: EdgeFakeWorldOptions
 ): Promise<EdgeFakeWorld> => hack
 
 /**
@@ -38,6 +41,7 @@ export const MakeEdgeContext = (props: {
   nativeIo?: EdgeNativeIo,
   onError?: (e: any) => mixed,
   onLoad: (context: EdgeContext) => mixed,
+  onLog?: EdgeOnLog,
   options: EdgeContextOptions
 }): any => hack // React element
 
@@ -49,6 +53,7 @@ export const MakeFakeEdgeWorld = (props: {
   nativeIo?: EdgeNativeIo,
   onError?: (e: any) => mixed,
   onLoad: (context: EdgeFakeWorld) => mixed,
+  onLog?: EdgeOnLog,
   users: EdgeFakeUser[]
 }): any => hack // React element
 

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -135,6 +135,19 @@ export type EdgeLog = EdgeLogMethod & {
   +error: EdgeLogMethod
 }
 
+/**
+ * The EdgeLog function stringifies its arguments and adds
+ * some extra information to form this event type.
+ */
+export type EdgeLogEvent = {
+  message: string,
+  source: string,
+  time: Date,
+  type: 'info' | 'warn' | 'error'
+}
+
+export type EdgeOnLog = (event: EdgeLogEvent) => void
+
 // plugins -------------------------------------------------------------
 
 /**
@@ -1002,6 +1015,10 @@ export type EdgeContextOptions = {
   appId: string,
   authServer?: string,
   hideKeys?: boolean,
+
+  // Intercepts all console logging:
+  onLog?: EdgeOnLog,
+
   path?: string, // Only used on node.js
   plugins?: EdgeCorePluginsInit
 }
@@ -1131,6 +1148,10 @@ export type EdgeContext = {
 // ---------------------------------------------------------------------
 // fake mode
 // ---------------------------------------------------------------------
+
+export type EdgeFakeWorldOptions = {
+  onLog?: EdgeOnLog
+}
 
 export type EdgeFakeUser = {
   username: string,

--- a/test/core/account/account.test.js
+++ b/test/core/account/account.test.js
@@ -14,6 +14,7 @@ import { fakeUser } from '../../fake/fake-user.js'
 
 const plugins = { fakecoin: true }
 const contextOptions = { apiKey: '', appId: '', plugins }
+const quiet = { onLog() {} }
 
 function findWallet(
   walletInfos: EdgeWalletInfoFull[],
@@ -24,7 +25,7 @@ function findWallet(
 
 describe('account', function () {
   it('has basic information', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -37,7 +38,7 @@ describe('account', function () {
   })
 
   it('has basic information for child apps', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext({
       ...contextOptions,
       appId: 'test-child-child'
@@ -53,7 +54,7 @@ describe('account', function () {
   })
 
   it('calls callbacks', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -65,7 +66,7 @@ describe('account', function () {
   })
 
   it('find repo', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -77,7 +78,7 @@ describe('account', function () {
   })
 
   it('attach repo', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -92,7 +93,7 @@ describe('account', function () {
   })
 
   it('create wallet', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -103,7 +104,7 @@ describe('account', function () {
   })
 
   it('create currency wallet', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account: EdgeAccount = await context.loginWithPIN(
       fakeUser.username,
@@ -119,7 +120,7 @@ describe('account', function () {
   })
 
   it('list keys', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -136,7 +137,7 @@ describe('account', function () {
   })
 
   it('list active wallet ids', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -148,7 +149,7 @@ describe('account', function () {
   })
 
   it('change currency plugin settings', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account1 = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -166,7 +167,7 @@ describe('account', function () {
   })
 
   it('change swap plugin settings', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext({
       ...contextOptions,
       plugins: { fakeswap: true }
@@ -195,7 +196,7 @@ describe('account', function () {
   })
 
   it('disable swap plugin', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext({
       ...contextOptions,
       plugins: { fakeswap: true }
@@ -217,7 +218,7 @@ describe('account', function () {
   })
 
   it('change key state', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -237,7 +238,7 @@ describe('account', function () {
   })
 
   it('split wallet', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -273,7 +274,7 @@ describe('account', function () {
   })
 
   it('hides keys', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext({
       ...contextOptions,
       hideKeys: true
@@ -308,7 +309,7 @@ describe('account', function () {
 
   it('logout', async function () {
     const log = makeAssertLog()
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 

--- a/test/core/account/data-store.test.js
+++ b/test/core/account/data-store.test.js
@@ -7,10 +7,11 @@ import { makeFakeEdgeWorld } from '../../../src/index.js'
 import { fakeUser } from '../../fake/fake-user.js'
 
 const contextOptions = { apiKey: '', appId: '' }
+const quiet = { onLog() {} }
 
 describe('data store API', function () {
   it('stores data', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 

--- a/test/core/context/context.test.js
+++ b/test/core/context/context.test.js
@@ -9,17 +9,18 @@ import { makeFakeEdgeWorld } from '../../../src/index.js'
 import { fakeUser, fakeUserDump } from '../../fake/fake-user.js'
 
 const contextOptions = { apiKey: '', appId: '' }
+const quiet = { onLog() {} }
 
 describe('context', function () {
   it('lists usernames', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
 
     expect(await context.listUsernames()).deep.equals(['js test 0'])
   })
 
   it('dumps fake users', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 

--- a/test/core/currency/wallet/currency-wallet.test.js
+++ b/test/core/currency/wallet/currency-wallet.test.js
@@ -16,11 +16,12 @@ import { expectRejection } from '../../../expect-rejection.js'
 import { fakeUser } from '../../../fake/fake-user.js'
 
 const contextOptions = { apiKey: '', appId: '' }
+const quiet = { onLog() {} }
 
 async function makeFakeCurrencyWallet(): Promise<
   [EdgeCurrencyWallet, EdgeCurrencyConfig]
 > {
-  const world = await makeFakeEdgeWorld([fakeUser])
+  const world = await makeFakeEdgeWorld([fakeUser], quiet)
   const context = await world.makeEdgeContext({
     ...contextOptions,
     plugins: { fakecoin: true, 'fake-exchange': true }

--- a/test/core/exchange/exchange.test.js
+++ b/test/core/exchange/exchange.test.js
@@ -11,6 +11,7 @@ import { makeFakeEdgeWorld } from '../../../src/index.js'
 import { fakeUser } from '../../fake/fake-user.js'
 
 const contextOptions = { apiKey: '', appId: '' }
+const quiet = { onLog() {} }
 
 // A hypothetical collection of currency pairs.
 // The fiat currencies would start with `iso:` in a real exchange-rate cache.
@@ -161,7 +162,7 @@ describe('exchange cache reducer', function () {
 
 describe('exchange pixie', function () {
   it('fetches exchange rates', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext({
       ...contextOptions,
       plugins: { 'broken-exchange': true, 'fake-exchange': true }

--- a/test/core/login/edge.test.js
+++ b/test/core/login/edge.test.js
@@ -12,6 +12,7 @@ import {
 import { fakeUser } from '../../fake/fake-user.js'
 
 const contextOptions = { apiKey: '', appId: '' }
+const quiet = { onLog() {} }
 
 async function simulateRemoteApproval(
   world: EdgeFakeWorld,
@@ -30,7 +31,7 @@ async function simulateRemoteApproval(
 
 describe('edge login', function () {
   it('request', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext({
       ...contextOptions,
       appId: 'test-child',
@@ -52,7 +53,7 @@ describe('edge login', function () {
   })
 
   it('cancel', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
 
     const opts = { displayName: 'test suite' }

--- a/test/core/login/lobby.test.js
+++ b/test/core/login/lobby.test.js
@@ -11,6 +11,8 @@ import {
 } from '../../../src/core/login/lobby.js'
 import { makeFakeEdgeWorld, makeFakeIo } from '../../../src/index.js'
 
+const quiet = { onLog() {} }
+
 const EC = elliptic.ec
 const secp256k1 = new EC('secp256k1')
 const contextOptions = { apiKey: '', appId: '' }
@@ -30,7 +32,7 @@ describe('edge login lobby', function () {
   })
 
   it('lobby ping-pong', async function () {
-    const world = await makeFakeEdgeWorld()
+    const world = await makeFakeEdgeWorld([], quiet)
     const context1 = await world.makeEdgeContext(contextOptions)
     const context2 = await world.makeEdgeContext(contextOptions)
     const i1 = getInternalStuff(context1)

--- a/test/core/login/login.test.js
+++ b/test/core/login/login.test.js
@@ -8,10 +8,11 @@ import { expectRejection } from '../../expect-rejection.js'
 import { fakeUser } from '../../fake/fake-user.js'
 
 const contextOptions = { apiKey: '', appId: '' }
+const quiet = { onLog() {} }
 
 describe('username', function () {
   it('normalize spaces and capitalization', async function () {
-    const world = await makeFakeEdgeWorld()
+    const world = await makeFakeEdgeWorld([], quiet)
     const context = await world.makeEdgeContext(contextOptions)
 
     assert.equal('test test', context.fixUsername('  TEST TEST  '))
@@ -25,7 +26,7 @@ describe('username', function () {
   })
 
   it('list usernames in local storage', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
 
     const list = await context.listUsernames()
@@ -41,7 +42,7 @@ describe('username', function () {
   })
 
   it('remove username from local storage', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
 
     expect(await context.listUsernames()).has.lengthOf(1)
@@ -50,7 +51,7 @@ describe('username', function () {
   })
 
   it('cannot remove logged-in users', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -63,7 +64,7 @@ describe('username', function () {
 
 describe('appId', function () {
   it('can log into unknown apps', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext({
       apiKey: '',
       appId: 'fakeApp'
@@ -74,7 +75,7 @@ describe('appId', function () {
 
 describe('creation', function () {
   it('username available', async function () {
-    const world = await makeFakeEdgeWorld()
+    const world = await makeFakeEdgeWorld([], quiet)
     const context = await world.makeEdgeContext(contextOptions)
 
     const available = await context.usernameAvailable('unknown user')
@@ -82,7 +83,7 @@ describe('creation', function () {
   })
 
   it('username not available', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
 
     const available = await context.usernameAvailable(fakeUser.username)
@@ -91,7 +92,7 @@ describe('creation', function () {
 
   it('password-less account', async function () {
     this.timeout(1000)
-    const world = await makeFakeEdgeWorld()
+    const world = await makeFakeEdgeWorld([], quiet)
     const contextOptions = { apiKey: '', appId: 'test' }
     const context = await world.makeEdgeContext(contextOptions)
     const remote = await world.makeEdgeContext(contextOptions)
@@ -114,7 +115,7 @@ describe('creation', function () {
 
   it('create account', async function () {
     this.timeout(15000)
-    const world = await makeFakeEdgeWorld()
+    const world = await makeFakeEdgeWorld([], quiet)
     const contextOptions = { apiKey: '', appId: 'test' }
     const context = await world.makeEdgeContext(contextOptions)
     const remote = await world.makeEdgeContext(contextOptions)
@@ -142,7 +143,7 @@ describe('creation', function () {
 
 describe('otp', function () {
   it('local login works', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
     expect(account.otpKey != null).equals(true)
@@ -156,7 +157,7 @@ describe('otp', function () {
   })
 
   it('remote login fails', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const remote = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
@@ -187,7 +188,7 @@ describe('otp', function () {
 
 describe('password', function () {
   it('login offline', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     await world.goOffline()
 
@@ -196,14 +197,14 @@ describe('password', function () {
   })
 
   it('login online', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     return context.loginWithPassword(fakeUser.username, fakeUser.password)
   })
 
   it('change', async function () {
     this.timeout(15000)
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -215,7 +216,7 @@ describe('password', function () {
   })
 
   it('check good', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -224,7 +225,7 @@ describe('password', function () {
   })
 
   it('check bad', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -233,7 +234,7 @@ describe('password', function () {
   })
 
   it('delete', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -247,7 +248,7 @@ describe('password', function () {
 
 describe('pin', function () {
   it('exists', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
 
     const exists = await context.pinLoginEnabled(fakeUser.username)
@@ -255,7 +256,7 @@ describe('pin', function () {
   })
 
   it('does not exist', async function () {
-    const world = await makeFakeEdgeWorld()
+    const world = await makeFakeEdgeWorld([], quiet)
     const context = await world.makeEdgeContext(contextOptions)
 
     const exists = await context.pinLoginEnabled(fakeUser.username)
@@ -263,13 +264,13 @@ describe('pin', function () {
   })
 
   it('login', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     await context.loginWithPIN(fakeUser.username, fakeUser.pin)
   })
 
   it('changes', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -281,7 +282,7 @@ describe('pin', function () {
   })
 
   it('enable / disable', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -312,7 +313,7 @@ describe('pin', function () {
   })
 
   it('check', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -321,7 +322,7 @@ describe('pin', function () {
   })
 
   it('delete', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -332,7 +333,7 @@ describe('pin', function () {
 
 describe('recovery2', function () {
   it('get local key', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
 
     const recovery2Key = await context.getRecovery2Key(fakeUser.username)
@@ -340,7 +341,7 @@ describe('recovery2', function () {
   })
 
   it('get questions', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
 
     const questions = await context.fetchRecovery2Questions(
@@ -355,7 +356,7 @@ describe('recovery2', function () {
   })
 
   it('login', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
 
     await context.loginWithRecovery2(
@@ -366,7 +367,7 @@ describe('recovery2', function () {
   })
 
   it('change', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
@@ -388,7 +389,7 @@ describe('recovery2', function () {
   })
 
   it('delete', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
 
     const account = await context.loginWithRecovery2(

--- a/test/core/plugins/plugins.test.js
+++ b/test/core/plugins/plugins.test.js
@@ -8,10 +8,11 @@ import { expectRejection } from '../../expect-rejection.js'
 import { fakeUser } from '../../fake/fake-user.js'
 
 const contextOptions = { apiKey: '', appId: '' }
+const quiet = { onLog() {} }
 
 describe('plugins system', function () {
   it('adds plugins', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext({
       ...contextOptions,
       plugins: {
@@ -29,7 +30,7 @@ describe('plugins system', function () {
   })
 
   it('cannot log in with broken plugins', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext({
       ...contextOptions,
       plugins: {

--- a/test/core/storage/repo.test.js
+++ b/test/core/storage/repo.test.js
@@ -12,6 +12,7 @@ import { fakeUser } from '../../fake/fake-user.js'
 const contextOptions = { apiKey: '', appId: '' }
 const dataKey = base64.parse(fakeUser.loginKey)
 const syncKey = base64.parse(fakeUser.syncKey)
+const quiet = { onLog() {} }
 
 describe('repo', function () {
   it('read file', async function () {
@@ -41,7 +42,7 @@ describe('repo', function () {
   })
 
   it('repo-to-repo sync', async function () {
-    const world = await makeFakeEdgeWorld([fakeUser])
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context1 = await world.makeEdgeContext(contextOptions)
     const context2 = await world.makeEdgeContext(contextOptions)
     const i1 = getInternalStuff(context1)


### PR DESCRIPTION
This allows the user to pass an `onLog` callback to the context constructor. If that's in place, all logs will go there instead of the console. This will solve several partner complaints, and allow our CLI to finally silence the core. For the GUI, it will let us do fancy things with the different currency plugin logs if we want to, or at least reliably send them to disk or wherever.