### PR TITLE
Fix the return type for `listRecoveryQuestionChoices`

### DIFF
--- a/src/core/context/context-api.js
+++ b/src/core/context/context-api.js
@@ -11,6 +11,7 @@ import {
   type EdgeLoginMessages,
   type EdgeLogSettings,
   type EdgePendingEdgeLogin,
+  type EdgeRecoveryQuestionChoice,
   type EdgeUserInfo
 } from '../../types/types.js'
 import { base58 } from '../../util/encoding.js'
@@ -172,7 +173,7 @@ export function makeContextApi(ai: ApiInput): EdgeContext {
       return getQuestions2(ai, base58.parse(recovery2Key), username)
     },
 
-    async listRecoveryQuestionChoices(): Promise<string[]> {
+    async listRecoveryQuestionChoices(): Promise<EdgeRecoveryQuestionChoice[]> {
       return listRecoveryQuestionChoices(ai)
     },
 

--- a/src/core/login/recovery2.js
+++ b/src/core/login/recovery2.js
@@ -7,7 +7,10 @@ import {
   asStartRecoveryPayload
 } from '../../types/server-cleaners.js'
 import { type Recovery2Payload } from '../../types/server-types.js'
-import { type EdgeAccountOptions } from '../../types/types.js'
+import {
+  type EdgeAccountOptions,
+  type EdgeRecoveryQuestionChoice
+} from '../../types/types.js'
 import { decrypt, decryptText, encrypt } from '../../util/crypto/crypto.js'
 import { hmacSha256 } from '../../util/crypto/hashes.js'
 import { utf8 } from '../../util/encoding.js'
@@ -172,7 +175,7 @@ export function makeRecovery2Kit(
 
 export async function listRecoveryQuestionChoices(
   ai: ApiInput
-): Promise<string[]> {
+): Promise<EdgeRecoveryQuestionChoice[]> {
   return asQuestionChoicesPayload(
     await loginFetch(ai, 'POST', '/v1/questions', {})
   )

--- a/src/types/server-cleaners.js
+++ b/src/types/server-cleaners.js
@@ -30,6 +30,7 @@ import {
   type PasswordPayload,
   type Pin2DisablePayload,
   type Pin2EnablePayload,
+  type QuestionChoicesPayload,
   type Recovery2Payload,
   type SecretPayload,
   type StartRecoveryPayload
@@ -233,7 +234,24 @@ export const asStartRecoveryPayload: Cleaner<StartRecoveryPayload> = asObject({
   question2Box: asEdgeBox
 })
 
-export const asQuestionChoicesPayload: Cleaner<string[]> = asArray(asString)
+export const asQuestionChoicesPayload: Cleaner<QuestionChoicesPayload> = asArray(
+  asObject({
+    min_length: asNumber,
+    category: raw => {
+      const clean = asString(raw)
+      switch (clean) {
+        case 'address':
+        case 'must':
+        case 'numeric':
+        case 'recovery2':
+        case 'string':
+          return clean
+      }
+      throw new TypeError('Invalid question category')
+    },
+    question: asString
+  })
+)
 
 // ---------------------------------------------------------------------
 // lobby subsystem

--- a/src/types/server-types.js
+++ b/src/types/server-types.js
@@ -1,6 +1,9 @@
 // @flow
 
-import { type EdgePendingVoucher } from './types.js'
+import {
+  type EdgePendingVoucher,
+  type EdgeRecoveryQuestionChoice
+} from './types.js'
 
 /**
  * Edge-format encrypted data.
@@ -196,6 +199,8 @@ export type OtpResetPayload = {
 export type StartRecoveryPayload = {
   question2Box: EdgeBox
 }
+
+export type QuestionChoicesPayload = EdgeRecoveryQuestionChoice[]
 
 // ---------------------------------------------------------------------
 // lobby subsystem

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -1058,6 +1058,12 @@ export type EdgeContextOptions = {
   plugins?: EdgeCorePluginsInit
 }
 
+export type EdgeRecoveryQuestionChoice = {
+  category: 'address' | 'must' | 'numeric' | 'recovery2' | 'string',
+  min_length: number,
+  question: string
+}
+
 // parameters ----------------------------------------------------------
 
 export type EdgeEdgeLoginOptions = EdgeAccountOptions & {
@@ -1170,7 +1176,8 @@ export type EdgeContext = {
     recovery2Key: string,
     username: string
   ): Promise<string[]>,
-  listRecoveryQuestionChoices(): Promise<string[]>,
+  // Really returns EdgeRecoveryQuestionChoice[]:
+  listRecoveryQuestionChoices(): Promise<any>,
 
   // OTP stuff:
   requestOtpReset(username: string, otpResetToken: string): Promise<Date>,


### PR DESCRIPTION
This has been incorrect since the very beginning, and yet nobody has noticed.

Since we don't want a breaking change, just chang the type to `any` and provide a correct definition on the side.