### PR TITLE
Do not trigger token-saving based on the intial load

### DIFF
--- a/src/core/account/account-pixie.js
+++ b/src/core/account/account-pixie.js
@@ -28,7 +28,7 @@ import {
 } from '../storage/storage-actions.js'
 import { makeAccountApi } from './account-api.js'
 import { loadAllWalletStates, reloadPluginSettings } from './account-files.js'
-import { type AccountState } from './account-reducer.js'
+import { type AccountState, initialCustomTokens } from './account-reducer.js'
 import {
   loadBuiltinTokens,
   loadCustomTokens,
@@ -183,13 +183,13 @@ const accountPixie: TamePixie<AccountProps> = combinePixies({
    * we will consolidate those down to a single write to disk.
    */
   tokenSaver(input: AccountInput) {
-    let lastTokens: EdgePluginMap<EdgeTokenMap> | void
+    let lastTokens: EdgePluginMap<EdgeTokenMap> = initialCustomTokens
 
     return async function update() {
       const { accountId, accountState } = input.props
 
       const { customTokens } = accountState
-      if (customTokens !== lastTokens && lastTokens != null) {
+      if (customTokens !== lastTokens && lastTokens !== initialCustomTokens) {
         await saveCustomTokens(toApiInput(input), accountId).catch(error =>
           input.props.onError(error)
         )

--- a/src/core/account/account-reducer.js
+++ b/src/core/account/account-reducer.js
@@ -74,6 +74,8 @@ export type AccountNext = {
   +self: AccountState
 }
 
+export const initialCustomTokens: EdgePluginMap<EdgeTokenMap> = {}
+
 const accountInner: FatReducer<
   AccountState,
   RootAction,
@@ -298,7 +300,10 @@ const accountInner: FatReducer<
     return state
   },
 
-  customTokens(state = {}, action: RootAction): EdgePluginMap<EdgeTokenMap> {
+  customTokens(
+    state = initialCustomTokens,
+    action: RootAction
+  ): EdgePluginMap<EdgeTokenMap> {
     switch (action.type) {
       case 'ACCOUNT_CUSTOM_TOKENS_LOADED': {
         const { customTokens } = action.payload


### PR DESCRIPTION
Redux updates trigger the auto-save, but we don't want the intial load to do this.