### PR TITLE
Add a native `requiresMainQueueSetup` method

### DIFF
--- a/ios/EdgeCoreWebViewManager.swift
+++ b/ios/EdgeCoreWebViewManager.swift
@@ -1,4 +1,5 @@
 @objc(EdgeCoreWebViewManager) class EdgeCoreWebViewManager: RCTViewManager {
+  override static func requiresMainQueueSetup() -> Bool { return false }
   override func view() -> UIView! { return EdgeCoreWebView() }
 
   @objc var onMessage: RCTDirectEventBlock?


### PR DESCRIPTION
This prevents React Native for iOS from printing a yellow-box warning.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201684341845269