### PR TITLE
Fix getTransactions

### DIFF
--- a/src/core/currency/wallet/currency-wallet-api.ts
+++ b/src/core/currency/wallet/currency-wallet-api.ts
@@ -251,6 +251,7 @@ export function makeCurrencyWalletApi(
     ): Promise<EdgeTransaction[]> {
       const { currencyCode = plugin.currencyInfo.currencyCode } = opts
 
+      // Load transactions from the engine if necessary:
       let state = input.props.walletState
       if (!state.gotTxs[currencyCode]) {
         const txs = await engine.getTransactions({ currencyCode })
@@ -265,22 +266,27 @@ export function makeCurrencyWalletApi(
         state = input.props.walletState
       }
 
-      // Txid array of all txs
-      const txids = state.txids
-      // Merged tx data from metadata files and blockchain data
-      const txs = state.txs
+      const {
+        // All the files we have loaded from disk:
+        files,
+        // All the txid hashes we know about from either the engine or disk,
+        // sorted using the lowest available date.
+        // Some may not exist on disk, and some may not exist on chain:
+        sortedTxidHashes,
+        // Maps from txid hashes to original txids:
+        txidHashes,
+        // All the transactions we have from the engine:
+        txs
+      } = state
+      const txids = Object.keys(txs)
       const { startIndex = 0, startEntries = txids.length } = opts
-      // Decrypted metadata files
-      const files = state.files
-      // A sorted list of transaction based on chronological order
-      // these are tx id hashes merged between blockchain and cache some tx id hashes
-      // some may have been dropped by the blockchain
-      const sortedTransactions = state.sortedTransactions.sortedList
+
       // create map of tx id hashes to their order (cardinality)
       const mappedUnfilteredIndexes: { [txid: string]: number } = {}
-      sortedTransactions.forEach((item, index) => {
+      sortedTxidHashes.forEach((item, index) => {
         mappedUnfilteredIndexes[item] = index
       })
+
       // we need to make sure that after slicing, the total txs number is equal to opts.startEntries
       // slice, verify txs in files, if some are dropped and missing, do it again recursively
       let searchedTxs = 0
@@ -288,7 +294,7 @@ export function makeCurrencyWalletApi(
       const out: EdgeTransaction[] = []
       while (searchedTxs < startEntries) {
         // take a slice from sorted transactions that begins at current index and goes until however many are left
-        const slicedTransactions = sortedTransactions.slice(
+        const slicedTransactions = sortedTxidHashes.slice(
           startIndex + startEntries * counter,
           startIndex + startEntries * (counter + 1)
         )
@@ -308,8 +314,9 @@ export function makeCurrencyWalletApi(
 
         for (const txidHash of slicedTransactions) {
           const file = files[txidHash]
-          if (file == null) continue
-          const tempTx = txs[file.txid]
+          const txid = file?.txid ?? txidHashes[txidHash]?.txid
+          if (txid == null) continue
+          const tempTx = txs[txid]
           // skip irrelevant transactions - txs that are not in the files (dropped)
           if (
             tempTx == null ||

--- a/src/core/currency/wallet/currency-wallet-api.ts
+++ b/src/core/currency/wallet/currency-wallet-api.ts
@@ -253,9 +253,7 @@ export function makeCurrencyWalletApi(
 
       let state = input.props.walletState
       if (!state.gotTxs[currencyCode]) {
-        const txs = await engine.getTransactions({
-          currencyCode: opts.currencyCode
-        })
+        const txs = await engine.getTransactions({ currencyCode })
         fakeCallbacks.onTransactionsChanged(txs)
         input.props.dispatch({
           type: 'CURRENCY_ENGINE_GOT_TXS',

--- a/src/core/currency/wallet/currency-wallet-callbacks.ts
+++ b/src/core/currency/wallet/currency-wallet-callbacks.ts
@@ -297,7 +297,7 @@ export function makeCurrencyWalletCallbacks(
         )
         if (isNew) created.push(combinedTx)
         else if (files[txidHash] != null) changed.push(combinedTx)
-        txidHashes[txidHash] = combinedTx.date
+        txidHashes[txidHash] = { date: combinedTx.date, txid }
       }
 
       // Tell everyone who cares:

--- a/src/core/currency/wallet/currency-wallet-export.ts
+++ b/src/core/currency/wallet/currency-wallet-export.ts
@@ -8,10 +8,11 @@ export function dateFilter(
   tx: EdgeTransaction,
   opts: EdgeGetTransactionsOptions
 ): boolean {
-  const { startDate = -Infinity, endDate = Date.now() } = opts
+  const { startDate = new Date(0), endDate = new Date() } = opts
 
-  if (tx.date * 1000 >= startDate && tx.date * 1000 < endDate) return true
-  return false
+  return (
+    tx.date * 1000 >= startDate.valueOf() && tx.date * 1000 < endDate.valueOf()
+  )
 }
 
 export function searchStringFilter(

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -565,13 +565,21 @@ export interface EdgeCurrencyCodeOptions {
 
 export interface EdgeGetTransactionsOptions {
   currencyCode?: string
+
+  // Pagination:
   startIndex?: number
   startEntries?: number
+
+  // Filtering:
   startDate?: Date
   endDate?: Date
   searchString?: string
+
+  /** @deprecated Does nothing */
   returnIndex?: number
+  /** @deprecated Does nothing */
   returnEntries?: number
+  /** @deprecated Does nothing */
   denomination?: string
 }
 
@@ -653,7 +661,7 @@ export interface EdgeCurrencyEngine {
   readonly getBalance: (opts: EdgeCurrencyCodeOptions) => string
   readonly getNumTransactions: (opts: EdgeCurrencyCodeOptions) => number
   readonly getTransactions: (
-    opts: EdgeGetTransactionsOptions
+    opts: EdgeCurrencyCodeOptions
   ) => Promise<EdgeTransaction[]>
   readonly getTxids?: () => EdgeTxidMap
 


### PR DESCRIPTION
### CHANGELOG

- fixed: Return transactions from `getTransactions`, even if they have no on-disk metadata.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

I have tested this by exporting CSV's before & after the change, and verifying that they appear identically.

I also set up a transaction with a missing file, and verified that it still appeared in the CSV / transaction list.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204535089316834