### PR TITLE
William/custom tokens

### DIFF
--- a/ios/edge-core-js.xcodeproj/project.pbxproj
+++ b/ios/edge-core-js.xcodeproj/project.pbxproj
@@ -1,0 +1,1 @@
+// Placeholder so react-native autolinking can find us.

--- a/src/core/account/account-cleaners.js
+++ b/src/core/account/account-cleaners.js
@@ -2,6 +2,7 @@
 
 import {
   type Cleaner,
+  asArray,
   asBoolean,
   asMap,
   asNumber,
@@ -11,12 +12,26 @@ import {
 } from 'cleaners'
 
 import { asBase16 } from '../../types/server-cleaners.js'
+import { type EdgeDenomination, type EdgeToken } from '../../types/types.js'
 import { asJsonObject } from '../../util/file-helpers.js'
 import { type SwapSettings } from './account-types.js'
 
 // ---------------------------------------------------------------------
 // building-block types
 // ---------------------------------------------------------------------
+
+const asEdgeDenomination: Cleaner<EdgeDenomination> = asObject({
+  multiplier: asString,
+  name: asString,
+  symbol: asOptional(asString)
+})
+
+const asEdgeToken: Cleaner<EdgeToken> = asObject({
+  currencyCode: asString,
+  denominations: asArray(asEdgeDenomination),
+  displayName: asString,
+  networkLocation: asOptional(asJsonObject)
+})
 
 const asSwapSettings: Cleaner<SwapSettings> = asObject({
   enabled: asOptional(asBoolean, true)
@@ -58,3 +73,25 @@ export const asPluginSettingsFile = asObject({
   // Swap plugins:
   swapSettings: asOptional(asMap(asSwapSettings), {})
 }).withRest
+
+/**
+ * The settings file managed by the GUI.
+ */
+export const asGuiSettingsFile = asObject({
+  customTokens: asArray(
+    asObject({
+      contractAddress: asString,
+      currencyCode: asString,
+      currencyName: asString,
+      denomination: asString,
+      denominations: asArray(asEdgeDenomination),
+      isVisible: asOptional(asBoolean, true),
+      multiplier: asString,
+      walletType: asOptional(asString, 'wallet:ethereum')
+    })
+  )
+})
+
+export const asCustomTokensFile = asObject({
+  customTokens: asObject(asObject(asEdgeToken))
+})

--- a/src/core/account/account-pixie.js
+++ b/src/core/account/account-pixie.js
@@ -18,7 +18,7 @@ import {
 import { makePeriodicTask } from '../../util/periodic-task.js'
 import { syncAccount } from '../login/login.js'
 import { waitForPlugins } from '../plugins/plugins-selectors.js'
-import { type ApiInput, type RootProps } from '../root-pixie.js'
+import { type RootProps, toApiInput } from '../root-pixie.js'
 import {
   addStorageWallet,
   syncStorageWallet
@@ -69,7 +69,7 @@ const accountPixie: TamePixie<AccountProps> = combinePixies({
       },
 
       async update() {
-        const ai: ApiInput = (input: any) // Safe, since input extends ApiInput
+        const ai = toApiInput(input)
         const { accountId, accountState, log } = input.props
         const { accountWalletInfos } = accountState
 
@@ -114,7 +114,7 @@ const accountPixie: TamePixie<AccountProps> = combinePixies({
   syncTimer: filterPixie(
     (input: AccountInput) => {
       async function doDataSync(): Promise<void> {
-        const ai: ApiInput = (input: any) // Safe, since input extends ApiInput
+        const ai = toApiInput(input)
         const { accountId, accountState } = input.props
         const { accountWalletInfos } = accountState
 
@@ -132,9 +132,8 @@ const accountPixie: TamePixie<AccountProps> = combinePixies({
       }
 
       async function doLoginSync(): Promise<void> {
-        const ai: ApiInput = (input: any) // Safe, since input extends ApiInput
         const { accountId } = input.props
-        await syncAccount(ai, accountId)
+        await syncAccount(toApiInput(input), accountId)
       }
 
       // We don't report sync failures, since that could be annoying:

--- a/src/core/account/account-reducer.js
+++ b/src/core/account/account-reducer.js
@@ -266,6 +266,10 @@ const accountInner: FatReducer<
 
   customTokens(state = {}, action: RootAction): EdgePluginMap<EdgeTokenMap> {
     switch (action.type) {
+      case 'ACCOUNT_CUSTOM_TOKENS_LOADED': {
+        const { customTokens } = action.payload
+        return customTokens
+      }
       case 'ACCOUNT_CUSTOM_TOKEN_ADDED': {
         const { pluginId, tokenId, token } = action.payload
         const oldList = state[pluginId] ?? {}

--- a/src/core/account/account-reducer.js
+++ b/src/core/account/account-reducer.js
@@ -15,6 +15,7 @@ import {
   type EdgeWalletStates,
   type JsonObject
 } from '../../types/types.js'
+import { compare } from '../../util/compare.js'
 import { ethereumKeyToAddress } from '../../util/crypto/ethereum.js'
 import { type RootAction } from '../actions.js'
 import {
@@ -267,8 +268,22 @@ const accountInner: FatReducer<
     switch (action.type) {
       case 'ACCOUNT_CUSTOM_TOKEN_ADDED': {
         const { pluginId, tokenId, token } = action.payload
-        const { [pluginId]: oldList = {} } = state
+        const oldList = state[pluginId] ?? {}
+
+        // Has anything changed?
+        if (compare(oldList[tokenId], token)) return state
+
         const newList = { ...oldList, [tokenId]: token }
+        return { ...state, [pluginId]: newList }
+      }
+      case 'ACCOUNT_CUSTOM_TOKEN_REMOVED': {
+        const { pluginId, tokenId } = action.payload
+        const oldList = state[pluginId] ?? {}
+
+        // Has anything changed?
+        if (oldList[tokenId] == null) return state
+
+        const { [tokenId]: unused, ...newList } = oldList
         return { ...state, [pluginId]: newList }
       }
     }

--- a/src/core/account/custom-tokens.js
+++ b/src/core/account/custom-tokens.js
@@ -3,11 +3,13 @@
 import { asMaybe, asObject, asString } from 'cleaners'
 
 import {
+  type EdgeCurrencyEngine,
   type EdgeMetaToken,
   type EdgeToken,
   type EdgeTokenInfo,
   type EdgeTokenMap
 } from '../../types/types.js'
+import { getCurrencyTools } from '../plugins/plugins-selectors.js'
 import { type ApiInput } from '../root-pixie.js'
 
 /**
@@ -19,6 +21,45 @@ const asMaybeContractLocation = asMaybe(
     contractAddress: asString
   })
 )
+
+/**
+ * We need to validate the token before we can add it.
+ *
+ * If the plugin has a `getTokenId` method, just use that.
+ *
+ * Otherwise, we need to call `EdgeCurrencyEngine.addCustomToken`
+ * to validate the contract address, and then guess the tokenId from that.
+ */
+export async function getTokenId(
+  ai: ApiInput,
+  pluginId: string,
+  token: EdgeToken
+): Promise<string> {
+  // The normal code path:
+  const tools = await getCurrencyTools(ai, pluginId)
+  if (tools.getTokenId != null) {
+    return await tools.getTokenId(token)
+  }
+
+  // Find an engine (any engine) to validate our token:
+  const engine = findEngine(ai, pluginId)
+  if (engine == null) {
+    throw new Error(
+      'A wallet must exist before adding tokens to a legacy currency plugin'
+    )
+  }
+
+  // Validate the token:
+  const tokenInfo = makeTokenInfo(token)
+  if (tokenInfo == null) {
+    throw new Error(
+      'A token must have a contract address to be added to a legacy currency plugin'
+    )
+  }
+  engine.addCustomToken({ ...tokenInfo, ...token })
+
+  return contractToTokenId(tokenInfo.contractAddress)
+}
 
 export function contractToTokenId(contractAddress: string): string {
   return contractAddress.toLowerCase().replace(/^0x/, '')
@@ -70,6 +111,19 @@ export function makeMetaTokens(tokens: EdgeTokenMap = {}): EdgeMetaToken[] {
   return out
 }
 
+export function makeTokenInfo(token: EdgeToken): EdgeTokenInfo | void {
+  const { currencyCode, displayName, denominations, networkLocation } = token
+  const cleanLocation = asMaybeContractLocation(networkLocation)
+  if (cleanLocation == null) return
+
+  return {
+    currencyCode,
+    currencyName: displayName,
+    multiplier: denominations[0].multiplier,
+    contractAddress: cleanLocation.contractAddress
+  }
+}
+
 export async function loadBuiltinTokens(
   ai: ApiInput,
   accountId: string
@@ -90,4 +144,17 @@ export async function loadBuiltinTokens(
       })
     })
   )
+}
+
+function findEngine(ai: ApiInput, pluginId: string): EdgeCurrencyEngine | void {
+  for (const walletId of Object.keys(ai.props.state.currency.wallets)) {
+    const walletOutput = ai.props.output.currency.wallets[walletId]
+    if (
+      walletOutput != null &&
+      walletOutput.engine != null &&
+      ai.props.state.currency.wallets[walletId].pluginId === pluginId
+    ) {
+      return walletOutput.engine
+    }
+  }
 }

--- a/src/core/account/plugin-api.js
+++ b/src/core/account/plugin-api.js
@@ -8,6 +8,7 @@ import {
   type EdgeOtherMethods,
   type EdgeSwapConfig,
   type EdgeSwapInfo,
+  type EdgeToken,
   type EdgeTokenMap,
   type JsonObject
 } from '../../types/types.js'
@@ -17,6 +18,7 @@ import {
   changePluginUserSettings,
   changeSwapSettings
 } from './account-files.js'
+import { getTokenId } from './custom-tokens.js'
 
 /**
  * Access to an individual currency plugin's methods.
@@ -57,6 +59,41 @@ export class CurrencyConfig extends Bridgeable<EdgeCurrencyConfig> {
     const { state } = this._ai.props
     const { _accountId: accountId, _pluginId: pluginId } = this
     return state.accounts[accountId].customTokens[pluginId]
+  }
+
+  async addCustomToken(token: EdgeToken): Promise<string> {
+    const { _accountId: accountId, _ai: ai, _pluginId: pluginId } = this
+    const tokenId = await getTokenId(ai, pluginId, token)
+
+    ai.props.dispatch({
+      type: 'ACCOUNT_CUSTOM_TOKEN_ADDED',
+      payload: { accountId, pluginId, tokenId, token }
+    })
+    return tokenId
+  }
+
+  async changeCustomToken(tokenId: string, token: EdgeToken): Promise<void> {
+    const { _accountId: accountId, _ai: ai, _pluginId: pluginId } = this
+    const newTokenId = await getTokenId(ai, pluginId, token)
+    if (newTokenId !== tokenId) {
+      throw new Error(
+        `The tokenId would change from ${tokenId} to ${newTokenId}`
+      )
+    }
+
+    ai.props.dispatch({
+      type: 'ACCOUNT_CUSTOM_TOKEN_ADDED',
+      payload: { accountId, pluginId, tokenId, token }
+    })
+  }
+
+  async removeCustomToken(tokenId: string): Promise<void> {
+    const { _accountId: accountId, _ai: ai, _pluginId: pluginId } = this
+
+    ai.props.dispatch({
+      type: 'ACCOUNT_CUSTOM_TOKEN_REMOVED',
+      payload: { accountId, pluginId, tokenId }
+    })
   }
 
   get userSettings(): JsonObject {

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -67,6 +67,14 @@ export type RootAction =
       }
     }
   | {
+      // We have just read the custom tokens from disk.
+      type: 'ACCOUNT_CUSTOM_TOKENS_LOADED',
+      payload: {
+        accountId: string,
+        customTokens: EdgePluginMap<EdgeTokenMap>
+      }
+    }
+  | {
       // The account fires this when it loads its keys from disk.
       type: 'ACCOUNT_KEYS_LOADED',
       payload: {

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -58,6 +58,15 @@ export type RootAction =
       }
     }
   | {
+      // Somebody just removed a custom token.
+      type: 'ACCOUNT_CUSTOM_TOKEN_REMOVED',
+      payload: {
+        accountId: string,
+        pluginId: string,
+        tokenId: string
+      }
+    }
+  | {
       // The account fires this when it loads its keys from disk.
       type: 'ACCOUNT_KEYS_LOADED',
       payload: {

--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -226,11 +226,19 @@ export function makeCurrencyWalletApi(
     async addCustomToken(tokenInfo: EdgeTokenInfo): Promise<void> {
       const token = upgradeTokenInfo(tokenInfo)
       const tokenId = contractToTokenId(tokenInfo.contractAddress)
+
+      // Ask the plugin to validate this:
+      if (tools.getTokenId != null) {
+        await tools.getTokenId(token)
+      } else {
+        // This is not ideal, since the pixie will add it too:
+        await engine.addCustomToken({ ...token, ...tokenInfo })
+      }
+
       ai.props.dispatch({
         type: 'ACCOUNT_CUSTOM_TOKEN_ADDED',
         payload: { accountId, pluginId, tokenId, token }
       })
-      await engine.addCustomToken({ ...token, ...tokenInfo })
     },
 
     // Transactions:

--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -9,6 +9,7 @@ import {
   type EdgeCurrencyCodeOptions,
   type EdgeCurrencyEngine,
   type EdgeCurrencyInfo,
+  type EdgeCurrencyTools,
   type EdgeCurrencyWallet,
   type EdgeDataDump,
   type EdgeEncodeUri,
@@ -32,8 +33,7 @@ import {
   makeMetaTokens,
   upgradeTokenInfo
 } from '../../account/custom-tokens.js'
-import { getCurrencyTools } from '../../plugins/plugins-selectors.js'
-import { type ApiInput } from '../../root-pixie.js'
+import { toApiInput } from '../../root-pixie.js'
 import { makeStorageWalletApi } from '../../storage/storage-api.js'
 import { getCurrencyMultiplier } from '../currency-selectors.js'
 import { makeCurrencyWalletCallbacks } from './currency-wallet-callbacks.js'
@@ -71,9 +71,10 @@ type SavedSpendTargets = $ElementType<EdgeTransaction, 'spendTargets'> & any[]
 export function makeCurrencyWalletApi(
   input: CurrencyWalletInput,
   engine: EdgeCurrencyEngine,
+  tools: EdgeCurrencyTools,
   publicWalletInfo: EdgeWalletInfo
 ): EdgeCurrencyWallet {
-  const ai: ApiInput = (input: any) // Safe, since input extends ApiInput
+  const ai = toApiInput(input)
   const { accountId, pluginId, walletInfo } = input.props.walletState
   const plugin = input.props.state.plugins.currency[pluginId]
 
@@ -141,7 +142,6 @@ export function makeCurrencyWalletApi(
       return plugin.currencyInfo
     },
     async validateMemo(memo: string): Promise<EdgeMemoRules> {
-      const tools = await getCurrencyTools(ai, pluginId)
       if (tools.validateMemo == null) return { passed: true }
       return await tools.validateMemo(memo)
     },
@@ -535,7 +535,6 @@ export function makeCurrencyWalletApi(
     },
 
     async parseUri(uri: string, currencyCode?: string): Promise<EdgeParsedUri> {
-      const tools = await getCurrencyTools(ai, pluginId)
       return tools.parseUri(
         uri,
         currencyCode,
@@ -546,7 +545,6 @@ export function makeCurrencyWalletApi(
     },
 
     async encodeUri(options: EdgeEncodeUri): Promise<string> {
-      const tools = await getCurrencyTools(ai, pluginId)
       return tools.encodeUri(
         options,
         makeMetaTokens(

--- a/src/core/currency/wallet/currency-wallet-files.js
+++ b/src/core/currency/wallet/currency-wallet-files.js
@@ -11,7 +11,7 @@ import { makeJsonFile } from '../../../util/file-helpers.js'
 import { mergeDeeply } from '../../../util/util.js'
 import { fetchAppIdInfo } from '../../account/lobby-api.js'
 import { getExchangeRate } from '../../exchange/exchange-selectors.js'
-import { type ApiInput } from '../../root-pixie.js'
+import { toApiInput } from '../../root-pixie.js'
 import { type RootState } from '../../root-reducer.js'
 import {
   getStorageWalletDisklet,
@@ -170,12 +170,11 @@ async function loadNameFile(input: CurrencyWalletInput): Promise<void> {
   let name: string | null = null
   if (clean == null || clean.walletName == null) {
     // If a wallet has no name file, try to pick a name based on the appId:
-    const ai: ApiInput = (input: any) // Safe, since input extends ApiInput
     const { appIds = [] } = input.props.walletState.walletInfo
 
     const appId = appIds.find(appId => appId !== '')
     if (appId != null) {
-      const { displayName } = await fetchAppIdInfo(ai, appId)
+      const { displayName } = await fetchAppIdInfo(toApiInput(input), appId)
       name = displayName
     }
   } else {

--- a/src/core/root-pixie.js
+++ b/src/core/root-pixie.js
@@ -37,6 +37,12 @@ export type RootProps = {
 
 export type ApiInput = PixieInput<RootProps>
 
+/**
+ * Downstream pixies take props that extend from `RootProps`,
+ * so this casts those back down if necessary.
+ */
+export const toApiInput = (input: PixieInput<any>): ApiInput => input
+
 export const rootPixie: TamePixie<RootProps> = combinePixies({
   accounts,
   context,

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -317,7 +317,7 @@ export type EdgeCurrencyInfo = {
 
   // Deprecated:
   defaultSettings: JsonObject, // The default user settings are `{}`
-  metaTokens: EdgeMetaToken[], // Use `EdgeCurrencyPlugins.getBuiltinTokens`
+  metaTokens: EdgeMetaToken[], // Use `EdgeCurrencyPlugin.getBuiltinTokens`
   symbolImage?: string, // The GUI handles this now
   symbolImageDarkMono?: string // The GUI handles this now
 }

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -558,9 +558,14 @@ export type EdgeCurrencyEngineCallbacks = {
 
 export type EdgeCurrencyEngineOptions = {
   callbacks: EdgeCurrencyEngineCallbacks,
-  log: EdgeLog, // Wallet-scoped logging
+
+  // Wallet-scoped IO objects:
+  log: EdgeLog,
   walletLocalDisklet: Disklet,
   walletLocalEncryptedDisklet: Disklet,
+
+  // User settings:
+  customTokens: EdgeTokenMap,
   userSettings: JsonObject | void
 }
 
@@ -587,11 +592,10 @@ export type EdgeCurrencyEngine = {
   +getTxids?: () => EdgeTxidMap,
 
   // Tokens:
+  +changeCustomTokens?: (tokens: EdgeTokenMap) => Promise<void>,
   +enableTokens: (tokens: string[]) => Promise<void>,
   +disableTokens: (tokens: string[]) => Promise<void>,
   +getEnabledTokens: () => Promise<string[]>,
-  +addCustomToken: (token: EdgeTokenInfo & EdgeToken) => Promise<void>,
-  +getTokenStatus: (token: string) => boolean,
 
   // Addresses:
   +getFreshAddress: (
@@ -615,7 +619,11 @@ export type EdgeCurrencyEngine = {
   +getStakingStatus?: () => Promise<EdgeStakingStatus>,
 
   // Escape hatch:
-  +otherMethods?: EdgeOtherMethods
+  +otherMethods?: EdgeOtherMethods,
+
+  // Deprecated:
+  +addCustomToken: (token: EdgeTokenInfo & EdgeToken) => Promise<void>,
+  +getTokenStatus: (token: string) => boolean
 }
 
 // currency plugin -----------------------------------------------------
@@ -638,6 +646,9 @@ export type EdgeCurrencyTools = {
   +getSplittableTypes?: (
     walletInfo: EdgeWalletInfo
   ) => string[] | Promise<string[]>,
+
+  // Derives a tokenId string from a token's network information:
+  +getTokenId?: (token: EdgeToken) => Promise<string>,
 
   // URIs:
   +parseUri: (
@@ -736,7 +747,6 @@ export type EdgeCurrencyWallet = {
   +enableTokens: (tokens: string[]) => Promise<void>,
   +disableTokens: (tokens: string[]) => Promise<void>,
   +getEnabledTokens: () => Promise<string[]>,
-  +addCustomToken: (token: EdgeTokenInfo) => Promise<void>,
 
   // Transaction history:
   +getNumTransactions: (opts?: EdgeCurrencyCodeOptions) => Promise<number>,
@@ -778,7 +788,10 @@ export type EdgeCurrencyWallet = {
   +parseUri: (uri: string, currencyCode?: string) => Promise<EdgeParsedUri>,
   +encodeUri: (obj: EdgeEncodeUri) => Promise<string>,
 
-  +otherMethods: EdgeOtherMethods
+  +otherMethods: EdgeOtherMethods,
+
+  // Deprecated:
+  +addCustomToken: (token: EdgeTokenInfo) => Promise<void>
 }
 
 // ---------------------------------------------------------------------
@@ -924,6 +937,9 @@ export type EdgeCurrencyConfig = {
   // Tokens:
   +builtinTokens: EdgeTokenMap,
   +customTokens: EdgeTokenMap,
+  +addCustomToken: (token: EdgeToken) => Promise<string>,
+  +changeCustomToken: (tokenId: string, token: EdgeToken) => Promise<void>,
+  +removeCustomToken: (tokenId: string) => Promise<void>,
 
   // User settings for this plugin:
   +userSettings: JsonObject | void,

--- a/src/util/snooze.js
+++ b/src/util/snooze.js
@@ -1,0 +1,5 @@
+// @flow
+
+export function snooze(ms: number): Promise<number> {
+  return new Promise(resolve => setTimeout(() => resolve(ms), ms))
+}

--- a/test/util/promise.test.js
+++ b/test/util/promise.test.js
@@ -4,11 +4,8 @@ import { expect } from 'chai'
 import { describe, it } from 'mocha'
 
 import { fuzzyTimeout } from '../../src/util/promise.js'
+import { snooze } from '../../src/util/snooze.js'
 import { expectRejection } from '../expect-rejection.js'
-
-export function snooze(ms: number): Promise<number> {
-  return new Promise(resolve => setTimeout(() => resolve(ms), ms))
-}
 
 describe('promise', function () {
   it('fuzzyTimeout resolves', async function () {


### PR DESCRIPTION
This moves the loading & saving of custom tokens into the core, instead of the GUI.

This is not a breaking change, since the core will just ignore already-existing tokens if the GUI adds them. Once we publish this, we can simply delete a bunch of code from the GUI.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201833665439726