### PR TITLE
Send 'transactionsChanged' when editing metadata

### DIFF
--- a/src/core/currency/wallet/currency-wallet-callbacks.ts
+++ b/src/core/currency/wallet/currency-wallet-callbacks.ts
@@ -276,7 +276,7 @@ export function makeCurrencyWalletCallbacks(
 
         // Verify that something has changed:
         const reduxTx = mergeTx(tx, defaultCurrency, reduxTxs[txid])
-        if (compare(reduxTx, reduxTxs[txid])) continue
+        if (compare(reduxTx, reduxTxs[txid]) && tx.metadata == null) continue
 
         // Ensure the transaction has metadata:
         const txidHash = hashStorageWalletFilename(state, walletId, txid)


### PR DESCRIPTION
### CHANGELOG

- fixed: Correctly send a 'transactionsChanged' event when editing metadata.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

We have always tried to send this callback, but we were filtering the transaction out because it had no on-chain changes. Currency engines do not send metadata, so we can conclude that the core sent the transaction if we get metadata. If the core sent the transaction, we should skip the filtering.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204809507156151