### PR TITLE
Allow 'hex' as a valid memo data type

### DIFF
--- a/src/types/types.js
+++ b/src/types/types.js
@@ -307,7 +307,7 @@ export type EdgeCurrencyInfo = {
   requiredConfirmations?: number, // Block confirmations required for a tx
   memoMaxLength?: number, // Max number of text characters, if supported
   memoMaxValue?: string, // Max numerical value, if supported
-  memoType?: 'text' | 'number' | 'other', // undefined means no memo support
+  memoType?: 'text' | 'number' | 'hex' | 'other', // undefined means no memo support
 
   // Explorers:
   addressExplorer: string,


### PR DESCRIPTION
EVM chains allow raw binary data in their transactions. We should extend `EdgeCurrencyInfo` to represent this, so the GUI can show the data (if needed), but won't necessarily provide a way to edit the data (as it does for chains that accept arbitrary text or numbers).