### PR TITLE
RBF Transaction Support

### DIFF
--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -390,6 +390,7 @@ export function makeCurrencyWalletApi(
         noUnconfirmed = false,
         networkFeeOption = 'standard',
         customNetworkFee,
+        rbfTxid,
         metadata,
         swapData,
         otherParams
@@ -442,6 +443,7 @@ export function makeCurrencyWalletApi(
         noUnconfirmed,
         networkFeeOption,
         customNetworkFee,
+        rbfTxid,
         metadata,
         otherParams
       })

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -374,6 +374,7 @@ export type EdgeSpendInfo = {
   noUnconfirmed?: boolean,
   networkFeeOption?: 'high' | 'standard' | 'low' | 'custom',
   customNetworkFee?: JsonObject, // Some kind of currency-specific JSON
+  rbfTxid?: string,
 
   // Core:
   metadata?: EdgeMetadata,


### PR DESCRIPTION
* Adds new `rbfTxid` optional string to `EdgeSpendInfo` type definition
* Adds new `rbfTxid` to the returned `EdgeTransaction` object in
`makeSpend` on `EdgeCurrencyWallet` objects