### PR TITLE
Fix WebView bundle to work on really old devices

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,13 @@ module.exports = {
         test: /\.js$/,
         exclude: /node_modules/,
         use: { loader: 'babel-loader', options: babelOptions }
+      },
+      {
+        include: path.resolve(__dirname, 'node_modules/buffer/index.js'),
+        use: {
+          loader: 'babel-loader',
+          options: { presets: ['@babel/preset-env'] }
+        }
       }
     ]
   },
@@ -40,7 +47,6 @@ module.exports = {
       })
     ]
   },
-
   output: {
     filename: 'lib/react-native/edge-core.js',
     path: path.resolve(__dirname)


### PR DESCRIPTION
The `buffer` package is using modern syntax, which we need to compile out.

### Fixed

- Fix the React Native WebView bundle to work on really old phones.