### PR TITLE
Use make `fetchCors` a pass-through to `fetch` and deprecate

### DIFF
--- a/src/io/react-native/react-native-worker.ts
+++ b/src/io/react-native/react-native-worker.ts
@@ -3,7 +3,6 @@ import './polyfills'
 import hashjs from 'hash.js'
 import HmacDRBG from 'hmac-drbg'
 import { base64 } from 'rfc4648'
-import { makeFetchResponse } from 'serverlet'
 import { Bridge, bridgifyObject } from 'yaob'
 
 import {
@@ -88,7 +87,7 @@ async function makeIo(clientIo: ClientIo): Promise<EdgeIo> {
     entropy: base64.parse(await nativeBridge.call('randomBytes', 32))
   })
 
-  return {
+  const io: EdgeIo = {
     disklet: {
       delete(path) {
         return nativeBridge.call('diskletDelete', normalizePath(path))
@@ -170,9 +169,11 @@ async function makeIo(clientIo: ClientIo): Promise<EdgeIo> {
       uri: string,
       opts: EdgeFetchOptions = {}
     ): Promise<EdgeFetchResponse> {
-      return clientIo.fetchCors(uri, opts).then(makeFetchResponse)
+      return io.fetch(uri, opts)
     }
   }
+
+  return io
 }
 
 /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -65,7 +65,11 @@ export interface EdgeIo {
   readonly disklet: Disklet
   readonly fetch: EdgeFetchFunction
 
-  // This is only present if the platform has some way to avoid CORS:
+  /**
+   * This is only present if the platform has some way to avoid CORS.
+   *
+   * @deprecated Use `fetch` method on `EdgeIo` interface.
+   */
   readonly fetchCors?: EdgeFetchFunction
 }
 

--- a/src/util/asyncWaterfall.ts
+++ b/src/util/asyncWaterfall.ts
@@ -1,0 +1,50 @@
+import { snooze } from './snooze'
+
+type AsyncFunction = () => Promise<any>
+
+export async function asyncWaterfall(
+  asyncFuncs: AsyncFunction[],
+  timeoutMs: number = 5000
+): Promise<any> {
+  let pending = asyncFuncs.length
+  const promises: Array<Promise<any>> = []
+  for (const func of asyncFuncs) {
+    const index = promises.length
+    promises.push(
+      func().catch(e => {
+        e.index = index
+        throw e
+      })
+    )
+    if (pending > 1) {
+      promises.push(
+        new Promise(resolve => {
+          snooze(timeoutMs)
+            .then(() => {
+              resolve('async_waterfall_timed_out')
+            })
+            .catch(_ => {})
+        })
+      )
+    }
+    try {
+      const result = await Promise.race(promises)
+      if (result === 'async_waterfall_timed_out') {
+        const p = promises.pop()
+        p?.catch(_ => {})
+        --pending
+      } else {
+        return result
+      }
+    } catch (e: any) {
+      const i = e.index
+      promises.splice(i, 1)
+      const p = promises.pop()
+      p?.catch(_ => {})
+      --pending
+      if (pending === 0) {
+        throw e
+      }
+    }
+  }
+}

--- a/src/util/shuffle.ts
+++ b/src/util/shuffle.ts
@@ -1,0 +1,7 @@
+export function shuffle<T>(arr: T[]): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[arr[i], arr[j]] = [arr[j], arr[i]]
+  }
+  return arr
+}


### PR DESCRIPTION
### CHANGELOG

- Changed: Added a fallback to edge-cors-proxy server to `fetch` method on `EdgeIo`.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204536097865430