### PR TITLE
Add support for token activation

### DIFF
--- a/src/core/actions.ts
+++ b/src/core/actions.ts
@@ -313,6 +313,14 @@ export type RootAction =
       }
     }
   | {
+      // Called when a currency engine fires the onAddressChecked callback.
+      type: 'CURRENCY_ENGINE_CHANGED_UNACTIVATED_TOKEN_IDS'
+      payload: {
+        unactivatedTokenIds: string[]
+        walletId: string
+      }
+    }
+  | {
       // Fired when we fetch exchange pairs from some server.
       type: 'EXCHANGE_PAIRS_FETCHED'
       payload: ExchangePair[]

--- a/src/core/currency/wallet/currency-wallet-api.ts
+++ b/src/core/currency/wallet/currency-wallet-api.ts
@@ -192,6 +192,9 @@ export function makeCurrencyWalletApi(
     get syncRatio(): number {
       return input.props.walletState.syncRatio
     },
+    get unactivatedTokenIds(): string[] {
+      return input.props.walletState.unactivatedTokenIds
+    },
 
     // Running state:
     async changePaused(paused: boolean): Promise<void> {

--- a/src/core/currency/wallet/currency-wallet-callbacks.ts
+++ b/src/core/currency/wallet/currency-wallet-callbacks.ts
@@ -112,6 +112,19 @@ export function makeCurrencyWalletCallbacks(
       })
     },
 
+    onUnactivatedTokenIdsChanged(unactivatedTokenIds: string[]) {
+      pushUpdate({
+        id: walletId,
+        action: 'onUnactivatedTokenIdsChanged',
+        updateFunc: () => {
+          input.props.dispatch({
+            type: 'CURRENCY_ENGINE_CHANGED_UNACTIVATED_TOKEN_IDS',
+            payload: { unactivatedTokenIds, walletId }
+          })
+        }
+      })
+    },
+
     onBalanceChanged(currencyCode: string, balance: string) {
       pushUpdate({
         id: `${walletId}==${currencyCode}`,

--- a/src/core/currency/wallet/currency-wallet-reducer.ts
+++ b/src/core/currency/wallet/currency-wallet-reducer.ts
@@ -83,6 +83,7 @@ export interface CurrencyWalletState {
   readonly syncRatio: number
   readonly txids: string[]
   readonly txs: { [txid: string]: MergedTransaction }
+  readonly unactivatedTokenIds: string[]
   readonly walletInfo: EdgeWalletInfoFull
 }
 
@@ -333,7 +334,18 @@ const currencyWalletInner = buildReducer<
       case 'CURRENCY_ENGINE_CLEARED':
         return {}
     }
+    return state
+  },
 
+  unactivatedTokenIds(state = [], action): string[] {
+    switch (action.type) {
+      case 'CURRENCY_ENGINE_CHANGED_UNACTIVATED_TOKEN_IDS': {
+        return action.payload.unactivatedTokenIds
+      }
+      case 'CURRENCY_ENGINE_CLEARED': {
+        return []
+      }
+    }
     return state
   },
 


### PR DESCRIPTION
- Add unactivatedTokenIds property to EdgeCurrencyWallet
- Add optional tokenMap to EdgeCurrencyInfo so newer plugins can declare it to avoid legacy EdgeMetaToken[] getting auto converted to the tokenMap in edge-currency-accountbased makeOuterPlugin()

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203860324833440