### PR TITLE
Overwrite publicAddress when encoding URI

### DIFF
--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -561,8 +561,13 @@ export function makeCurrencyWalletApi(
     },
 
     async encodeUri(obj: EdgeEncodeUri): Promise<string> {
+      const { legacyAddress, segwitAddress } = obj
+      const copy = { ...obj }
+      if (segwitAddress != null) copy.publicAddress = segwitAddress
+      if (legacyAddress != null) copy.publicAddress = legacyAddress
+
       const tools = await getCurrencyTools(ai, walletInfo.type)
-      return tools.encodeUri(obj, input.props.state.currency.customTokens)
+      return tools.encodeUri(copy, input.props.state.currency.customTokens)
     },
 
     otherMethods,

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -438,8 +438,8 @@ export type EdgeParsedUri = {
 
 export type EdgeEncodeUri = {
   publicAddress: string,
-  segwitAddress?: string,
-  legacyAddress?: string,
+  segwitAddress?: string, // Deprecated. Use publicAddress instead.
+  legacyAddress?: string, // Deprecated. Use publicAddress instead.
   nativeAmount?: string,
   label?: string,
   message?: string,


### PR DESCRIPTION
The type `EdgeEncodeUri` should not contain `segwitAddress` or `legacyAddress` as it should only be dealing with 1 address (the `publicAddress`)