### PR TITLE
Forget account

### DIFF
--- a/src/core/actions.ts
+++ b/src/core/actions.ts
@@ -347,7 +347,7 @@ export type RootAction =
   | {
       // Fires when we delete login data from disk.
       type: 'LOGIN_STASH_DELETED'
-      payload: string // username
+      payload: Uint8Array // loginId
     }
   | {
       // Fires when we write a login stash to disk.

--- a/src/core/context/context-api.ts
+++ b/src/core/context/context-api.ts
@@ -41,7 +41,7 @@ export function makeContextApi(ai: ApiInput): EdgeContext {
   const $internalStuff = new EdgeInternalStuff(ai)
   let pauseTimer: ReturnType<typeof setTimeout> | undefined
 
-  const out: EdgeContext = {
+  const out: EdgeContext & { $internalStuff: EdgeInternalStuff } = {
     on: onMethod,
     watch: watchMethod,
 
@@ -52,7 +52,6 @@ export function makeContextApi(ai: ApiInput): EdgeContext {
       ai.props.close()
     },
 
-    // @ts-expect-error: This isn't supposed to be here:
     $internalStuff,
 
     fixUsername,

--- a/src/core/login/login-reducer.ts
+++ b/src/core/login/login-reducer.ts
@@ -80,8 +80,10 @@ export const login = buildReducer<LoginState, RootAction, RootState>({
       }
 
       case 'LOGIN_STASH_DELETED': {
-        const username = action.payload
-        return state.filter(stashTree => stashTree.username !== username)
+        const loginId = action.payload
+        return state.filter(
+          stashTree => !verifyData(stashTree.loginId, loginId)
+        )
       }
 
       case 'LOGIN_STASH_SAVED': {

--- a/src/core/login/login-stash.ts
+++ b/src/core/login/login-stash.ts
@@ -22,6 +22,7 @@ import {
 } from '../../types/server-cleaners'
 import { EdgeBox, EdgeSnrp } from '../../types/server-types'
 import { EdgeLog, EdgePendingVoucher } from '../../types/types'
+import { verifyData } from '../../util/crypto/verify'
 import { base58 } from '../../util/encoding'
 import { ApiInput } from '../root-pixie'
 
@@ -94,7 +95,7 @@ export async function loadStashes(
  */
 export async function removeStash(
   ai: ApiInput,
-  username: string
+  loginId: Uint8Array
 ): Promise<void> {
   const { dispatch, io } = ai.props
 
@@ -102,13 +103,13 @@ export async function removeStash(
   for (const path of paths) {
     try {
       const stash = asLoginStash(JSON.parse(await io.disklet.getText(path)))
-      if (stash.username === username) await io.disklet.delete(path)
+      if (verifyData(stash.loginId, loginId)) await io.disklet.delete(path)
     } catch (error: any) {}
   }
 
   dispatch({
     type: 'LOGIN_STASH_DELETED',
-    payload: username
+    payload: loginId
   })
 }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1532,16 +1532,16 @@ export interface EdgeContext {
 
   // Local user management:
   localUsers: EdgeUserInfo[]
-  readonly fixUsername: (username: string) => string
-  readonly deleteLocalAccount: (username: string) => Promise<void>
+  readonly forgetAccount: (rootLoginId: string) => Promise<void>
 
   // Account creation:
+  readonly fixUsername: (username: string) => string
   readonly usernameAvailable: (username: string) => Promise<boolean>
   readonly createAccount: (
     opts: EdgeCreateAccountOptions & EdgeAccountOptions
   ) => Promise<EdgeAccount>
 
-  // Edge login:
+  // Barcode login:
   readonly requestEdgeLogin: (
     opts?: EdgeAccountOptions
   ) => Promise<EdgePendingEdgeLogin>
@@ -1608,6 +1608,9 @@ export interface EdgeContext {
 
   /** @deprecated Use `localUsers` instead. */
   readonly pinLoginEnabled: (username: string) => Promise<boolean>
+
+  /** @deprecated Use `forgetAccount` instead. */
+  readonly deleteLocalAccount: (username: string) => Promise<void>
 }
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
### CHANGELOG

- added: Add an `EdgeContext.forgetAccount` method
- deprecated: `EdgeContext.deleteLocalAccount`. Use `EdgeContext.forgetAccount` instead.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204773336231740