### PR TITLE
Call setupNewTxMetadata for every new unknown transaction

### DIFF
--- a/src/core/currency/wallet/currency-wallet-callbacks.ts
+++ b/src/core/currency/wallet/currency-wallet-callbacks.ts
@@ -280,7 +280,7 @@ export function makeCurrencyWalletCallbacks(
 
         // Ensure the transaction has metadata:
         const txidHash = hashStorageWalletFilename(state, walletId, txid)
-        const isNew = tx.isSend ? false : fileNames[txidHash] == null
+        const isNew = fileNames[txidHash] == null
         if (isNew) {
           setupNewTxMetadata(input, tx).catch(error =>
             input.props.onError(error)


### PR DESCRIPTION
The previous logic assumed that a send always originated from an Edge account and setupNewTxMetadata was already called during saveTx. This isn't the case for sends that are broadcast outside of the app and first seen through a transaction query

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204535089316834