### PR TITLE
Make the currency engine's address methods async

### DIFF
--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -359,7 +359,7 @@ export function makeCurrencyWalletApi(
     async getReceiveAddress(
       opts: EdgeCurrencyCodeOptions = {}
     ): Promise<EdgeReceiveAddress> {
-      const freshAddress = engine.getFreshAddress(opts)
+      const freshAddress = await engine.getFreshAddress(opts)
       const receiveAddress: EdgeReceiveAddress = {
         metadata: fakeMetadata,
         nativeAmount: '0',

--- a/src/core/currency/wallet/currency-wallet-files.js
+++ b/src/core/currency/wallet/currency-wallet-files.js
@@ -414,34 +414,34 @@ async function loadTxFileNames(
 /**
  * Loads address metadata files.
  */
-function loadAddressFiles(
+async function loadAddressFiles(
   input: CurrencyWalletInput,
   folder: DiskletFolder
 ): Promise<string[]> {
   // Actually load the files:
-  const oldFiles = mapFiles(folder.folder('Addresses'), file =>
-    file
-      .getText()
-      .then(text => JSON.parse(text))
-      .catch(e => null)
+  const oldFiles: LegacyAddressFile[] = await mapFiles(
+    folder.folder('Addresses'),
+    file =>
+      file
+        .getText()
+        .then(text => JSON.parse(text))
+        .catch(e => null)
   )
 
   // Save the results to our state:
-  return oldFiles.then((oldFiles: LegacyAddressFile[]) => {
-    const out: string[] = []
-    for (const json of oldFiles) {
-      if (json == null || !json.state || !json.meta) continue
-      const address = json.address
-      if (!address || json.state.recycleable) continue
-      out.push(address)
-    }
+  const out: string[] = []
+  for (const json of oldFiles) {
+    if (json == null || !json.state || !json.meta) continue
+    const address = json.address
+    if (!address || json.state.recycleable) continue
+    out.push(address)
+  }
 
-    // Load these addresses into the engine:
-    const engine = input.props.selfOutput.engine
-    if (engine) engine.addGapLimitAddresses(out)
+  // Load these addresses into the engine:
+  const engine = input.props.selfOutput.engine
+  if (engine) await engine.addGapLimitAddresses(out)
 
-    return out
-  })
+  return out
 }
 
 /**

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -511,9 +511,11 @@ export type EdgeCurrencyEngine = {
   getTokenStatus(token: string): boolean,
 
   // Addresses:
-  getFreshAddress(opts: EdgeCurrencyCodeOptions): EdgeFreshAddress,
-  addGapLimitAddresses(addresses: string[]): void,
-  isAddressUsed(address: string): boolean,
+  getFreshAddress(
+    opts: EdgeCurrencyCodeOptions
+  ): Promise<EdgeFreshAddress> | EdgeFreshAddress,
+  addGapLimitAddresses(addresses: string[]): Promise<void> | void,
+  isAddressUsed(address: string): Promise<boolean> | boolean,
 
   // Spending:
   makeSpend(spendInfo: EdgeSpendInfo): Promise<EdgeTransaction>,


### PR DESCRIPTION
This is not a breaking change, since non-async return values are still acceptable.

This has not been tested.