### PR TITLE
Make deprecated token methods optional

### DIFF
--- a/src/core/account/custom-tokens.ts
+++ b/src/core/account/custom-tokens.ts
@@ -58,6 +58,9 @@ export async function getTokenId(
       'A wallet must exist before adding tokens to a legacy currency plugin'
     )
   }
+  if (engine.addCustomToken == null) {
+    throw new Error(`${pluginId} doesn't support tokens`)
+  }
 
   // Validate the token:
   const tokenInfo = makeTokenInfo(token)

--- a/src/core/currency/wallet/currency-wallet-api.ts
+++ b/src/core/currency/wallet/currency-wallet-api.ts
@@ -576,9 +576,11 @@ export function makeCurrencyWalletApi(
       // Ask the plugin to validate this:
       if (tools.getTokenId != null) {
         await tools.getTokenId(token)
-      } else {
+      } else if (engine.addCustomToken != null) {
         // This is not ideal, since the pixie will add it too:
         await engine.addCustomToken({ ...token, ...tokenInfo })
+      } else {
+        throw new Error(`${pluginId} doesn't support tokens`)
       }
 
       ai.props.dispatch({

--- a/src/core/currency/wallet/currency-wallet-pixie.ts
+++ b/src/core/currency/wallet/currency-wallet-pixie.ts
@@ -336,7 +336,7 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
       if (lastTokens !== customTokens && engine != null) {
         if (engine.changeCustomTokens != null) {
           await engine.changeCustomTokens(customTokens)
-        } else {
+        } else if (engine.addCustomToken != null) {
           for (const tokenId of Object.keys(customTokens)) {
             const token = customTokens[tokenId]
             if (token === lastTokens[tokenId]) continue
@@ -346,7 +346,7 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
               .addCustomToken({ ...tokenInfo, ...token })
               .catch(error => input.props.onError(error))
           }
-        }
+        } // else { no token support }
       }
       lastTokens = customTokens
 
@@ -357,7 +357,10 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
           await engine
             .changeEnabledTokenIds(allEnabledTokenIds)
             .catch(error => input.props.onError(error))
-        } else {
+        } else if (
+          engine.disableTokens != null &&
+          engine.enableTokens != null
+        ) {
           const removed = tokenIdsToCurrencyCodes(
             accountState.builtinTokens[pluginId],
             accountState.customTokens[pluginId],
@@ -376,7 +379,7 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
           await engine
             .enableTokens(added)
             .catch(error => input.props.onError(error))
-        }
+        } // else { no token support }
       }
       lastEnabledTokenIds = allEnabledTokenIds
     }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -633,10 +633,11 @@ export interface EdgeCurrencyEngine {
   // Tokens:
   readonly changeCustomTokens?: (tokens: EdgeTokenMap) => Promise<void>
   readonly changeEnabledTokenIds?: (tokenIds: string[]) => Promise<void>
+
+  // Asset activation:
   readonly engineGetActivationAssets?: (
     options: EdgeEngineGetActivationAssetsOptions
   ) => Promise<EdgeGetActivationAssetsResults>
-
   readonly engineActivateWallet?: (
     options: EdgeEngineActivationOptions
   ) => Promise<EdgeActivationQuote>
@@ -673,11 +674,11 @@ export interface EdgeCurrencyEngine {
   readonly otherMethods?: EdgeOtherMethods
 
   // Deprecated:
-  readonly enableTokens: (tokens: string[]) => Promise<void>
-  readonly disableTokens: (tokens: string[]) => Promise<void>
-  readonly getEnabledTokens: () => Promise<string[]>
-  readonly addCustomToken: (token: EdgeTokenInfo & EdgeToken) => Promise<void>
-  readonly getTokenStatus: (token: string) => boolean
+  readonly enableTokens?: (tokens: string[]) => Promise<void>
+  readonly disableTokens?: (tokens: string[]) => Promise<void>
+  readonly getEnabledTokens?: () => Promise<string[]>
+  readonly addCustomToken?: (token: EdgeTokenInfo & EdgeToken) => Promise<void>
+  readonly getTokenStatus?: (token: string) => boolean
 }
 
 // currency plugin -----------------------------------------------------


### PR DESCRIPTION
### CHANGELOG

- changed: Make deprecated token methods optional on `EdgeCurrencyEngine`.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204141001997409