### PR TITLE
Don't crash on barcode logins with OTP reset dates

### DIFF
--- a/src/core/login/edge.js
+++ b/src/core/login/edge.js
@@ -11,7 +11,7 @@ import { base58 } from '../../util/encoding.js'
 import { makeAccount } from '../account/account-init.js'
 import { type ApiInput } from '../root-pixie.js'
 import { type LobbySubscription, makeLobby } from './lobby.js'
-import { saveStash } from './login-stash.js'
+import { asLoginStash, saveStash } from './login-stash.js'
 import { makeLoginTree, searchTree, syncLogin } from './login.js'
 
 /**
@@ -52,7 +52,7 @@ async function onReply(
   opts: EdgeEdgeLoginOptions
 ): Promise<void> {
   subscription.unsubscribe()
-  const stashTree = reply.loginStash
+  const stashTree = asLoginStash(reply.loginStash)
   const { log } = ai.props
   const { now = new Date() } = opts
 
@@ -68,9 +68,10 @@ async function onReply(
 
   // The Airbitz mobile will sometimes send the pin2Key in base58
   // instead of base64 due to an unfortunate bug. Fix that:
-  if (child.pin2Key != null && child.pin2Key.slice(-1) !== '=') {
+  const { pin2Key } = child
+  if (pin2Key != null && pin2Key.slice(-1) !== '=') {
     log.warn('Fixing base58 pin2Key')
-    child.pin2Key = base64.stringify(base58.parse(child.pin2Key))
+    child.pin2Key = base64.stringify(base58.parse(pin2Key))
   }
   stashTree.lastLogin = now
   await saveStash(ai, stashTree)

--- a/src/core/login/login-stash.js
+++ b/src/core/login/login-stash.js
@@ -137,7 +137,7 @@ export async function saveStash(
   dispatch({ type: 'LOGIN_STASH_SAVED', payload: stashTree })
 }
 
-const asLoginStash: Cleaner<LoginStash> = asObject({
+export const asLoginStash: Cleaner<LoginStash> = asObject({
   // Identity:
   appId: asString,
   created: asOptional(asDate),

--- a/src/core/login/login.js
+++ b/src/core/login/login.js
@@ -456,7 +456,11 @@ export function syncLogin(
   const stashTree = getStash(ai, loginTree.username)
   const request = makeAuthJson(login)
   return loginFetch(ai, 'POST', '/v2/login', request).then(reply => {
-    const newStashTree = applyLoginReply(stashTree, login.loginKey, reply)
+    const newStashTree = applyLoginReply(
+      stashTree,
+      login.loginKey,
+      asLoginReply(reply)
+    )
     const newLoginTree = makeLoginTree(
       newStashTree,
       login.loginKey,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4115,7 +4115,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@^2.0.0:
+node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
We weren't cleaning the server replies properly, which meant dates were sometimes still strings.