### PR TITLE
Allow plugins to fail to load

### DIFF
--- a/src/core/plugins/plugins-reducer.js
+++ b/src/core/plugins/plugins-reducer.js
@@ -44,6 +44,14 @@ export const plugins = (
       }
       for (const pluginId of Object.keys(action.payload)) {
         const plugin = action.payload[pluginId]
+
+        // Don't stop loading the bundle if plugin(s) fail to load. Some plugins may rely on advanced features
+        // that aren't locally available so we can skip loading those but should continue and load what we can.
+        if (plugin == null) {
+          out.init = { ...out.init, [pluginId]: false }
+          continue
+        }
+
         // $FlowFixMe - Flow doesn't see the type refinement here:
         if (plugin.currencyInfo != null) out.currency[pluginId] = plugin
         // $FlowFixMe


### PR DESCRIPTION
This was tested by breaking a currency plugin on devices that don't support bigints. It does not blow up. The app loads normally without any mention of the broken plugin.

This has not been tested with other types of plugins like rates or swaps.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202654362524309