### PR TITLE
Add an `EdgeCurrencyWallet.currencyConfig` property

### DIFF
--- a/src/core/currency/wallet/currency-wallet-api.js
+++ b/src/core/currency/wallet/currency-wallet-api.js
@@ -7,6 +7,7 @@ import { bridgifyObject, onMethod, watchMethod } from 'yaob'
 import {
   type EdgeBalances,
   type EdgeCurrencyCodeOptions,
+  type EdgeCurrencyConfig,
   type EdgeCurrencyEngine,
   type EdgeCurrencyInfo,
   type EdgeCurrencyTools,
@@ -140,6 +141,10 @@ export function makeCurrencyWalletApi(
     },
 
     // Currency info:
+    get currencyConfig(): EdgeCurrencyConfig {
+      const { accountApi } = input.props.output.accounts[accountId]
+      return accountApi.currencyConfig[pluginId]
+    },
     get currencyInfo(): EdgeCurrencyInfo {
       return plugin.currencyInfo
     },

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -724,6 +724,7 @@ export type EdgeCurrencyWallet = {
   +setFiatCurrencyCode: (fiatCurrencyCode: string) => Promise<void>,
 
   // Currency info:
+  +currencyConfig: EdgeCurrencyConfig, // eslint-disable-line no-use-before-define
   +currencyInfo: EdgeCurrencyInfo,
   +validateMemo: (memo: string) => Promise<EdgeMemoRules>,
   +nativeToDenomination: (

--- a/test/core/currency/wallet/currency-wallet.test.js
+++ b/test/core/currency/wallet/currency-wallet.test.js
@@ -76,6 +76,11 @@ describe('currency wallets', function () {
     })
   })
 
+  it('has the right currencyConfig object', async function () {
+    const { account, wallet } = await makeFakeCurrencyWallet()
+    expect(account.currencyConfig.fakecoin).equals(wallet.currencyConfig)
+  })
+
   it('triggers callbacks', async function () {
     const log = makeAssertLog()
     const { wallet, config } = await makeFakeCurrencyWallet()
@@ -190,9 +195,8 @@ describe('currency wallets', function () {
   })
 
   it('exposes builtin tokens', async function () {
-    const { account } = await makeFakeCurrencyWallet()
+    const { config } = await makeFakeCurrencyWallet()
 
-    const config = account.currencyConfig.fakecoin
     expect(config.builtinTokens).deep.equals({
       f98103e9217f099208569d295c1b276f1821348636c268c854bb2a086e0037cd: {
         currencyCode: 'TOKEN',
@@ -208,8 +212,7 @@ describe('currency wallets', function () {
 
   it('exposes custom tokens', async function () {
     const log = makeAssertLog()
-    const { account, wallet } = await makeFakeCurrencyWallet()
-    const config = account.currencyConfig.fakecoin
+    const { config, wallet } = await makeFakeCurrencyWallet()
 
     config.watch('customTokens', () => log('customTokens changed'))
     await wallet.addCustomToken({


### PR DESCRIPTION
This makes the wallet self-contained - given an `EdgeCurrencyWallet`, you can access everything needed to convert and display currencies.