### PR TITLE
Add key-access methods

### DIFF
--- a/src/core/account/account-api.ts
+++ b/src/core/account/account-api.ts
@@ -95,46 +95,62 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
     on: onMethod,
     watch: watchMethod,
 
+    // ----------------------------------------------------------------
     // Data store:
+    // ----------------------------------------------------------------
+
     get id(): string {
       return storageWalletApi.id
     },
+
     get type(): string {
       return storageWalletApi.type
     },
+
     get keys(): JsonObject {
       lockdown()
       return storageWalletApi.keys
     },
+
     get disklet(): Disklet {
       lockdown()
       return storageWalletApi.disklet
     },
+
     get localDisklet(): Disklet {
       lockdown()
       return storageWalletApi.localDisklet
     },
+
     async sync(): Promise<void> {
       await storageWalletApi.sync()
     },
 
+    // ----------------------------------------------------------------
     // Basic login information:
+    // ----------------------------------------------------------------
+
     get appId(): string {
       return accountState().login.appId
     },
+
     get created(): Date | undefined {
       return accountState().login.created
     },
+
     get lastLogin(): Date {
       return accountState().login.lastLogin
     },
+
     get loggedIn(): boolean {
       return accountState() != null
     },
+
     get loginKey(): string {
       lockdown()
       return base58.stringify(accountState().login.loginKey)
     },
+
     get recoveryKey(): string | undefined {
       lockdown()
       const { login } = accountState()
@@ -142,45 +158,61 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
         ? base58.stringify(login.recovery2Key)
         : undefined
     },
+
     get rootLoginId(): string {
       lockdown()
       return base58.stringify(loginTree.loginId)
     },
+
     get username(): string {
       if (username == null) throw new Error('Missing username')
       return username
     },
 
-    // Speciality API's:
+    // ----------------------------------------------------------------
+    // Specialty API's:
+    // ----------------------------------------------------------------
+
     get currencyConfig(): EdgePluginMap<EdgeCurrencyConfig> {
       return currencyConfigs
     },
+
     get swapConfig(): EdgePluginMap<EdgeSwapConfig> {
       return swapConfigs
     },
+
     get rateCache(): EdgeRateCache {
       return rateCache
     },
+
     get dataStore(): EdgeDataStore {
       return dataStore
     },
 
+    // ----------------------------------------------------------------
     // What login method was used?
+    // ----------------------------------------------------------------
+
     get edgeLogin(): boolean {
       const { loginTree } = accountState()
       return loginTree.loginKey == null
     },
+
     keyLogin: loginType === 'keyLogin',
     newAccount: loginType === 'newAccount',
     passwordLogin: loginType === 'passwordLogin',
     pinLogin: loginType === 'pinLogin',
     recoveryLogin: loginType === 'recoveryLogin',
 
+    // ----------------------------------------------------------------
     // Change or create credentials:
+    // ----------------------------------------------------------------
+
     async changePassword(password: string): Promise<void> {
       lockdown()
       await changePassword(ai, accountId, password)
     },
+
     async changePin(opts: {
       pin?: string // We keep the existing PIN if unspecified
       enableLogin?: boolean // We default to true if unspecified
@@ -191,6 +223,7 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
       const { login } = accountState()
       return login.pin2Key != null ? base58.stringify(login.pin2Key) : ''
     },
+
     async changeRecovery(
       questions: string[],
       answers: string[]
@@ -204,12 +237,16 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
       return base58.stringify(loginTree.recovery2Key)
     },
 
+    // ----------------------------------------------------------------
     // Verify existing credentials:
+    // ----------------------------------------------------------------
+
     async checkPassword(password: string): Promise<boolean> {
       lockdown()
       const { loginTree } = accountState()
       return await checkPassword(ai, loginTree, password)
     },
+
     async checkPin(pin: string): Promise<boolean> {
       lockdown()
       const { login, loginTree } = accountState()
@@ -220,21 +257,29 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
         : await checkPin2(ai, loginTree, pin)
     },
 
+    // ----------------------------------------------------------------
     // Remove credentials:
+    // ----------------------------------------------------------------
+
     async deletePassword(): Promise<void> {
       lockdown()
       await deletePassword(ai, accountId)
     },
+
     async deletePin(): Promise<void> {
       lockdown()
       await deletePin(ai, accountId)
     },
+
     async deleteRecovery(): Promise<void> {
       lockdown()
       await deleteRecovery(ai, accountId)
     },
 
+    // ----------------------------------------------------------------
     // OTP:
+    // ----------------------------------------------------------------
+
     get otpKey(): string | undefined {
       lockdown()
       const { loginTree } = accountState()
@@ -242,68 +287,90 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
         ? base32.stringify(loginTree.otpKey, { pad: false })
         : undefined
     },
+
     get otpResetDate(): Date | undefined {
       lockdown()
       const { loginTree } = accountState()
       return loginTree.otpResetDate
     },
+
     async cancelOtpReset(): Promise<void> {
       lockdown()
       await cancelOtpReset(ai, accountId)
     },
+
     async enableOtp(timeout: number = 7 * 24 * 60 * 60): Promise<void> {
       lockdown()
       await enableOtp(ai, accountId, timeout)
     },
+
     async disableOtp(): Promise<void> {
       lockdown()
       await disableOtp(ai, accountId)
     },
+
     async repairOtp(otpKey: string): Promise<void> {
       lockdown()
       await repairOtp(ai, accountId, base32.parse(otpKey, { loose: true }))
     },
 
+    // ----------------------------------------------------------------
     // 2fa bypass voucher approval / rejection:
+    // ----------------------------------------------------------------
+
     get pendingVouchers(): EdgePendingVoucher[] {
       const { login } = accountState()
       return login.pendingVouchers
     },
+
     async approveVoucher(voucherId: string): Promise<void> {
       return await changeVoucherStatus(ai, loginTree, {
         approvedVouchers: [voucherId]
       })
     },
+
     async rejectVoucher(voucherId: string): Promise<void> {
       return await changeVoucherStatus(ai, loginTree, {
         rejectedVouchers: [voucherId]
       })
     },
 
+    // ----------------------------------------------------------------
     // Edge login approval:
+    // ----------------------------------------------------------------
+
     async fetchLobby(lobbyId: string): Promise<EdgeLobby> {
       lockdown()
       return await makeLobbyApi(ai, accountId, lobbyId)
     },
 
+    // ----------------------------------------------------------------
     // Login management:
+    // ----------------------------------------------------------------
+
     async deleteRemoteAccount(): Promise<void> {
       const { loginTree } = accountState()
       await deleteLogin(ai, loginTree)
     },
+
     async logout(): Promise<void> {
       ai.props.dispatch({ type: 'LOGOUT', payload: { accountId } })
     },
 
+    // ----------------------------------------------------------------
     // Master wallet list:
+    // ----------------------------------------------------------------
+
     get allKeys(): EdgeWalletInfoFull[] {
       return ai.props.state.hideKeys
         ? ai.props.state.accounts[accountId].allWalletInfosClean
         : ai.props.state.accounts[accountId].allWalletInfosFull
     },
+
     async changeWalletStates(walletStates: EdgeWalletStates): Promise<void> {
       await changeWalletStates(ai, accountId, walletStates)
     },
+
     async createWallet(walletType: string, keys?: JsonObject): Promise<string> {
       const { login, loginTree } = accountState()
 
@@ -322,41 +389,53 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
       await applyKit(ai, loginTree, kit)
       return walletInfo.id
     },
+
     getFirstWalletInfo: AccountSync.prototype.getFirstWalletInfo,
     getWalletInfo: AccountSync.prototype.getWalletInfo,
     listWalletIds: AccountSync.prototype.listWalletIds,
+
     async splitWalletInfo(
       walletId: string,
       newWalletType: string
     ): Promise<string> {
       return await splitWalletInfo(ai, accountId, walletId, newWalletType)
     },
+
     async listSplittableWalletTypes(walletId: string): Promise<string[]> {
       return await listSplittableWalletTypes(ai, accountId, walletId)
     },
 
+    // ----------------------------------------------------------------
     // Currency wallets:
+    // ----------------------------------------------------------------
+
     get activeWalletIds(): string[] {
       return ai.props.state.accounts[accountId].activeWalletIds
     },
+
     get archivedWalletIds(): string[] {
       return ai.props.state.accounts[accountId].archivedWalletIds
     },
+
     get hiddenWalletIds(): string[] {
       return ai.props.state.accounts[accountId].hiddenWalletIds
     },
+
     get currencyWallets(): { [walletId: string]: EdgeCurrencyWallet } {
       return ai.props.output.accounts[accountId].currencyWallets
     },
+
     get currencyWalletErrors(): { [walletId: string]: Error } {
       return ai.props.state.accounts[accountId].currencyWalletErrors
     },
+
     async createCurrencyWallet(
       type: string,
       opts: EdgeCreateCurrencyWalletOptions = {}
     ): Promise<EdgeCurrencyWallet> {
       return await createCurrencyWallet(ai, accountId, type, opts)
     },
+
     async waitForCurrencyWallet(walletId: string): Promise<EdgeCurrencyWallet> {
       return await new Promise((resolve, reject) => {
         const check = (): void => {
@@ -384,6 +463,7 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
         check()
       })
     },
+
     async waitForAllWallets(): Promise<void> {
       return await new Promise((resolve, reject) => {
         const check = (): void => {
@@ -407,6 +487,10 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
         check()
       })
     },
+
+    // ----------------------------------------------------------------
+    // Token & wallet activation:
+    // ----------------------------------------------------------------
 
     async getActivationAssets({
       activateWalletId,
@@ -457,6 +541,10 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
       return bridgifyObject(out)
     },
 
+    // ----------------------------------------------------------------
+    // Web compatibility:
+    // ----------------------------------------------------------------
+
     async signEthereumTransaction(
       walletId: string,
       transaction: EthereumTransaction
@@ -473,6 +561,10 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
       }
       return signEthereumTransaction(walletInfo.keys.ethereumKey, transaction)
     },
+
+    // ----------------------------------------------------------------
+    // Swapping:
+    // ----------------------------------------------------------------
 
     async fetchSwapQuote(
       request: EdgeSwapRequest,

--- a/src/core/account/custom-tokens.ts
+++ b/src/core/account/custom-tokens.ts
@@ -159,7 +159,7 @@ export async function loadBuiltinTokens(
   )
 }
 
-function findEngine(
+export function findEngine(
   ai: ApiInput,
   pluginId: string
 ): EdgeCurrencyEngine | undefined {

--- a/src/core/currency/wallet/currency-wallet-pixie.ts
+++ b/src/core/currency/wallet/currency-wallet-pixie.ts
@@ -442,7 +442,7 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
 /**
  * Attempts to load/derive the wallet public keys.
  */
-async function getPublicWalletInfo(
+export async function getPublicWalletInfo(
   walletInfo: EdgeWalletInfo,
   disklet: Disklet,
   tools: EdgeCurrencyTools

--- a/src/core/currency/wallet/currency-wallet-pixie.ts
+++ b/src/core/currency/wallet/currency-wallet-pixie.ts
@@ -139,10 +139,18 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
       input.onOutput(engine)
 
       // Grab initial state:
-      const displayPrivateSeed = engine.getDisplayPrivateSeed(
-        privateWalletInfo.keys
-      )
-      const displayPublicSeed = engine.getDisplayPublicSeed()
+      const displayPrivateSeed =
+        tools.getDisplayPrivateKey != null
+          ? await tools.getDisplayPrivateKey(privateWalletInfo)
+          : engine.getDisplayPrivateSeed != null
+          ? engine.getDisplayPrivateSeed(privateWalletInfo.keys)
+          : null
+      const displayPublicSeed =
+        tools.getDisplayPublicKey != null
+          ? await tools.getDisplayPublicKey(publicWalletInfo)
+          : engine.getDisplayPublicSeed != null
+          ? engine.getDisplayPublicSeed()
+          : null
       input.props.dispatch({
         type: 'CURRENCY_ENGINE_CHANGED_SEEDS',
         payload: { displayPrivateSeed, displayPublicSeed, walletId }

--- a/src/core/storage/repo.ts
+++ b/src/core/storage/repo.ts
@@ -1,6 +1,6 @@
 import { Disklet, mergeDisklets, navigateDisklet } from 'disklet'
 import { SyncClient } from 'edge-sync-client'
-import { base16 } from 'rfc4648'
+import { base16, base64 } from 'rfc4648'
 
 import { EdgeIo } from '../../types/types'
 import { sha256 } from '../../util/crypto/hashes'
@@ -13,6 +13,13 @@ const CHANGESET_MAX_ENTRIES = 100
 export interface SyncResult {
   changes: { [path: string]: any }
   status: StorageWalletStatus
+}
+
+export function makeLocalDisklet(io: EdgeIo, walletId: string): Disklet {
+  return navigateDisklet(
+    io.disklet,
+    'local/' + base58.stringify(base64.parse(walletId))
+  )
 }
 
 /**

--- a/src/core/storage/storage-actions.ts
+++ b/src/core/storage/storage-actions.ts
@@ -1,11 +1,14 @@
-import { navigateDisklet } from 'disklet'
 import { base64 } from 'rfc4648'
 import { bridgifyObject } from 'yaob'
 
 import { EdgeWalletInfo } from '../../types/types'
-import { base58 } from '../../util/encoding'
 import { ApiInput } from '../root-pixie'
-import { loadRepoStatus, makeRepoPaths, syncRepo } from './repo'
+import {
+  loadRepoStatus,
+  makeLocalDisklet,
+  makeRepoPaths,
+  syncRepo
+} from './repo'
 import { StorageWalletStatus } from './storage-reducer'
 
 export async function addStorageWallet(
@@ -18,10 +21,7 @@ export async function addStorageWallet(
   const syncKey = base64.parse(walletInfo.keys.syncKey)
 
   const paths = makeRepoPaths(io, syncKey, dataKey)
-  const localDisklet = navigateDisklet(
-    io.disklet,
-    'local/' + base58.stringify(base64.parse(walletInfo.id))
-  )
+  const localDisklet = makeLocalDisklet(io, walletInfo.id)
   bridgifyObject(localDisklet)
 
   const status: StorageWalletStatus = await loadRepoStatus(paths)

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -641,10 +641,6 @@ export interface EdgeCurrencyEngineOptions {
 export interface EdgeCurrencyEngine {
   readonly changeUserSettings: (settings: JsonObject) => Promise<void>
 
-  // Keys:
-  readonly getDisplayPrivateSeed: (privateKeys: JsonObject) => string | null
-  readonly getDisplayPublicSeed: () => string | null
-
   // Engine status:
   readonly startEngine: () => Promise<void>
   readonly killEngine: () => Promise<void>
@@ -735,6 +731,12 @@ export interface EdgeCurrencyEngine {
 
   /** @deprecated No longer used */
   readonly getTokenStatus?: (token: string) => boolean
+
+  /** @deprecated Provide EdgeCurrencyTools.getDisplayPrivateKey: */
+  readonly getDisplayPrivateSeed?: (privateKeys: JsonObject) => string | null
+
+  /** @deprecated Provide EdgeCurrencyTools.getDisplayPublicKey: */
+  readonly getDisplayPublicSeed?: () => string | null
 }
 
 // currency plugin -----------------------------------------------------
@@ -753,9 +755,17 @@ export interface EdgeCurrencyTools {
     walletType: string,
     opts?: JsonObject
   ) => Promise<JsonObject>
-  readonly derivePublicKey: (walletInfo: EdgeWalletInfo) => Promise<JsonObject>
+  readonly derivePublicKey: (
+    privateWalletInfo: EdgeWalletInfo
+  ) => Promise<JsonObject>
+  readonly getDisplayPrivateKey?: (
+    privateWalletInfo: EdgeWalletInfo
+  ) => Promise<string>
+  readonly getDisplayPublicKey?: (
+    publicWalletInfo: EdgeWalletInfo
+  ) => Promise<string>
   readonly getSplittableTypes?: (
-    walletInfo: EdgeWalletInfo
+    publicWalletInfo: EdgeWalletInfo
   ) => string[] | Promise<string[]>
   readonly importPrivateKey?: (
     key: string,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1370,6 +1370,12 @@ export interface EdgeAccount {
     newWalletType: string
   ) => Promise<string>
 
+  // Key access:
+  readonly getDisplayPrivateKey: (walletId: string) => Promise<string>
+  readonly getDisplayPublicKey: (walletId: string) => Promise<string>
+  readonly getRawPrivateKey: (walletId: string) => Promise<JsonObject>
+  readonly getRawPublicKey: (walletId: string) => Promise<JsonObject>
+
   // Currency wallets:
   readonly activeWalletIds: string[]
   readonly archivedWalletIds: string[]

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -875,15 +875,10 @@ export interface EdgeCurrencyWallet {
   // Data store:
   readonly disklet: Disklet
   readonly id: string
-  readonly keys: JsonObject
   readonly localDisklet: Disklet
   readonly publicWalletInfo: EdgeWalletInfo
   readonly sync: () => Promise<void>
   readonly type: string
-
-  // Wallet keys:
-  readonly displayPrivateSeed: string | null
-  readonly displayPublicSeed: string | null
 
   // Wallet name:
   readonly name: string | null
@@ -999,6 +994,15 @@ export interface EdgeCurrencyWallet {
 
   /** @deprecated Read enabledTokenIds instead */
   readonly getEnabledTokens: () => Promise<string[]>
+
+  /** @deprecated Call `EdgeAccount.getDisplayPrivateKey` instead */
+  readonly displayPrivateSeed: string | null
+
+  /** @deprecated Call `EdgeAccount.getDisplayPublicKey` instead */
+  readonly displayPublicSeed: string | null
+
+  /** @deprecated Call `EdgeAccount.getRawPrivateKey` instead */
+  readonly keys: JsonObject
 }
 
 // ---------------------------------------------------------------------
@@ -1297,7 +1301,6 @@ export interface EdgeAccount {
 
   // Data store:
   readonly id: string
-  readonly keys: JsonObject
   readonly type: string
   readonly disklet: Disklet
   readonly localDisklet: Disklet
@@ -1420,6 +1423,9 @@ export interface EdgeAccount {
     request: EdgeSwapRequest,
     opts?: EdgeSwapRequestOptions
   ) => Promise<EdgeSwapQuote>
+
+  /** @deprecated Use `EdgeAccount.getRawPrivateKey` */
+  readonly keys: JsonObject
 }
 
 // ---------------------------------------------------------------------

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -315,11 +315,17 @@ export interface EdgeCurrencyInfo {
   unsafeMakeSpend?: boolean
   unsafeSyncNetwork?: boolean
 
-  // Deprecated:
-  defaultSettings: JsonObject // The default user settings are `{}`
-  metaTokens: EdgeMetaToken[] // Use `EdgeCurrencyPlugin.getBuiltinTokens`
-  symbolImage?: string // The GUI handles this now
-  symbolImageDarkMono?: string // The GUI handles this now
+  /** @deprecated The default user settings are always `{}` */
+  defaultSettings: JsonObject
+
+  /** @deprecated Use EdgeCurrencyPlugin.getBuiltinTokens instead */
+  metaTokens: EdgeMetaToken[]
+
+  /** @deprecated Unused. The GUI handles this now */
+  symbolImage?: string
+
+  /** @deprecated Unused. The GUI handles this now */
+  symbolImageDarkMono?: string
 }
 
 // spending ------------------------------------------------------------
@@ -331,7 +337,7 @@ export interface EdgeMetadata {
   name?: string
   notes?: string
 
-  // Deprecated. Use exchangeAmount instead:
+  /** @deprecated Use exchangeAmount instead */
   amountFiat?: number
 }
 
@@ -392,8 +398,8 @@ export interface EdgeTransaction {
     readonly nativeAmount: string
     readonly publicAddress: string
 
-    // Deprecated:
-    uniqueIdentifier: string | undefined // Use memo instead.
+    /** @deprecated Use memo instead */
+    uniqueIdentifier: string | undefined
   }>
   swapData?: EdgeTxSwap
   txSecret?: string // Monero decryption key
@@ -411,7 +417,7 @@ export interface EdgeTransaction {
   walletId: string
   otherParams?: JsonObject
 
-  // Deprecated:
+  /** @deprecated This will always be undefined */
   wallet?: EdgeCurrencyWallet // eslint-disable-line no-use-before-define
 }
 
@@ -421,7 +427,7 @@ export interface EdgeSpendTarget {
   otherParams?: JsonObject
   publicAddress?: string
 
-  // Deprecated:
+  /** @deprecated Use memo instead */
   uniqueIdentifier?: string // Use memo instead.
 }
 
@@ -435,7 +441,6 @@ export interface EdgePaymentProtocolInfo {
 
 export interface EdgeSpendInfo {
   // Basic information:
-  currencyCode?: string // Deprecated
   tokenId?: string
   privateKeys?: string[]
   spendTargets: EdgeSpendTarget[]
@@ -452,6 +457,9 @@ export interface EdgeSpendInfo {
   metadata?: EdgeMetadata
   swapData?: EdgeTxSwap
   otherParams?: JsonObject
+
+  /** @deprecated Use tokenId instead */
+  currencyCode?: string
 }
 
 // query data ----------------------------------------------------------
@@ -612,7 +620,7 @@ export interface EdgeCurrencyEngineCallbacks {
   readonly onUnactivatedTokenIdsChanged: (unactivatedTokenIds: string[]) => void
   readonly onWcNewContractCall: (payload: JsonObject) => void
 
-  // Deprecated
+  /** @deprecated onTransactionsChanged handles confirmation changes */
   readonly onBlockHeightChanged: (blockHeight: number) => void
 }
 
@@ -713,11 +721,19 @@ export interface EdgeCurrencyEngine {
   // Escape hatch:
   readonly otherMethods?: EdgeOtherMethods
 
-  // Deprecated:
+  /** @deprecated Replaced by changeEnabledTokenIds */
   readonly enableTokens?: (tokens: string[]) => Promise<void>
+
+  /** @deprecated Replaced by changeEnabledTokenIds */
   readonly disableTokens?: (tokens: string[]) => Promise<void>
+
+  /** @deprecated No longer used */
   readonly getEnabledTokens?: () => Promise<string[]>
+
+  /** @deprecated Replaced by changeCustomTokens */
   readonly addCustomToken?: (token: EdgeTokenInfo & EdgeToken) => Promise<void>
+
+  /** @deprecated No longer used */
   readonly getTokenStatus?: (token: string) => boolean
 }
 
@@ -959,11 +975,19 @@ export interface EdgeCurrencyWallet {
   // Generic:
   readonly otherMethods: EdgeOtherMethods
 
-  // Deprecated:
+  /** @deprecated Call EdgeCurrencyConfig.addCustomToken instead */
   readonly addCustomToken: (token: EdgeTokenInfo) => Promise<void>
+
+  /** @deprecated Call changeEnabledTokenIds instead */
   readonly changeEnabledTokens: (currencyCodes: string[]) => Promise<void>
+
+  /** @deprecated Call changeEnabledTokenIds instead */
   readonly disableTokens: (tokens: string[]) => Promise<void>
+
+  /** @deprecated Call changeEnabledTokenIds instead */
   readonly enableTokens: (tokens: string[]) => Promise<void>
+
+  /** @deprecated Read enabledTokenIds instead */
   readonly getEnabledTokens: () => Promise<string[]>
 }
 
@@ -998,8 +1022,10 @@ export interface EdgeSwapRequest {
   nativeAmount: string
   quoteFor: 'from' | 'max' | 'to'
 
-  // Deprecated. Use the tokenId instead:
+  /** @deprecated Use fromTokenId instead */
   fromCurrencyCode?: string
+
+  /** @deprecated Use toTokenId instead */
   toCurrencyCode?: string
 }
 
@@ -1223,7 +1249,7 @@ export interface EdgeLoginRequest {
   readonly approve: () => Promise<void>
   readonly close: () => Promise<void>
 
-  // Deprecated. Use the dark & light images instead:
+  /** @deprecated Use displayImageDarkUrl or displayImageLightUrl instead */
   readonly displayImageUrl?: string
 }
 

--- a/test/core/account/account.test.ts
+++ b/test/core/account/account.test.ts
@@ -149,6 +149,24 @@ describe('account', function () {
     ])
   })
 
+  it('provides access to keys', async function () {
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
+    const context = await world.makeEdgeContext(contextOptions)
+    const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
+
+    const walletId = 'narfavJN4rp9ZzYigcRj1i0vrU2OAGGp4+KksAksj54='
+    expect(await account.getRawPrivateKey(walletId)).deep.equals({
+      dataKey: 'RlY1l6wQ5ntQgUHE70vG/2M/qiLdvWMnIAM7KJIcsDs=',
+      fakecoinKey: 'zARFBBkgUe6pYB6l',
+      syncKey: 'XKg8OnJCRNUZrsSe/lqPyWxvzaw='
+    })
+    expect(await account.getRawPublicKey(walletId)).deep.equals({
+      fakeAddress: 'FakePublicAddress'
+    })
+    expect(await account.getDisplayPrivateKey(walletId)).deep.equals('xpriv')
+    expect(await account.getDisplayPublicKey(walletId)).deep.equals('xpub')
+  })
+
   it('change currency plugin settings', async function () {
     const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)

--- a/test/fake/fake-currency-plugin.ts
+++ b/test/fake/fake-currency-plugin.ts
@@ -76,7 +76,7 @@ const asState = asObject({
 /**
  * Currency plugin transaction engine.
  */
-class FakeCurrencyEngine {
+class FakeCurrencyEngine implements EdgeCurrencyEngine {
   private readonly walletId: string
   private readonly callbacks: EdgeCurrencyEngineCallbacks
   private running: boolean
@@ -164,15 +164,6 @@ class FakeCurrencyEngine {
 
   async changeUserSettings(settings: JsonObject): Promise<void> {
     await this.updateState(asState(settings))
-  }
-
-  // Keys:
-  getDisplayPrivateSeed(): string | null {
-    return 'xpriv'
-  }
-
-  getDisplayPublicSeed(): string | null {
-    return 'xpub'
   }
 
   // Engine state
@@ -324,7 +315,7 @@ class FakeCurrencyEngine {
 /**
  * Currency plugin setup object.
  */
-class FakeCurrencyTools {
+class FakeCurrencyTools implements EdgeCurrencyTools {
   // Keys:
   createPrivateKey(
     walletType: string,
@@ -336,13 +327,25 @@ class FakeCurrencyTools {
     return Promise.resolve({ fakeKey: 'FakePrivateKey' })
   }
 
-  derivePublicKey(walletInfo: EdgeWalletInfo): Promise<JsonObject> {
-    return Promise.resolve({
-      fakeAddress: 'FakePublicAddress'
-    })
+  async derivePublicKey(
+    privateWalletInfo: EdgeWalletInfo
+  ): Promise<JsonObject> {
+    return { fakeAddress: 'FakePublicAddress' }
   }
 
-  getSplittableTypes(walletInfo: EdgeWalletInfo): string[] {
+  async getDisplayPrivateKey(
+    privateWalletInfo: EdgeWalletInfo
+  ): Promise<string> {
+    return 'xpriv'
+  }
+
+  async getDisplayPublicKey(
+    privateWalletInfo: EdgeWalletInfo
+  ): Promise<string> {
+    return 'xpub'
+  }
+
+  getSplittableTypes(publicWalletInfo: EdgeWalletInfo): string[] {
     return ['wallet:tulipcoin']
   }
 


### PR DESCRIPTION
### CHANGELOG

- added: Provide `EdgeAccount` methods for reading public and private keys:
  - `getDisplayPrivateKey`
  - `getDisplayPublicKey`
  - `getRawPrivateKey`
  - `getRawPublicKey`
- added: Add `EdgeCurrencyTools` methods for getting display keys.
- deprecated: `EdgeCurrencyEngine` methods for getting display keys.
- deprecated: `EdgeAccount` and `EdgeCurrencyWallet` key properties.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204451072447687