### PR TITLE
Verify Engine Tx Cache

### DIFF
--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -232,6 +232,10 @@ export function makeCurrencyWalletApi(
       const currencyCode = opts.currencyCode || defaultCurrency
 
       let state = input.props.selfState
+
+      if (state.txids.length !== (await this.getNumTransactions(opts)))
+        state.gotTxs[currencyCode] = false
+
       if (!state.gotTxs[currencyCode]) {
         const txs = await engine.getTransactions({
           currencyCode: opts.currencyCode


### PR DESCRIPTION
### Transaction Cache 
After transactions are fetched from the engine, the core marks in its state that the transactions have been cached via the `state.gotTxs[currencyCode]`. However, if transactions are fetched from the engine before the entire account history has been downloaded, the core will have already marked all the transactions as cached and will not try to fetch any more from the engine. 

To get around this, I compare the count of cached transactions to the count the engine returns via `engine.getNumTransactions({ currencyCode })` function.