### PR TITLE
Update the API for enabled tokens

### DIFF
--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -238,6 +238,13 @@ export type RootAction =
       }
     }
   | {
+      type: 'CURRENCY_WALLET_ENABLED_TOKENS_CHANGED',
+      payload: {
+        currencyCodes: string[],
+        walletId: string
+      }
+    }
+  | {
       // Called when a currency wallet receives a new name.
       type: 'CURRENCY_WALLET_FIAT_CHANGED',
       payload: {

--- a/src/core/currency/wallet/currency-wallet-cleaners.js
+++ b/src/core/currency/wallet/currency-wallet-cleaners.js
@@ -114,6 +114,10 @@ type LegacyMapFile = {
   [fileName: string]: { timestamp: number, txidHash: string }
 }
 
+// ---------------------------------------------------------------------
+// building-block cleaners
+// ---------------------------------------------------------------------
+
 /**
  * Turns user-provided metadata into its on-disk format.
  */
@@ -183,6 +187,18 @@ const asDiskMetadata: Cleaner<DiskMetadata> = asObject({
   name: asOptional(asString),
   notes: asOptional(asString)
 })
+
+// ---------------------------------------------------------------------
+// file cleaners
+// ---------------------------------------------------------------------
+
+/**
+ * This uses currency codes, since we cannot break the data on disk.
+ * To fix this one day, we can either migrate to a new file name,
+ * or we can use `asEither` to switch between this format
+ * and some new format based on token ID's.
+ */
+export const asEnabledTokensFile: Cleaner<string[]> = asArray(asString)
 
 export const asTransactionFile: Cleaner<TransactionFile> = asObject({
   txid: asString,

--- a/src/core/currency/wallet/currency-wallet-pixie.js
+++ b/src/core/currency/wallet/currency-wallet-pixie.js
@@ -81,6 +81,7 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
         input.props.io
       )
 
+      // Derive the public keys:
       const tools = await getCurrencyTools(ai, pluginId)
       const publicWalletInfo = await getPublicWalletInfo(
         walletInfo,
@@ -112,6 +113,7 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
 
         // User settings:
         customTokens: accountState.customTokens[pluginId] ?? {},
+        enabledTokenIds: input.props.walletState.enabledTokenIds,
         userSettings: accountState.userSettings[pluginId] ?? {}
       })
       input.props.dispatch({
@@ -278,6 +280,7 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
     let lastState
     let lastSettings: JsonObject = {}
     let lastTokens: EdgeTokenMap = {}
+    let lastEnabledTokens: string[] = []
 
     return async () => {
       const { state, walletState, walletOutput } = input.props
@@ -317,6 +320,28 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
         }
       }
       lastTokens = customTokens
+
+      // Update enabled tokens:
+      const { enabledTokens } = walletState
+      if (lastEnabledTokens !== enabledTokens && engine != null) {
+        if (engine.changeEnabledTokenIds != null) {
+          await engine
+            .changeEnabledTokenIds(walletState.enabledTokenIds)
+            .catch(e => input.props.onError(e))
+        } else {
+          await engine
+            .disableTokens(
+              lastEnabledTokens.filter(code => enabledTokens.indexOf(code) < 0)
+            )
+            .catch(e => input.props.onError(e))
+          await engine
+            .enableTokens(
+              enabledTokens.filter(code => lastEnabledTokens.indexOf(code) < 0)
+            )
+            .catch(e => input.props.onError(e))
+        }
+      }
+      lastEnabledTokens = enabledTokens
     }
   }
 })

--- a/src/core/currency/wallet/currency-wallet-pixie.js
+++ b/src/core/currency/wallet/currency-wallet-pixie.js
@@ -279,7 +279,7 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
     let lastSettings: JsonObject = {}
     let lastTokens: EdgeTokenMap = {}
 
-    return () => {
+    return async () => {
       const { state, walletState, walletOutput } = input.props
       if (walletState == null || walletOutput == null) return
       const { engine, walletApi } = walletOutput
@@ -310,7 +310,9 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
             if (token === lastTokens[tokenId]) continue
             const tokenInfo = makeTokenInfo(token)
             if (tokenInfo == null) continue
-            engine.addCustomToken({ ...tokenInfo, ...token })
+            await engine
+              .addCustomToken({ ...tokenInfo, ...token })
+              .catch(e => input.props.onError(e))
           }
         }
       }

--- a/src/core/currency/wallet/enabled-tokens.js
+++ b/src/core/currency/wallet/enabled-tokens.js
@@ -1,0 +1,56 @@
+// @flow
+
+import {
+  type EdgeCurrencyInfo,
+  type EdgeTokenMap
+} from '../../../types/types.js'
+
+function flipTokenMap(
+  tokens: EdgeTokenMap
+): { [currencyCode: string]: string } {
+  const out: { [currencyCode: string]: string } = {}
+  for (const tokenId of Object.keys(tokens)) {
+    const token = tokens[tokenId]
+    out[token.currencyCode] = tokenId
+  }
+  return out
+}
+
+export function currencyCodesToTokenIds(
+  builtinTokens: EdgeTokenMap = {},
+  customTokens: EdgeTokenMap = {},
+  currencyInfo: EdgeCurrencyInfo,
+  currencyCodes: string[]
+): string[] {
+  const builtinIds = flipTokenMap(builtinTokens)
+  const customIds = flipTokenMap(customTokens)
+
+  const out: string[] = []
+  for (const currencyCode of currencyCodes) {
+    if (currencyCode === currencyInfo.currencyCode) {
+      out.push('')
+    } else {
+      const tokenId = customIds[currencyCode] ?? builtinIds[currencyCode]
+      if (tokenId != null) out.push(tokenId)
+    }
+  }
+  return out
+}
+
+export function tokenIdsToCurrencyCodes(
+  builtinTokens: EdgeTokenMap = {},
+  customTokens: EdgeTokenMap = {},
+  currencyInfo: EdgeCurrencyInfo,
+  tokenIds: string[]
+): string[] {
+  const out: string[] = []
+  for (const tokenId of tokenIds) {
+    if (tokenId === '') {
+      out.push(currencyInfo.currencyCode)
+    } else {
+      const token = customTokens[tokenId] ?? builtinTokens[tokenId]
+      if (token != null) out.push(token.currencyCode)
+    }
+  }
+  return out
+}

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -566,6 +566,7 @@ export type EdgeCurrencyEngineOptions = {
 
   // User settings:
   customTokens: EdgeTokenMap,
+  enabledTokenIds: string[],
   userSettings: JsonObject | void
 }
 
@@ -593,9 +594,7 @@ export type EdgeCurrencyEngine = {
 
   // Tokens:
   +changeCustomTokens?: (tokens: EdgeTokenMap) => Promise<void>,
-  +enableTokens: (tokens: string[]) => Promise<void>,
-  +disableTokens: (tokens: string[]) => Promise<void>,
-  +getEnabledTokens: () => Promise<string[]>,
+  +changeEnabledTokenIds?: (tokenIds: string[]) => Promise<void>,
 
   // Addresses:
   +getFreshAddress: (
@@ -622,6 +621,9 @@ export type EdgeCurrencyEngine = {
   +otherMethods?: EdgeOtherMethods,
 
   // Deprecated:
+  +enableTokens: (tokens: string[]) => Promise<void>,
+  +disableTokens: (tokens: string[]) => Promise<void>,
+  +getEnabledTokens: () => Promise<string[]>,
   +addCustomToken: (token: EdgeTokenInfo & EdgeToken) => Promise<void>,
   +getTokenStatus: (token: string) => boolean
 }
@@ -743,10 +745,10 @@ export type EdgeCurrencyWallet = {
   +changePaused: (paused: boolean) => Promise<void>,
 
   // Token management:
-  +changeEnabledTokens: (currencyCodes: string[]) => Promise<void>,
-  +enableTokens: (tokens: string[]) => Promise<void>,
-  +disableTokens: (tokens: string[]) => Promise<void>,
-  +getEnabledTokens: () => Promise<string[]>,
+  // Available tokens can be found in `EdgeCurrencyConfig`.
+  // This list is allowed to include missing or deleted `tokenIds`:
+  +enabledTokenIds: string[],
+  +changeEnabledTokenIds: (tokenIds: string[]) => Promise<void>,
 
   // Transaction history:
   +getNumTransactions: (opts?: EdgeCurrencyCodeOptions) => Promise<number>,
@@ -791,6 +793,10 @@ export type EdgeCurrencyWallet = {
   +otherMethods: EdgeOtherMethods,
 
   // Deprecated:
+  +changeEnabledTokens: (currencyCodes: string[]) => Promise<void>,
+  +disableTokens: (tokens: string[]) => Promise<void>,
+  +enableTokens: (tokens: string[]) => Promise<void>,
+  +getEnabledTokens: () => Promise<string[]>,
   +addCustomToken: (token: EdgeTokenInfo) => Promise<void>
 }
 

--- a/test/core/currency/wallet/currency-wallet.test.js
+++ b/test/core/currency/wallet/currency-wallet.test.js
@@ -234,6 +234,32 @@ describe('currency wallets', function () {
     })
   })
 
+  it('enables tokens', async function () {
+    const log = makeAssertLog()
+    const { wallet } = await makeFakeCurrencyWallet()
+    const tokenId =
+      'f98103e9217f099208569d295c1b276f1821348636c268c854bb2a086e0037cd'
+
+    wallet.watch('enabledTokenIds', ids => log(ids.join(', ')))
+    expect(wallet.enabledTokenIds).deep.equals([])
+
+    // New API:
+    await wallet.changeEnabledTokenIds([tokenId])
+    expect(wallet.enabledTokenIds).deep.equals([tokenId])
+    log.assert(tokenId)
+
+    // Legacy API:
+    await wallet.enableTokens(['OOPS', 'MISSING'])
+    expect(await wallet.getEnabledTokens()).deep.equals([
+      'MISSING',
+      'OOPS',
+      'TOKEN'
+    ])
+
+    // The last update hand missing ID's, but an update still occurs:
+    log.assert(tokenId)
+  })
+
   it('search transactions', async function () {
     const { wallet, config } = await makeFakeCurrencyWallet()
     await config.changeUserSettings({


### PR DESCRIPTION
 - Add new methods and properties based on tokenIds.
 - Deprecate old methods based on currency codes.
 - Save the data to disk.
 - Make this information more readily available to the GUI and the engine.
