### PR TITLE
Always call the iOS WebView on the main thread

### DIFF
--- a/ios/EdgeCoreWebView.swift
+++ b/ios/EdgeCoreWebView.swift
@@ -81,12 +81,16 @@ class EdgeCoreWebView: RCTView, WKNavigationDelegate, WKScriptMessageHandler {
 
       let promise = PendingCall(
         resolve: { result in
-          self.runJs(
-            js: "window.nativeBridge.resolve(\(id), \(self.stringify(result)))")
+          DispatchQueue.main.async {
+            self.runJs(
+              js: "window.nativeBridge.resolve(\(id), \(self.stringify(result)))")
+          }
         },
         reject: { message in
-          self.runJs(
-            js: "window.nativeBridge.reject(\(id), \(self.stringify(message)))")
+          DispatchQueue.main.async {
+            self.runJs(
+              js: "window.nativeBridge.reject(\(id), \(self.stringify(message)))")
+          }
         })
 
       return queue.async {


### PR DESCRIPTION
Apparently, the WebView will randomly crash if you call it from some thread other than the main UI one.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201642978012044