### PR TITLE
Improve the OTP error cleaner

### DIFF
--- a/src/types/server-cleaners.js
+++ b/src/types/server-cleaners.js
@@ -315,7 +315,7 @@ export const asOtpErrorPayload: Cleaner<OtpErrorPayload> = asObject({
   login_id: asOptional(asBase64),
   otp_reset_auth: asOptional(asString),
   otp_timeout_date: asOptional(asDate),
-  reason: asOptional(asString),
+  reason: asOptional(asValue('ip', 'otp'), 'otp'),
   voucher_activates: asOptional(asDate),
   voucher_auth: asOptional(asBase64),
   voucher_id: asOptional(asString)

--- a/src/types/server-types.js
+++ b/src/types/server-types.js
@@ -248,10 +248,19 @@ export type MessagesPayload = Array<{
  * Returned when the 2fa authentication fails.
  */
 export type OtpErrorPayload = {
+  // This should usually be present:
   login_id?: Uint8Array,
+
+  // Use this to request an OTP reset (if enabled):
   otp_reset_auth?: string,
+
+  // Set if an OTP reset has already been requested:
   otp_timeout_date?: Date,
-  reason?: string,
+
+  // We might also get a different reason:
+  reason: 'ip' | 'otp',
+
+  // We might also get a login voucher:
   voucher_activates?: Date,
   voucher_auth?: Uint8Array,
   voucher_id?: string


### PR DESCRIPTION
Cleaners are doing a bunch of work already, so we can replace the try / catch with `asMaybe`, and rely on the cleaner to check for null, so we can use fewer if statements.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203232868265425