### PR TITLE
Fix barcode logins for username-free accounts

### DIFF
--- a/src/core/login/edge.ts
+++ b/src/core/login/edge.ts
@@ -94,7 +94,6 @@ export async function requestEdgeLogin(
     // Decode the reply:
     const payload = asLobbyLoginPayload(reply)
     const { username } = payload.loginStash
-    if (username == null) throw new Error('No username in reply')
     out.state = 'started'
     out.username = username
     update(out)


### PR DESCRIPTION
### CHANGELOG

- fixed: Do not throw a "No username in reply" error when logging into light accounts via barcode.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204773336231750