### PR TITLE
Loosen constraint for checking tx confirmation status

### DIFF
--- a/src/core/currency/wallet/currency-wallet-callbacks.js
+++ b/src/core/currency/wallet/currency-wallet-callbacks.js
@@ -235,7 +235,10 @@ export function makeCurrencyWalletCallbacks(
         const { txid } = tx
 
         // DEPRECATE: After all currency plugins implement new Confirmations API
-        if (tx.confirmations == null) {
+        if (
+          tx.confirmations !== 'confirmed' &&
+          tx.confirmations !== 'dropped'
+        ) {
           const { requiredConfirmations } = input.props.walletState.currencyInfo
           const { height } = input.props.walletState
 


### PR DESCRIPTION
For non-UTXO currencies, the plugins may not send an `onTransactionChanged` event when loading transactions while syncing. This makes the GUI ask for transactions through the `getTransactions` API, which does a pass-through to the engine's `getTransaction` method. Somehow, the plugin's engine transaction-list state has a defined `confirmations` field for each transaction; in turn the core passes the these txs to the `onTransactionChanged` method and it wont update the `confirmations` field for the transactions because the field is defined.

The solution is to always update `confirmations` field except for these "static" field values which are `"confirmed"` and `"dropped"` in the `onTransactionUpdated` callback. This is an identical condition in `onBlockHeightChanged`.