### PR TITLE
Add an `EdgeAccount.getPin` method

### DIFF
--- a/src/core/account/account-api.ts
+++ b/src/core/account/account-api.ts
@@ -256,6 +256,11 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
         : await checkPin2(ai, loginTree, pin)
     },
 
+    async getPin(): Promise<string | undefined> {
+      const { login, loginTree } = accountState()
+      return login.pin ?? loginTree.pin
+    },
+
     // ----------------------------------------------------------------
     // Remove credentials:
     // ----------------------------------------------------------------

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1361,6 +1361,7 @@ export interface EdgeAccount {
   // Verify existing credentials:
   readonly checkPassword: (password: string) => Promise<boolean>
   readonly checkPin: (pin: string) => Promise<boolean>
+  readonly getPin: () => Promise<string | undefined>
 
   // Remove credentials:
   readonly deletePassword: () => Promise<void>

--- a/test/core/login/login.test.ts
+++ b/test/core/login/login.test.ts
@@ -206,7 +206,11 @@ describe('pin', function () {
   it('login', async function () {
     const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)
-    await context.loginWithPIN(fakeUser.username, fakeUser.pin)
+    const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
+
+    // Although PIN login is enabled, we don't know the PIN in plain text
+    // because the fake user has a legacy setup:
+    expect(await account.getPin()).equals(undefined)
   })
 
   it('changes', async function () {
@@ -215,6 +219,7 @@ describe('pin', function () {
     const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
 
     await account.changePin({ pin: '4321' })
+    expect(await account.getPin()).equals('4321')
     await context.loginWithPIN(fakeUser.username, '4321')
 
     const remote = await world.makeEdgeContext(contextOptions)


### PR DESCRIPTION
### CHANGELOG

- added: Add an `EdgeAccount.getPin` method

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204827955021807