### PR TITLE
Configurable URL for the core service

### DIFF
--- a/src/io/react-native/react-native-webview.js
+++ b/src/io/react-native/react-native-webview.js
@@ -17,6 +17,7 @@ import { type YaobCallbacks, makeYaobCallbacks } from './yaob-callbacks.js'
 
 type Props = {
   allowDebugging?: boolean,
+  coreServerUrl?: string,
   debug?: boolean,
   onError(e: any): mixed,
   onLoad(clientIo: ClientIo, root: WorkerApi): Promise<mixed>
@@ -45,13 +46,20 @@ export class EdgeCoreBridge extends React.Component<Props> {
   }
 
   render(): React.Node {
-    const { allowDebugging = false, debug = false, onError } = this.props
+    const {
+      allowDebugging = false,
+      coreServerUrl,
+      debug = false,
+      onError
+    } = this.props
 
     return (
       <NativeWebView
         ref={this.callbacks.setRef}
         allowDebugging={debug || allowDebugging}
-        source={debug ? 'http://localhost:8080/edge-core.js' : null}
+        source={
+          coreServerUrl ?? debug ? 'http://localhost:8080/edge-core.js' : null
+        }
         style={{ opacity: 0, position: 'absolute', height: 1, width: 1 }}
         onMessage={this.callbacks.handleMessage}
         onScriptError={event => {

--- a/src/react-native.js
+++ b/src/react-native.js
@@ -33,6 +33,7 @@ let warningShown = false
 export function MakeEdgeContext(props: EdgeContextProps): React.Node {
   const {
     allowDebugging,
+    coreServerUrl,
     debug,
     nativeIo,
     pluginUris = [],
@@ -55,6 +56,7 @@ export function MakeEdgeContext(props: EdgeContextProps): React.Node {
   return (
     <EdgeCoreBridge
       allowDebugging={allowDebugging}
+      coreServerUrl={coreServerUrl}
       debug={debug}
       onError={onError}
       onLoad={(clientIo, root) =>
@@ -75,6 +77,7 @@ export function MakeEdgeContext(props: EdgeContextProps): React.Node {
 export function MakeFakeEdgeWorld(props: EdgeFakeWorldProps): React.Node {
   const {
     allowDebugging,
+    coreServerUrl,
     crashReporter,
     debug,
     nativeIo,
@@ -91,6 +94,7 @@ export function MakeFakeEdgeWorld(props: EdgeFakeWorldProps): React.Node {
   return (
     <EdgeCoreBridge
       allowDebugging={allowDebugging}
+      coreServerUrl={coreServerUrl}
       debug={debug}
       onError={onError}
       onLoad={(clientIo, root) =>

--- a/src/types/exports.js
+++ b/src/types/exports.js
@@ -51,6 +51,9 @@ interface CommonProps {
   // since the `debug` prop also activates Chrome debugging.
   allowDebugging?: boolean;
 
+  // Changes the location we load the core JS bundle from.
+  coreServerUrl?: string;
+
   // Enable core debugging.
   // You must call `yarn start` in the edge-core-js project for this to work:
   debug?: boolean;


### PR DESCRIPTION
This is useful to override the default "file://..." URL with a
localhost URL for development purposes.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201210979646259