### PR TITLE
Only pass public keys to engines

### DIFF
--- a/src/core/currency/wallet/currency-wallet-pixie.ts
+++ b/src/core/currency/wallet/currency-wallet-pixie.ts
@@ -104,7 +104,7 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
 
       // Start the engine:
       const accountState = state.accounts[accountId]
-      const engine = await plugin.makeCurrencyEngine(privateWalletInfo, {
+      const engine = await plugin.makeCurrencyEngine(publicWalletInfo, {
         callbacks: makeCurrencyWalletCallbacks(input),
 
         // Wallet-scoped IO objects:


### PR DESCRIPTION
### CHANGELOG

- changed: Removed private keys from `walletInfo` for `makeCurrencyEngine`

### Dependencies

- https://github.com/EdgeApp/edge-core-js/pull/508

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204255757649666