### PR TITLE
Add `max` as a swap quote type

### DIFF
--- a/src/types/types.js
+++ b/src/types/types.js
@@ -716,7 +716,7 @@ export type EdgeSwapRequest = {
 
   // How much?
   nativeAmount: string,
-  quoteFor: 'from' | 'to'
+  quoteFor: 'from' | 'max' | 'to'
 }
 
 /**


### PR DESCRIPTION
Setting the `quoteFor` field to "max" indicates that we just want the max amount, whatever that is.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1200828710714390