### PR TITLE
Fix denom bug with built in tokens

### DIFF
--- a/src/core/currency/currency-selectors.ts
+++ b/src/core/currency/currency-selectors.ts
@@ -1,39 +1,37 @@
 import {
   EdgeCurrencyPlugin,
   EdgeCurrencyWallet,
-  EdgePluginMap,
   EdgeTokenMap
 } from '../../types/types'
 import { ApiInput, RootProps } from '../root-pixie'
 
-export function getCurrencyMultiplier(
-  plugins: EdgePluginMap<EdgeCurrencyPlugin>,
-  customTokens: EdgeTokenMap = {},
+const getFromTokenMap = (
+  tokenMap: EdgeTokenMap,
   currencyCode: string
-): string {
-  const pluginIds = Object.keys(plugins)
-  for (const pluginId of pluginIds) {
-    const info = plugins[pluginId].currencyInfo
-    for (const denomination of info.denominations) {
+): string | undefined => {
+  for (const tokenId of Object.keys(tokenMap)) {
+    const token = tokenMap[tokenId]
+    for (const denomination of token.denominations) {
       if (denomination.name === currencyCode) {
         return denomination.multiplier
       }
     }
   }
+}
 
-  for (const pluginId of pluginIds) {
-    const info = plugins[pluginId].currencyInfo
-    for (const token of info.metaTokens) {
-      for (const denomination of token.denominations) {
-        if (denomination.name === currencyCode) {
-          return denomination.multiplier
-        }
-      }
+export function getCurrencyMultiplier(
+  plugin: EdgeCurrencyPlugin,
+  allTokens: EdgeTokenMap = {},
+  currencyCode: string
+): string {
+  const info = plugin.currencyInfo
+  for (const denomination of info.denominations) {
+    if (denomination.name === currencyCode) {
+      return denomination.multiplier
     }
   }
 
-  for (const tokenId of Object.keys(customTokens)) {
-    const token = customTokens[tokenId]
+  for (const token of info.metaTokens) {
     for (const denomination of token.denominations) {
       if (denomination.name === currencyCode) {
         return denomination.multiplier
@@ -41,6 +39,8 @@ export function getCurrencyMultiplier(
     }
   }
 
+  const multiplier = getFromTokenMap(allTokens, currencyCode)
+  if (multiplier != null) return multiplier
   return '1'
 }
 

--- a/src/core/currency/wallet/currency-wallet-api.ts
+++ b/src/core/currency/wallet/currency-wallet-api.ts
@@ -159,9 +159,10 @@ export function makeCurrencyWalletApi(
       denominatedAmount: string,
       currencyCode: string
     ): Promise<string> {
+      const plugin = input.props.state.plugins.currency[pluginId]
       const multiplier = getCurrencyMultiplier(
-        { [pluginId]: input.props.state.plugins.currency[pluginId] },
-        input.props.state.accounts[accountId].customTokens[pluginId],
+        plugin,
+        input.props.state.accounts[accountId].allTokens[pluginId],
         currencyCode
       )
       return mul(denominatedAmount, multiplier)
@@ -170,9 +171,10 @@ export function makeCurrencyWalletApi(
       nativeAmount: string,
       currencyCode: string
     ): Promise<string> {
+      const plugin = input.props.state.plugins.currency[pluginId]
       const multiplier = getCurrencyMultiplier(
-        { [pluginId]: input.props.state.plugins.currency[pluginId] },
-        input.props.state.accounts[accountId].customTokens[pluginId],
+        plugin,
+        input.props.state.accounts[accountId].allTokens[pluginId],
         currencyCode
       )
       return div(nativeAmount, multiplier, multiplier.length)

--- a/src/core/currency/wallet/currency-wallet-files.ts
+++ b/src/core/currency/wallet/currency-wallet-files.ts
@@ -462,13 +462,15 @@ export async function setupNewTxMetadata(
 
   const creationDate = Date.now() / 1000
 
+  const plugin = input.props.state.plugins.currency[pluginId]
+
   // Calculate the exchange rate:
   const rate =
     getExchangeRate(state, currencyCode, fiat, () => 1) /
     parseFloat(
       getCurrencyMultiplier(
-        { [pluginId]: input.props.state.plugins.currency[pluginId] },
-        input.props.state.accounts[accountId].customTokens[pluginId],
+        plugin,
+        input.props.state.accounts[accountId].allTokens[pluginId],
         currencyCode
       )
     )

--- a/test/core/currency/currency.test.ts
+++ b/test/core/currency/currency.test.ts
@@ -2,18 +2,15 @@ import { expect } from 'chai'
 import { describe, it } from 'mocha'
 
 import { getCurrencyMultiplier } from '../../../src/core/currency/currency-selectors'
-import { EdgeCurrencyPlugin, EdgePluginMap } from '../../../src/types/types'
 import { fakeCurrencyPlugin } from '../../fake/fake-currency-plugin'
 
 describe('currency selectors', function () {
-  const plugins: EdgePluginMap<EdgeCurrencyPlugin> = {
-    fakecoin: fakeCurrencyPlugin
-  }
-
   it('find currency multiplier', function () {
-    expect(getCurrencyMultiplier(plugins, {}, 'SMALL')).equals('10')
-    expect(getCurrencyMultiplier(plugins, {}, 'FAKE')).equals('100')
-    expect(getCurrencyMultiplier(plugins, {}, 'TOKEN')).equals('1000')
-    expect(getCurrencyMultiplier(plugins, {}, '-error-')).equals('1')
+    expect(getCurrencyMultiplier(fakeCurrencyPlugin, {}, 'SMALL')).equals('10')
+    expect(getCurrencyMultiplier(fakeCurrencyPlugin, {}, 'FAKE')).equals('100')
+    expect(getCurrencyMultiplier(fakeCurrencyPlugin, {}, 'TOKEN')).equals(
+      '1000'
+    )
+    expect(getCurrencyMultiplier(fakeCurrencyPlugin, {}, '-error-')).equals('1')
   })
 })


### PR DESCRIPTION
Have getCurrencyMultiplier also accept builtInTokens retrieved via getBuiltInTokens()

Also change getCurrencyMultiplier to only take one plugin since that's all it ever did. And scanning multiple plugins for a currencyCode is incorrect

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204057267024831