### PR TITLE
Re-enable ES 2020 syntax features

### DIFF
--- a/src/types/error.js
+++ b/src/types/error.js
@@ -58,7 +58,7 @@ export class InsufficientFundsError extends Error {
       }
     } else {
       const { currencyCode, networkFee } = opts
-      super(`Insufficient ${currencyCode != null ? currencyCode : 'funds'}`)
+      super(`Insufficient ${currencyCode ?? 'funds'}`)
       this.currencyCode = currencyCode
       this.networkFee = networkFee
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,8 @@ const babelOptions = {
     : ['@babel/preset-flow', '@babel/preset-react'],
   plugins: [
     ['@babel/plugin-transform-for-of', { assumeArray: true }],
+    '@babel/plugin-proposal-nullish-coalescing-operator',
+    '@babel/plugin-proposal-optional-chaining',
     '@babel/plugin-transform-runtime',
     'babel-plugin-transform-fake-error-class'
   ],


### PR DESCRIPTION
This instructs Webpack to transform away `??` and `?.` before they become a problem.