### PR TITLE
Remove accidental nesting of privateKeys for signTx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # edge-core-js
 
+## Unreleased
+
+- fixed: Incorrectly formed `privateKeys` argument for `signTx` call to the engine
+
 ## v0.19.48 (2023-03-27)
 
 - fixed: Passing only the private keys to `EdgeEnginePrivateKeyOptions['privateKeys']` for `syncNetwork`, instead of the entire `EdgeWalletInfo`

--- a/src/core/currency/wallet/currency-wallet-api.ts
+++ b/src/core/currency/wallet/currency-wallet-api.ts
@@ -549,7 +549,7 @@ export function makeCurrencyWalletApi(
     async signTx(tx: EdgeTransaction): Promise<EdgeTransaction> {
       const privateKeys = walletInfo.keys
 
-      return await engine.signTx(tx, { privateKeys })
+      return await engine.signTx(tx, privateKeys)
     },
     async sweepPrivateKeys(spendInfo: EdgeSpendInfo): Promise<EdgeTransaction> {
       if (engine.sweepPrivateKeys == null) {


### PR DESCRIPTION
### CHANGELOG

- fixed: Incorrectly formed `privateKeys` argument for `signTx` call to the engine

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
