### PR TITLE
Expose engine errors

### DIFF
--- a/src/core/account/account-api.ts
+++ b/src/core/account/account-api.ts
@@ -384,6 +384,29 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
         check()
       })
     },
+    async waitForAllWallets(): Promise<void> {
+      return await new Promise((resolve, reject) => {
+        const check = (): void => {
+          const busyWallet = this.activeWalletIds.find(
+            id =>
+              this.currencyWallets[id] == null &&
+              this.currencyWalletErrors[id] == null
+          )
+          if (busyWallet == null) {
+            for (const cleanup of cleanups) cleanup()
+            resolve()
+          }
+        }
+
+        const cleanups = [
+          this.watch('activeWalletIds', check),
+          this.watch('currencyWallets', check),
+          this.watch('currencyWalletErrors', check)
+        ]
+
+        check()
+      })
+    },
 
     async getActivationAssets({
       activateWalletId,

--- a/src/core/currency/wallet/currency-wallet-pixie.ts
+++ b/src/core/currency/wallet/currency-wallet-pixie.ts
@@ -152,7 +152,8 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
           })
           .catch(error => input.props.onError(error))
       }
-    } catch (error: any) {
+    } catch (raw: unknown) {
+      const error = raw instanceof Error ? raw : new Error(String(raw))
       input.props.onError(error)
       input.props.dispatch({
         type: 'CURRENCY_ENGINE_FAILED',

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1301,6 +1301,7 @@ export interface EdgeAccount {
   readonly archivedWalletIds: string[]
   readonly hiddenWalletIds: string[]
   readonly currencyWallets: { [walletId: string]: EdgeCurrencyWallet }
+  readonly currencyWalletErrors: { [walletId: string]: Error }
   readonly createCurrencyWallet: (
     type: string,
     opts?: EdgeCreateCurrencyWalletOptions

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1309,6 +1309,9 @@ export interface EdgeAccount {
   readonly waitForCurrencyWallet: (
     walletId: string
   ) => Promise<EdgeCurrencyWallet>
+  readonly waitForAllWallets: () => Promise<void>
+
+  // Token & wallet activation:
   readonly getActivationAssets: (
     options: EdgeGetActivationAssetsOptions
   ) => Promise<EdgeGetActivationAssetsResults>

--- a/test/core/currency/wallet/currency-wallet.test.ts
+++ b/test/core/currency/wallet/currency-wallet.test.ts
@@ -507,5 +507,8 @@ describe('currency wallets', function () {
       account.waitForCurrencyWallet(info.id),
       "SyntaxError: I can't do this"
     )
+
+    // Loading is complete, even though we have an error:
+    await account.waitForAllWallets()
   })
 })

--- a/test/fake/fake-broken-engine.ts
+++ b/test/fake/fake-broken-engine.ts
@@ -1,0 +1,39 @@
+import { EdgeCurrencyPlugin } from '../../src'
+
+export const brokenEnginePlugin: EdgeCurrencyPlugin = {
+  currencyInfo: {
+    addressExplorer: '',
+    currencyCode: 'BORK',
+    defaultSettings: {},
+    denominations: [],
+    displayName: 'Broken Engine',
+    metaTokens: [],
+    pluginId: 'broken-engine',
+    transactionExplorer: '',
+    walletType: 'wallet:broken'
+  },
+
+  async makeCurrencyEngine() {
+    throw new SyntaxError("I can't do this")
+  },
+
+  async makeCurrencyTools() {
+    return {
+      createPrivateKey() {
+        return Promise.resolve({})
+      },
+      derivePublicKey() {
+        return Promise.resolve({})
+      },
+      getSplittableTypes() {
+        return Promise.resolve([])
+      },
+      parseUri() {
+        return Promise.resolve({})
+      },
+      encodeUri() {
+        return Promise.resolve('')
+      }
+    }
+  }
+}

--- a/test/fake/fake-plugins.ts
+++ b/test/fake/fake-plugins.ts
@@ -1,4 +1,5 @@
 import { EdgeRateHint, EdgeRatePair, EdgeRatePlugin } from '../../src/index'
+import { brokenEnginePlugin } from './fake-broken-engine'
 import { fakeCurrencyPlugin } from './fake-currency-plugin'
 import { fakeSwapPlugin } from './fake-swap-plugin'
 
@@ -42,6 +43,7 @@ export const allPlugins = {
     throw new Error('Expect to fail')
   },
   'broken-exchange': () => brokenExchangePlugin,
+  'broken-engine': brokenEnginePlugin,
   'fake-exchange': fakeExchangePlugin,
   fakecoin: fakeCurrencyPlugin,
   fakeswap: fakeSwapPlugin


### PR DESCRIPTION
- added: `EdgeAccount.currencyEngineErrors` - these are set for wallets that fail to load.
- added: `EdgeAccount.waitForAllWallets()` - resolves once all wallets have either loaded or failed (but balances may not be correct yet).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204061614314748