### PR TITLE
Increase BCH replay protection transaction value amount

### DIFF
--- a/src/core/login/keys.js
+++ b/src/core/login/keys.js
@@ -358,7 +358,7 @@ async function protectBchWallet(wallet: EdgeCurrencyWallet): Promise<void> {
     currencyCode: 'BCH',
     spendTargets: [
       {
-        nativeAmount: '1000',
+        nativeAmount: '10000',
         otherParams: { script: { type: 'replayProtection' } },
         publicAddress: ''
       }


### PR DESCRIPTION
The amount is too small it doesn't get included in the tainted transaction, so we must increase it by an order of magnitude.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203247465719862