### PR TITLE
Restore fetch behavior for security

### DIFF
--- a/src/core/fake/fake-io.ts
+++ b/src/core/fake/fake-io.ts
@@ -44,7 +44,8 @@ export function makeFakeIo(): EdgeIo {
     disklet: makeMemoryDisklet(),
 
     // Networking:
-    fetch: fakeFetch
+    fetch: fakeFetch,
+    fetchCors: fakeFetch
   }
   return out
 }

--- a/src/io/browser/browser-io.ts
+++ b/src/io/browser/browser-io.ts
@@ -2,6 +2,16 @@ import { makeLocalStorageDisklet } from 'disklet'
 
 import { EdgeFetchOptions, EdgeFetchResponse, EdgeIo } from '../../types/types'
 import { scrypt } from '../../util/crypto/scrypt'
+import { fetchCorsProxy } from '../fetch-cors-proxy'
+
+// Only try CORS proxy/bridge techniques up to 5 times
+const MAX_CORS_FAILURE_COUNT = 5
+
+// A map of domains that failed CORS and succeeded via the CORS proxy server
+const hostnameProxyWhitelist = new Set<string>()
+
+// A map of domains that failed all CORS techniques and should not re-attempt CORS techniques
+const hostnameCorsProxyBlacklist = new Map<string, number>()
 
 /**
  * Extracts the io functions we need from the browser.
@@ -31,6 +41,55 @@ export function makeBrowserIo(): EdgeIo {
     // Networking:
     fetch(uri: string, opts?: EdgeFetchOptions): Promise<EdgeFetchResponse> {
       return window.fetch(uri, opts)
+    },
+    async fetchCors(
+      uri: string,
+      opts?: EdgeFetchOptions
+    ): Promise<EdgeFetchResponse> {
+      const { hostname } = new URL(uri)
+      const corsFailureCount = hostnameCorsProxyBlacklist.get(hostname) ?? 0
+
+      let doFetch = true
+      const doFetchCors = true
+
+      if (
+        corsFailureCount < MAX_CORS_FAILURE_COUNT &&
+        hostnameProxyWhitelist.has(hostname)
+      ) {
+        // Proactively use fetchCorsProxy for any hostnames added to whitelist:
+        doFetch = false
+      }
+
+      let errorToThrow
+      if (doFetch) {
+        try {
+          // Attempt regular fetch:
+          return await window.fetch(uri, opts)
+        } catch (error) {
+          // If we exhaust attempts to use CORS-safe fetch, then throw the error:
+          if (corsFailureCount >= MAX_CORS_FAILURE_COUNT) {
+            throw error
+          }
+          errorToThrow = error
+        }
+      }
+
+      if (doFetchCors) {
+        try {
+          const response = await fetchCorsProxy(uri, opts)
+          hostnameProxyWhitelist.add(hostname)
+          return response
+        } catch (error) {
+          if (errorToThrow == null) errorToThrow = error
+        }
+      }
+
+      // We failed all CORS techniques, so track attempts
+      hostnameCorsProxyBlacklist.set(hostname, corsFailureCount + 1)
+
+      // Throw the error from the first fetch instead of the one from
+      // proxy server.
+      throw errorToThrow
     }
   }
 }

--- a/src/io/fetch-cors-proxy.ts
+++ b/src/io/fetch-cors-proxy.ts
@@ -1,0 +1,23 @@
+import { EdgeFetchOptions } from '../types/types'
+import { asyncWaterfall } from '../util/asyncWaterfall'
+import { shuffle } from '../util/shuffle'
+
+// Hard-coded CORS proxy server
+const PROXY_SERVER_URLS = ['https://cors1.edge.app', 'https://cors2.edge.app']
+
+export const fetchCorsProxy = async (
+  uri: string,
+  opts?: EdgeFetchOptions
+): Promise<Response> => {
+  const shuffledUrls = shuffle([...PROXY_SERVER_URLS])
+  const tasks = shuffledUrls.map(proxyServerUrl => async () =>
+    await window.fetch(proxyServerUrl, {
+      ...opts,
+      headers: {
+        ...opts?.headers,
+        'x-proxy-url': uri
+      }
+    })
+  )
+  return await asyncWaterfall(tasks)
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -66,11 +66,10 @@ export interface EdgeIo {
   readonly fetch: EdgeFetchFunction
 
   /**
-   * This is only present if the platform has some way to avoid CORS.
-   *
-   * @deprecated Use `fetch` method on `EdgeIo` interface.
+   * This is like `fetch`, but will try to avoid CORS limitations
+   * on platforms where that may be a problem.
    */
-  readonly fetchCors?: EdgeFetchFunction
+  readonly fetchCors: EdgeFetchFunction
 }
 
 // logging -------------------------------------------------------------


### PR DESCRIPTION
We cannot send any secrets or credentials through the CORS proxy servers, since those aren't a secure environment.

Therefore, we need to restore the distinction between the two `fetch` methods. However, since we *do* have bouncer servers, we can finally offer the `fetchCors` methods on the other platforms.

### CHANGELOG

- changed: Remove `fetch` fallback logic. No proxy servers will be used.
- changed: The `fetchCors` method is no longer deprecated. Use this if CORS might be an issue. Do *not* use this for any secrets or credentials.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205163372569911