### PR TITLE
Add an `EdgeCurrencyEngine.getMaxSpendable` method

### DIFF
--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -484,6 +484,9 @@ export function makeCurrencyWalletApi(
     },
 
     async getMaxSpendable(spendInfo: EdgeSpendInfo): Promise<string> {
+      if (typeof engine.getMaxSpendable === 'function') {
+        return await engine.getMaxSpendable(spendInfo)
+      }
       const { currencyCode, networkFeeOption, customNetworkFee } = spendInfo
       const balance = engine.getBalance({ currencyCode })
 

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -523,6 +523,7 @@ export type EdgeCurrencyEngine = {
   isAddressUsed(address: string): Promise<boolean> | boolean,
 
   // Spending:
+  getMaxSpendable?: (spendInfo: EdgeSpendInfo) => Promise<string>,
   makeSpend(spendInfo: EdgeSpendInfo): Promise<EdgeTransaction>,
   signTx(transaction: EdgeTransaction): Promise<EdgeTransaction>,
   broadcastTx(transaction: EdgeTransaction): Promise<EdgeTransaction>,


### PR DESCRIPTION
If the engine implements this optional method, we defer to the plugin's calculation.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201615930226391