### PR TITLE
Fix passing the privateKeys to syncNetwork

### DIFF
--- a/src/core/currency/wallet/currency-wallet-pixie.ts
+++ b/src/core/currency/wallet/currency-wallet-pixie.ts
@@ -236,7 +236,9 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
               const requiresPrivateKeys =
                 currencyInfo.unsafeSyncNetwork === true &&
                 publicWalletInfo != null
-              const privateKeys = requiresPrivateKeys ? walletInfo : undefined
+              const privateKeys = requiresPrivateKeys
+                ? walletInfo.keys
+                : undefined
               const doNetworkSync = async (): Promise<void> => {
                 if (engine.syncNetwork != null) {
                   const delay = await engine.syncNetwork({ privateKeys })


### PR DESCRIPTION
### CHANGELOG

- fixed: Passing only the private keys to `EdgeEnginePrivateKeyOptions['privateKeys']` for `syncNetwork`, instead of the entire `EdgeWalletInfo`

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
