### PR TITLE
Do not crash when an account has no username

### DIFF
--- a/src/core/account/account-api.ts
+++ b/src/core/account/account-api.ts
@@ -162,8 +162,7 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
       return base58.stringify(loginTree.loginId)
     },
 
-    get username(): string {
-      if (username == null) throw new Error('Missing username')
+    get username(): string | undefined {
       return username
     },
 

--- a/src/types/fake-types.ts
+++ b/src/types/fake-types.ts
@@ -101,7 +101,7 @@ export interface FakeUser {
   loginKey: Uint8Array
   repos: { [repo: string]: { [path: string]: EdgeBox } }
   server: LoginDump
-  username: string
+  username?: string
 }
 
 export const asVoucherDump: Cleaner<VoucherDump> = asObject({
@@ -189,7 +189,7 @@ export const asFakeUser: Cleaner<FakeUser> = asObject({
   loginKey: asBase64,
   repos: asObject(asObject(asEdgeBox)),
   server: asLoginDump,
-  username: asUsername
+  username: asOptional(asUsername)
 })
 
 export const asFakeUsers = asArray<FakeUser>(asFakeUser)

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1299,7 +1299,7 @@ export interface EdgeAccount {
   readonly loggedIn: boolean
   readonly recoveryKey: string | undefined // base58, for email backup
   readonly rootLoginId: string // base58
-  readonly username: string
+  readonly username: string | undefined
 
   /** Gets the base58 decryption key for biometric login */
   readonly getLoginKey: () => Promise<string> // base58

--- a/test/core/login/login.test.ts
+++ b/test/core/login/login.test.ts
@@ -69,6 +69,7 @@ describe('creation', function () {
       pin: fakeUser.pin,
       now
     })
+    expect(account.username).equals(undefined)
     expect(context.localUsers).deep.equals([
       {
         keyLoginEnabled: true,


### PR DESCRIPTION
### CHANGELOG

- fixed: Do not crash when accessing `Account.username` on an account that has none.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
