### PR TITLE
Save fee information in the spend metadata

### DIFF
--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -436,7 +436,7 @@ export function makeCurrencyWalletApi(
         throw new TypeError('Only sweepPrivateKeys takes private keys')
       }
 
-      const tx = await engine.makeSpend({
+      const tx: EdgeTransaction = await engine.makeSpend({
         currencyCode,
         spendTargets: cleanTargets,
         noUnconfirmed,
@@ -445,9 +445,12 @@ export function makeCurrencyWalletApi(
         metadata,
         otherParams
       })
+      tx.networkFeeOption = networkFeeOption
+      tx.requestedCustomFee = customNetworkFee
       tx.spendTargets = savedTargets
       if (metadata != null) tx.metadata = metadata
       if (swapData != null) tx.swapData = asTxSwap(swapData)
+
       return tx
     },
 
@@ -616,6 +619,16 @@ export function combineTxWithFile(
         ...unpackMetadata(merged.metadata, walletFiat)
       }
     }
+
+    if (file.feeRequested != null) {
+      if (typeof file.feeRequested === 'string') {
+        out.networkFeeOption = file.feeRequested
+      } else {
+        out.networkFeeOption = 'custom'
+        out.requestedCustomFee = file.feeRequested
+      }
+    }
+    out.feeRateUsed = file.feeUsed
 
     if (file.payees != null) {
       out.spendTargets = file.payees.map(payee => ({

--- a/src/core/currency/wallet/currency-wallet-files.js
+++ b/src/core/currency/wallet/currency-wallet-files.js
@@ -6,7 +6,8 @@ import { type DiskletFile, type DiskletFolder, mapFiles } from 'disklet'
 import {
   type EdgeCurrencyEngineCallbacks,
   type EdgeTransaction,
-  type EdgeTxSwap
+  type EdgeTxSwap,
+  type JsonObject
 } from '../../../types/types.js'
 import { mergeDeeply } from '../../../util/util.js'
 import { fetchAppIdInfo } from '../../account/lobby-api.js'
@@ -39,6 +40,8 @@ export type TransactionFile = {
       providerFeeSent?: string
     }
   },
+  feeRequested?: 'high' | 'standard' | 'low' | JsonObject,
+  feeUsed?: JsonObject,
   payees?: Array<{
     address: string,
     amount: string,
@@ -560,6 +563,15 @@ export function setupNewTxMetadata(
     swap: swapData
   }
   json.currencies[currencyCode] = { metadata, nativeAmount }
+
+  // Set up the fee metadata:
+  if (tx.networkFeeOption != null) {
+    json.feeRequested =
+      tx.networkFeeOption === 'custom'
+        ? tx.requestedCustomFee
+        : tx.networkFeeOption
+  }
+  json.feeUsed = tx.feeRateUsed
 
   // Set up payees:
   if (spendTargets != null) {

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -317,16 +317,21 @@ export type EdgeTransaction = {
   signedTx: string,
   ourReceiveAddresses: string[],
 
-  // Core:
-  metadata?: EdgeMetadata,
+  // Spend-specific metadata:
+  networkFeeOption?: 'high' | 'standard' | 'low' | 'custom',
+  requestedCustomFee?: JsonObject,
+  feeRateUsed?: JsonObject,
   spendTargets?: Array<{
     +currencyCode: string,
     +nativeAmount: string,
     +publicAddress: string,
     +uniqueIdentifier?: string
   }>,
-  txSecret?: string, // Monero decryption key
   swapData?: EdgeTxSwap,
+  txSecret?: string, // Monero decryption key
+
+  // Core:
+  metadata?: EdgeMetadata,
   wallet?: EdgeCurrencyWallet, // eslint-disable-line no-use-before-define
   otherParams?: JsonObject
 }
@@ -354,7 +359,7 @@ export type EdgeSpendInfo = {
 
   // Options:
   noUnconfirmed?: boolean,
-  networkFeeOption?: string, // 'high' | 'standard' | 'low' | 'custom',
+  networkFeeOption?: 'high' | 'standard' | 'low' | 'custom',
   customNetworkFee?: JsonObject, // Some kind of currency-specific JSON
 
   // Core:

--- a/test/core/currency/wallet/currency-wallet.test.js
+++ b/test/core/currency/wallet/currency-wallet.test.js
@@ -243,7 +243,8 @@ describe('currency wallets', function () {
         }
       ],
       metadata,
-      swapData
+      swapData,
+      networkFeeOption: 'high'
     })
     tx = await wallet.signTx(tx)
     await wallet.broadcastTx(tx)
@@ -262,6 +263,7 @@ describe('currency wallets', function () {
       amountFiat: 1.5,
       ...metadata
     })
+    expect(txs[0].networkFeeOption).deep.equals('high')
     expect(txs[0].spendTargets).deep.equals([
       {
         currencyCode: 'FAKE',
@@ -270,12 +272,12 @@ describe('currency wallets', function () {
         uniqueIdentifier: undefined
       }
     ])
-    expect(txs[0].txSecret).equals('open sesame')
     expect(txs[0].swapData).deep.equals({
       orderUri: undefined,
       refundAddress: undefined,
       ...swapData
     })
+    expect(txs[0].txSecret).equals('open sesame')
   })
 
   it('can update metadata', async function () {

--- a/test/fake/fake-currency-plugin.js
+++ b/test/fake/fake-currency-plugin.js
@@ -257,6 +257,7 @@ class FakeCurrencyEngine {
       date: 0,
       nativeAmount: total,
       networkFee: '0',
+      feeRateUsed: { fakePrice: 0 },
       otherParams: {},
       ourReceiveAddresses: [],
       signedTx: '',


### PR DESCRIPTION
This is a better version of #299 with the disk back-end working now.