### PR TITLE
Accept tokenId's for spending and swapping

### DIFF
--- a/scripts/make-types.js
+++ b/scripts/make-types.js
@@ -37,9 +37,10 @@ const files = [
   { js: 'src/types/error.js', ts: 'lib/types/error.ts' },
   { js: 'src/types/exports.js', ts: 'lib/types/exports.ts' },
   { js: 'src/types/fake-types.js', ts: 'lib/types/fake-types.ts' },
-  { js: 'src/types/types.js', ts: 'lib/types/types.ts' },
+  { js: 'src/types/server-cleaners.js', ts: 'lib/types/server-cleaners.ts' },
   { js: 'src/types/server-types.js', ts: 'lib/types/server-types.ts' },
-  { js: 'src/types/server-cleaners.js', ts: 'lib/types/server-cleaners.ts' }
+  { js: 'src/types/type-helpers.js', ts: 'lib/types/type-helpers.ts' },
+  { js: 'src/types/types.js', ts: 'lib/types/types.ts' }
 ]
 
 async function main() {

--- a/src/core/swap/swap-api.js
+++ b/src/core/swap/swap-api.js
@@ -3,6 +3,7 @@
 import { gt, lt } from 'biggystring'
 import { bridgifyObject } from 'yaob'
 
+import { upgradeCurrencyCode } from '../../types/type-helpers.js'
 import {
   type EdgePluginMap,
   type EdgeSwapQuote,
@@ -33,6 +34,27 @@ export async function fetchSwapQuote(
   const account = ai.props.state.accounts[accountId]
   const { swapSettings, userSettings } = account
   const swapPlugins = ai.props.state.plugins.swap
+
+  // Upgrade legacy currency codes:
+  const from = upgradeCurrencyCode({
+    allTokens: request.fromWallet.currencyConfig.allTokens,
+    currencyInfo: request.fromWallet.currencyInfo,
+    currencyCode: request.fromCurrencyCode,
+    tokenId: request.fromTokenId
+  })
+  const to = upgradeCurrencyCode({
+    allTokens: request.toWallet.currencyConfig.allTokens,
+    currencyInfo: request.toWallet.currencyInfo,
+    currencyCode: request.toCurrencyCode,
+    tokenId: request.toTokenId
+  })
+  request = {
+    ...request,
+    fromTokenId: from.tokenId,
+    toTokenId: to.tokenId,
+    fromCurrencyCode: from.currencyCode,
+    toCurrencyCode: to.currencyCode
+  }
 
   log.warn(
     'Requesting swap quotes for: ',

--- a/src/types/type-helpers.js
+++ b/src/types/type-helpers.js
@@ -1,0 +1,33 @@
+// @flow
+
+import type { EdgeCurrencyInfo, EdgeTokenMap } from './types.js'
+
+/**
+ * Translates a currency code to a tokenId,
+ * and then back again for bi-directional backwards compatibility.
+ */
+export function upgradeCurrencyCode(opts: {
+  allTokens: EdgeTokenMap,
+  currencyInfo: EdgeCurrencyInfo,
+  currencyCode?: string,
+  tokenId?: string
+}): { currencyCode: string, tokenId?: string } {
+  const { currencyInfo, allTokens } = opts
+
+  // Find the tokenId:
+  let tokenId = opts.tokenId
+  if (
+    tokenId == null &&
+    opts.currencyCode != null &&
+    opts.currencyCode !== currencyInfo.currencyCode
+  ) {
+    tokenId = Object.keys(allTokens).find(
+      tokenId => allTokens[tokenId].currencyCode === opts.currencyCode
+    )
+  }
+
+  // Get the currency code:
+  const { currencyCode } = tokenId == null ? currencyInfo : allTokens[tokenId]
+
+  return { currencyCode, tokenId }
+}

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -422,7 +422,8 @@ export type EdgePaymentProtocolInfo = {
 
 export type EdgeSpendInfo = {
   // Basic information:
-  currencyCode?: string,
+  currencyCode?: string, // Deprecated
+  tokenId?: string,
   privateKeys?: string[],
   spendTargets: EdgeSpendTarget[],
 
@@ -827,12 +828,16 @@ export type EdgeSwapRequest = {
   toWallet: EdgeCurrencyWallet,
 
   // What?
-  fromCurrencyCode: string,
-  toCurrencyCode: string,
+  fromTokenId?: string,
+  toTokenId?: string,
 
   // How much?
   nativeAmount: string,
-  quoteFor: 'from' | 'max' | 'to'
+  quoteFor: 'from' | 'max' | 'to',
+
+  // Deprecated. Use the tokenId instead:
+  fromCurrencyCode?: string,
+  toCurrencyCode?: string
 }
 
 /**

--- a/test/fake/fake-swap-plugin.js
+++ b/test/fake/fake-swap-plugin.js
@@ -35,10 +35,6 @@ export const fakeSwapPlugin: EdgeSwapPlugin = {
     }
 
     // We don't actually support any currencies:
-    throw new SwapCurrencyError(
-      swapInfo,
-      request.fromCurrencyCode,
-      request.toCurrencyCode
-    )
+    throw new SwapCurrencyError(swapInfo, request)
   }
 }


### PR DESCRIPTION
We will upgrade the `currencyCode` into the `tokenId` if not provided, and vice-versa so the plugin remains compatible as well.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203287918505521