### PR TITLE
Fix metadata saving

### DIFF
--- a/src/core/currency/wallet/currency-wallet-callbacks.ts
+++ b/src/core/currency/wallet/currency-wallet-callbacks.ts
@@ -1,3 +1,4 @@
+import { lt } from 'biggystring'
 import { asMaybe } from 'cleaners'
 import { isPixieShutdownError } from 'redux-pixies'
 import { emit } from 'yaob'
@@ -244,6 +245,7 @@ export function makeCurrencyWalletCallbacks(
           )
           return
         }
+        if (tx.isSend == null) tx.isSend = lt(tx.nativeAmount, '0')
       }
 
       // Grab stuff from redux:
@@ -278,7 +280,7 @@ export function makeCurrencyWalletCallbacks(
 
         // Ensure the transaction has metadata:
         const txidHash = hashStorageWalletFilename(state, walletId, txid)
-        const isNew = tx.spendTargets != null || fileNames[txidHash] == null
+        const isNew = tx.isSend ? false : fileNames[txidHash] == null
         if (isNew) {
           setupNewTxMetadata(input, tx).catch(error =>
             input.props.onError(error)

--- a/src/core/currency/wallet/currency-wallet-callbacks.ts
+++ b/src/core/currency/wallet/currency-wallet-callbacks.ts
@@ -16,7 +16,14 @@ import {
 } from '../../storage/storage-selectors'
 import { combineTxWithFile } from './currency-wallet-api'
 import { asIntegerString } from './currency-wallet-cleaners'
-import { loadAllFiles, setupNewTxMetadata } from './currency-wallet-files'
+import {
+  loadAddressFiles,
+  loadEnabledTokensFile,
+  loadFiatFile,
+  loadNameFile,
+  loadTxFileNames,
+  setupNewTxMetadata
+} from './currency-wallet-files'
 import {
   CurrencyWalletInput,
   CurrencyWalletProps
@@ -241,11 +248,7 @@ export function makeCurrencyWalletCallbacks(
 
       // Grab stuff from redux:
       const { state } = input.props
-      const {
-        fileNames,
-        fileNamesLoaded,
-        txs: reduxTxs
-      } = input.props.walletState
+      const { fileNames, txs: reduxTxs } = input.props.walletState
       const defaultCurrency = input.props.walletState.currencyInfo.currencyCode
 
       const txidHashes: TxidHashes = {}
@@ -275,9 +278,7 @@ export function makeCurrencyWalletCallbacks(
 
         // Ensure the transaction has metadata:
         const txidHash = hashStorageWalletFilename(state, walletId, txid)
-        const isNew =
-          tx.spendTargets != null ||
-          (fileNamesLoaded && fileNames[txidHash] == null)
+        const isNew = tx.spendTargets != null || fileNames[txidHash] == null
         if (isNew) {
           setupNewTxMetadata(input, tx).catch(error =>
             input.props.onError(error)
@@ -326,22 +327,29 @@ export function watchCurrencyWallet(input: CurrencyWalletInput): void {
   const { walletId } = input.props
 
   let lastChanges: string[]
-  function checkChangesLoop(props: CurrencyWalletProps): void {
+  async function checkChanges(props: CurrencyWalletProps): Promise<void> {
     // Check for data changes:
     const changes = getStorageWalletLastChanges(props.state, walletId)
     if (changes !== lastChanges) {
       lastChanges = changes
-      loadAllFiles(input).catch(error => input.props.onError(error))
+      await loadEnabledTokensFile(input)
+      await loadFiatFile(input)
+      await loadNameFile(input)
+      await loadTxFileNames(input)
+      await loadAddressFiles(input)
     }
-
+  }
+  function checkChangesLoop(): void {
     input
       .nextProps()
-      .then(checkChangesLoop)
-      .catch(error => {
-        if (!isPixieShutdownError(error)) input.props.onError(error)
+      .then(checkChanges)
+      .then(checkChangesLoop, error => {
+        if (isPixieShutdownError(error)) return
+        input.props.onError(error)
+        checkChangesLoop()
       })
   }
-  checkChangesLoop(input.props)
+  checkChangesLoop()
 }
 
 export const validateConfirmations = (

--- a/src/core/currency/wallet/currency-wallet-files.ts
+++ b/src/core/currency/wallet/currency-wallet-files.ts
@@ -409,7 +409,9 @@ export async function setCurrencyWalletTxMetadata(
   // Load the old file:
   const oldFile = input.props.walletState.files[oldTxidHash]
   const creationDate =
-    oldFile == null ? Date.now() / 1000 : oldFile.creationDate
+    oldFile == null
+      ? Math.min(tx.date, Date.now() / 1000)
+      : oldFile.creationDate
 
   // Set up the new file:
   const { fileName, txidHash } = getTxFileName(

--- a/src/core/currency/wallet/currency-wallet-files.ts
+++ b/src/core/currency/wallet/currency-wallet-files.ts
@@ -146,7 +146,7 @@ export async function setCurrencyWalletFiat(
   })
 }
 
-async function loadEnabledTokensFile(
+export async function loadEnabledTokensFile(
   input: CurrencyWalletInput
 ): Promise<void> {
   const { dispatch, state, walletId } = input.props
@@ -166,7 +166,7 @@ async function loadEnabledTokensFile(
 /**
  * Loads the wallet fiat currency file.
  */
-async function loadFiatFile(input: CurrencyWalletInput): Promise<void> {
+export async function loadFiatFile(input: CurrencyWalletInput): Promise<void> {
   const { dispatch, state, walletId } = input.props
   const disklet = getStorageWalletDisklet(state, walletId)
 
@@ -191,7 +191,7 @@ async function loadFiatFile(input: CurrencyWalletInput): Promise<void> {
 /**
  * Loads the wallet name file.
  */
-async function loadNameFile(input: CurrencyWalletInput): Promise<void> {
+export async function loadNameFile(input: CurrencyWalletInput): Promise<void> {
   const { dispatch, state, walletId } = input.props
   const disklet = getStorageWalletDisklet(state, walletId)
 
@@ -314,7 +314,9 @@ async function getLegacyFileNames(
 /**
  * Loads transaction metadata file names.
  */
-async function loadTxFileNames(input: CurrencyWalletInput): Promise<void> {
+export async function loadTxFileNames(
+  input: CurrencyWalletInput
+): Promise<void> {
   const { dispatch, state, walletId } = input.props
   const disklet = getStorageWalletDisklet(state, walletId)
 
@@ -352,7 +354,9 @@ async function loadTxFileNames(input: CurrencyWalletInput): Promise<void> {
 /**
  * Loads address metadata files.
  */
-async function loadAddressFiles(input: CurrencyWalletInput): Promise<void> {
+export async function loadAddressFiles(
+  input: CurrencyWalletInput
+): Promise<void> {
   const { state, walletId } = input.props
   const disklet = getStorageWalletDisklet(state, walletId)
 
@@ -371,17 +375,6 @@ async function loadAddressFiles(input: CurrencyWalletInput): Promise<void> {
   // Load these addresses into the engine:
   const engine = input.props.walletOutput?.engine
   if (engine != null) await engine.addGapLimitAddresses(out)
-}
-
-/**
- * Updates the wallet in response to data syncs.
- */
-export async function loadAllFiles(input: CurrencyWalletInput): Promise<void> {
-  await loadEnabledTokensFile(input)
-  await loadFiatFile(input)
-  await loadNameFile(input)
-  await loadTxFileNames(input)
-  await loadAddressFiles(input)
 }
 
 /**

--- a/src/core/currency/wallet/currency-wallet-reducer.ts
+++ b/src/core/currency/wallet/currency-wallet-reducer.ts
@@ -73,7 +73,6 @@ export interface CurrencyWalletState {
   readonly fiat: string
   readonly fiatLoaded: boolean
   readonly fileNames: TxFileNames
-  readonly fileNamesLoaded: boolean
   readonly files: TxFileJsons
   readonly gotTxs: { [currencyCode: string]: boolean }
   readonly height: number
@@ -262,10 +261,6 @@ const currencyWalletInner = buildReducer<
       }
     }
     return state
-  },
-
-  fileNamesLoaded(state = false, action): boolean {
-    return action.type === 'CURRENCY_WALLET_FILE_NAMES_LOADED' ? true : state
   },
 
   syncRatio(state = 0, action): number {

--- a/test/core/currency/wallet/currency-wallet.test.ts
+++ b/test/core/currency/wallet/currency-wallet.test.ts
@@ -364,7 +364,8 @@ describe('currency wallets', function () {
     await config.changeUserSettings({ balance: 100 }) // Spending balance
 
     // Subscribe to new transactions:
-    wallet.on('newTransactions', txs => {
+    wallet.on('newTransactions', () => log('bad'))
+    wallet.on('transactionsChanged', txs => {
       const { txid, metadata = {} } = tx
       const { name = '' } = metadata
       log('new', txs.map(tx => `${txid} ${name}`).join(' '))

--- a/test/core/currency/wallet/currency-wallet.test.ts
+++ b/test/core/currency/wallet/currency-wallet.test.ts
@@ -408,11 +408,11 @@ describe('currency wallets', function () {
     expect(txs.length).equals(1)
     expect(txs[0].nativeAmount).equals('50')
     expect(txs[0].metadata).deep.equals({
+      amountFiat: undefined,
       bizId: undefined,
       category: undefined,
+      exchangeAmount: {},
       notes: undefined,
-      exchangeAmount: { 'iso:USD': 1.5 },
-      amountFiat: 1.5,
       ...metadata
     })
     expect(txs[0].networkFeeOption).equals('high')


### PR DESCRIPTION
We have been calling `setupNewTxMetadata` incorrectly this whole time. This can race with editing fiat amounts, and prevent the right data from hitting disk. Change the `isNew` logic to be much more picky.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203783246749086