### PR TITLE
Add a new `alwaysEnabledTokenIds` API

### DIFF
--- a/src/core/account/account-reducer.js
+++ b/src/core/account/account-reducer.js
@@ -64,6 +64,7 @@ export type AccountState = {
   +allTokens: EdgePluginMap<EdgeTokenMap>,
   +builtinTokens: EdgePluginMap<EdgeTokenMap>,
   +customTokens: EdgePluginMap<EdgeTokenMap>,
+  +alwaysEnabledTokenIds: EdgePluginMap<string[]>,
   +swapSettings: EdgePluginMap<SwapSettings>,
   +userSettings: EdgePluginMap<JsonObject>
 }
@@ -328,6 +329,19 @@ const accountInner: FatReducer<
 
         const { [tokenId]: unused, ...newList } = oldList
         return { ...state, [pluginId]: newList }
+      }
+    }
+    return state
+  },
+
+  alwaysEnabledTokenIds(
+    state: EdgePluginMap<string[]> = {},
+    action: RootAction
+  ): EdgePluginMap<string[]> {
+    switch (action.type) {
+      case 'ACCOUNT_ALWAYS_ENABLED_TOKENS_CHANGED': {
+        const { pluginId, tokenIds } = action.payload
+        return { ...state, [pluginId]: tokenIds }
       }
     }
     return state

--- a/src/core/account/plugin-api.js
+++ b/src/core/account/plugin-api.js
@@ -22,6 +22,7 @@ import {
 import { getTokenId } from './custom-tokens.js'
 
 const emptyTokens: EdgeTokenMap = {}
+const emptyTokenIds: string[] = []
 
 /**
  * Access to an individual currency plugin's methods.
@@ -137,6 +138,23 @@ export class CurrencyConfig extends Bridgeable<EdgeCurrencyConfig> {
     ai.props.dispatch({
       type: 'ACCOUNT_CUSTOM_TOKEN_REMOVED',
       payload: { accountId, pluginId, tokenId }
+    })
+  }
+
+  get alwaysEnabledTokenIds(): string[] {
+    const { state } = this._ai.props
+    const { _accountId: accountId, _pluginId: pluginId } = this
+    return (
+      state.accounts[accountId].alwaysEnabledTokenIds[pluginId] ?? emptyTokenIds
+    )
+  }
+
+  async changeAlwaysEnabledTokenIds(tokenIds: string[]): Promise<void> {
+    const { _accountId: accountId, _ai: ai, _pluginId: pluginId } = this
+
+    ai.props.dispatch({
+      type: 'ACCOUNT_ALWAYS_ENABLED_TOKENS_CHANGED',
+      payload: { accountId, pluginId, tokenIds }
     })
   }
 

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -32,6 +32,15 @@ import {
 
 export type RootAction =
   | {
+      // Fired when somebody changes the always-enabled token list:
+      type: 'ACCOUNT_ALWAYS_ENABLED_TOKENS_CHANGED',
+      payload: {
+        accountId: string,
+        pluginId: string,
+        tokenIds: string[]
+      }
+    }
+  | {
       // A currency plugin has returned its builtin tokens.
       type: 'ACCOUNT_BUILTIN_TOKENS_LOADED',
       payload: {

--- a/src/core/currency/wallet/currency-wallet-reducer.js
+++ b/src/core/currency/wallet/currency-wallet-reducer.js
@@ -21,7 +21,7 @@ import { type RootAction } from '../../actions.js'
 import { findCurrencyPluginId } from '../../plugins/plugins-selectors.js'
 import { type RootState } from '../../root-reducer.js'
 import { type TransactionFile } from './currency-wallet-cleaners.js'
-import { currencyCodesToTokenIds } from './enabled-tokens.js'
+import { currencyCodesToTokenIds, uniqueStrings } from './enabled-tokens.js'
 
 /** Maps from txid hash to file creation date & path. */
 export type TxFileNames = {
@@ -62,6 +62,7 @@ export type CurrencyWalletState = {
 
   +paused: boolean,
 
+  +allEnabledTokenIds: string[],
   +balances: EdgeBalances,
   +currencyInfo: EdgeCurrencyInfo,
   +displayPrivateSeed: string | null,
@@ -111,6 +112,16 @@ const currencyWalletInner: FatReducer<
     }
     throw new Error(`Cannot find account for walletId ${next.id}`)
   },
+
+  allEnabledTokenIds: memoizeReducer(
+    (next: CurrencyWalletNext) =>
+      next.root.accounts[next.self.accountId].alwaysEnabledTokenIds[
+        next.self.pluginId
+      ],
+    (next: CurrencyWalletNext) => next.self.enabledTokenIds,
+    (alwaysEnabledTokenIds = [], enabledTokenIds = []) =>
+      uniqueStrings([...alwaysEnabledTokenIds, ...enabledTokenIds])
+  ),
 
   pluginId: memoizeReducer(
     next => next.root.login.walletInfos[next.id].type,

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -982,6 +982,10 @@ export type EdgeCurrencyConfig = {
   +changeCustomToken: (tokenId: string, token: EdgeToken) => Promise<void>,
   +removeCustomToken: (tokenId: string) => Promise<void>,
 
+  // Always-enabled tokens:
+  +alwaysEnabledTokenIds: string[],
+  +changeAlwaysEnabledTokenIds: (tokenIds: string[]) => Promise<void>,
+
   // User settings for this plugin:
   +userSettings: JsonObject | void,
   +changeUserSettings: (settings: JsonObject) => Promise<void>,

--- a/test/core/currency/wallet/currency-wallet.test.js
+++ b/test/core/currency/wallet/currency-wallet.test.js
@@ -264,7 +264,22 @@ describe('currency wallets', function () {
       'TOKEN'
     ])
 
-    // The last update hand missing ID's, but an update still occurs:
+    // The last update had missing ID's, but an update still occurs:
+    log.assert(tokenId)
+  })
+
+  it('supports always-enabled tokens', async function () {
+    const log = makeAssertLog()
+    const { config } = await makeFakeCurrencyWallet()
+    const tokenId =
+      'f98103e9217f099208569d295c1b276f1821348636c268c854bb2a086e0037cd'
+
+    config.watch('alwaysEnabledTokenIds', ids => log(ids.join(', ')))
+    expect(config.alwaysEnabledTokenIds).deep.equals([])
+
+    // Change the config object:
+    await config.changeAlwaysEnabledTokenIds([tokenId])
+    expect(config.alwaysEnabledTokenIds).deep.equals([tokenId])
     log.assert(tokenId)
   })
 


### PR DESCRIPTION
These tokens will add to the per-wallet enabled token list, so the engine will always check the balances on these other currencies.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203582470755080