### PR TITLE
DumpData return type 

### DIFF
--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -487,7 +487,7 @@ export function makeCurrencyWalletApi(
     },
 
     async dumpData(): Promise<EdgeDataDump> {
-      return engine.dumpData()
+      return await engine.dumpData()
     },
 
     async getPaymentProtocolInfo(

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -494,7 +494,7 @@ export type EdgeCurrencyEngine = {
   startEngine(): Promise<mixed>,
   killEngine(): Promise<mixed>,
   resyncBlockchain(): Promise<mixed>,
-  dumpData(): EdgeDataDump,
+  dumpData(): EdgeDataDump | Promise<EdgeDataDump>,
 
   // Chain state:
   getBlockHeight(): number,


### PR DESCRIPTION
It updates `EdgeCurrencyEngine.dumpData` return type to resolve a promise. Because the new currency plugins read data from disk via `memlet` it must resolve a promise.