### PR TITLE
Skip block height

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "rfc4648": "^1.4.0",
     "scrypt-js": "^2.0.3",
     "serverlet": "^0.1.2",
-    "yaob": "^0.3.9",
+    "yaob": "^0.3.11",
     "yavent": "^0.1.3"
   },
   "devDependencies": {

--- a/src/core/actions.ts
+++ b/src/core/actions.ts
@@ -329,6 +329,7 @@ export type RootAction =
         logSettings: EdgeLogSettings
         rateHintCache: EdgeRateHint[]
         pluginsInit: EdgeCorePluginsInit
+        skipBlockHeight: boolean
         stashes: LoginStash[]
       }
     }

--- a/src/core/currency/wallet/currency-wallet-api.ts
+++ b/src/core/currency/wallet/currency-wallet-api.ts
@@ -175,7 +175,8 @@ export function makeCurrencyWalletApi(
       return input.props.walletState.balances
     },
     get blockHeight(): number {
-      return input.props.walletState.height
+      const { skipBlockHeight } = input.props.state
+      return skipBlockHeight ? 0 : input.props.walletState.height
     },
     get syncRatio(): number {
       return input.props.walletState.syncRatio

--- a/src/core/currency/wallet/currency-wallet-callbacks.ts
+++ b/src/core/currency/wallet/currency-wallet-callbacks.ts
@@ -164,10 +164,9 @@ export function makeCurrencyWalletCallbacks(
         action: 'onBlockHeightChanged',
         updateFunc: () => {
           // Update transaction confirmation status
-          const { txs: reduxTxs } = input.props.walletState
-          const txsHack: any = Object.values(reduxTxs)
-          const reduxTxsArray: MergedTransaction[] = txsHack
-          for (const reduxTx of reduxTxsArray) {
+          const { txs } = input.props.walletState
+          for (const txid of Object.keys(txs)) {
+            const reduxTx = txs[txid]
             if (
               reduxTx.confirmations !== 'confirmed' &&
               reduxTx.confirmations !== 'dropped'

--- a/src/core/fake/fake-db.ts
+++ b/src/core/fake/fake-db.ts
@@ -91,7 +91,7 @@ export class FakeDb {
 
     // Create fake repos:
     for (const syncKey of Object.keys(user.repos)) {
-      this.repos[syncKey] = { ...user.repos[syncKey] } as any
+      this.repos[syncKey] = { ...user.repos[syncKey] }
     }
   }
 

--- a/src/core/root-reducer.ts
+++ b/src/core/root-reducer.ts
@@ -20,6 +20,7 @@ export interface RootState {
   readonly paused: boolean
   readonly rateHintCache: EdgeRateHint[]
   readonly ready: boolean
+  readonly skipBlockHeight: boolean
 
   // Children reducers:
   readonly currency: CurrencyState
@@ -94,6 +95,10 @@ export const reducer = buildReducer<RootState, RootAction, RootState>({
 
   ready(state = false, action): boolean {
     return action.type === 'INIT' ? true : state
+  },
+
+  skipBlockHeight(state = false, action): boolean {
+    return action.type === 'INIT' ? action.payload.skipBlockHeight : state
   },
 
   currency,

--- a/src/core/root.ts
+++ b/src/core/root.ts
@@ -37,7 +37,8 @@ export async function makeContext(
     authServer = 'https://login.edge.app/api',
     deviceDescription = null,
     hideKeys = false,
-    plugins: pluginsInit = {}
+    plugins: pluginsInit = {},
+    skipBlockHeight = false
   } = opts
   const logSettings = { ...defaultLogSettings, ...opts.logSettings }
   if (apiKey == null) {
@@ -83,6 +84,7 @@ export async function makeContext(
       logSettings,
       pluginsInit,
       rateHintCache,
+      skipBlockHeight,
       stashes
     }
   })

--- a/src/core/storage/encrypt-disklet.ts
+++ b/src/core/storage/encrypt-disklet.ts
@@ -33,10 +33,9 @@ export function encryptDisklet(
     },
 
     setData(path: string, data: ArrayLike<number>): Promise<unknown> {
-      const dataCast: any = data // Work around `Uint8Array.from` flow bug
       return disklet.setText(
         path,
-        JSON.stringify(encrypt(io, Uint8Array.from(dataCast), dataKey))
+        JSON.stringify(encrypt(io, Uint8Array.from(data), dataKey))
       )
     },
 

--- a/src/react-native.tsx
+++ b/src/react-native.tsx
@@ -41,7 +41,8 @@ export function MakeEdgeContext(props: EdgeContextProps): JSX.Element {
     deviceDescription,
     hideKeys,
     logSettings,
-    plugins
+    plugins,
+    skipBlockHeight
   } = props
   if (onLoad == null) {
     throw new TypeError('No onLoad passed to MakeEdgeContext')
@@ -66,7 +67,8 @@ export function MakeEdgeContext(props: EdgeContextProps): JSX.Element {
               deviceDescription,
               hideKeys,
               logSettings,
-              plugins
+              plugins,
+              skipBlockHeight
             }
           )
           .then(onLoad)

--- a/src/types/exports.ts
+++ b/src/types/exports.ts
@@ -78,6 +78,7 @@ export interface EdgeContextProps extends CommonProps {
   hideKeys?: boolean
   logSettings?: Partial<EdgeLogSettings>
   plugins?: EdgeCorePluginsInit
+  skipBlockHeight?: boolean
 }
 
 export interface EdgeFakeWorldProps extends CommonProps {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1489,6 +1489,15 @@ export interface EdgeContextOptions {
 
   path?: string // Only used on node.js
   plugins?: EdgeCorePluginsInit
+
+  /**
+   * True to skip updating the `EdgeCurrencyWallet.blockHeight` property.
+   * This may improve performance by reducing bridge traffic,
+   * but there will be no way to query the overall chain height.
+   * The core will continue updating individual transactions
+   * as their confirmation status changes.
+   */
+  skipBlockHeight?: boolean
 }
 
 export interface EdgeRecoveryQuestionChoice {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -371,6 +371,20 @@ export interface EdgeTxSwap {
   refundAddress?: string
 }
 
+export type EdgeConfirmationState =
+  // More than `EdgeCurrencyInfo.requiredConfirmations`:
+  | 'confirmed'
+  // Dropped from the network without confirmations:
+  | 'dropped'
+  // We don't know the chain height yet:
+  | 'syncing'
+  // No confirmations yet:
+  | 'unconfirmed'
+  // Something between 1 and `requiredConfirmations`.
+  // Currency engines can always return a number,
+  // and the core will translate it into one of the other states:
+  | number
+
 export interface EdgeTransaction {
   // Amounts:
   currencyCode: string
@@ -381,7 +395,7 @@ export interface EdgeTransaction {
   parentNetworkFee?: string
 
   // Confirmation status:
-  confirmations?: 'confirmed' | 'unconfirmed' | 'syncing' | 'dropped' | number
+  confirmations?: EdgeConfirmationState
   blockHeight: number
   date: number
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5686,10 +5686,10 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
-yaob@^0.3.9:
-  version "0.3.10"
-  resolved "https://registry.yarnpkg.com/yaob/-/yaob-0.3.10.tgz#fb86d54d564ff6014f6f52fafc4219b6c068f613"
-  integrity sha512-QU+03xtNssGOw01Tten5zlfNcrsMPQjy0Nr/gueVEbXYsXHgYeDKXNLgPNMdYdTY7qkvLj8IGLOk/MKtsUh+Fg==
+yaob@^0.3.11:
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/yaob/-/yaob-0.3.11.tgz#54dc4e03f5edabf7a0701c57e73e97cc69d2fc42"
+  integrity sha512-RRMKxWsjMGF9X7fyPny0w3icGriQCCT7FMtNrmxxyjxQIQn8GB4+CT4SWpgUca82RBvjRt5pRqKmbnvmMfKc9A==
   dependencies:
     rfc4648 "^1.1.0"
 


### PR DESCRIPTION
### CHANGELOG

- added: Add a `skipBlockHeight` context option, to avoid sending block-height changes over the React Native bridge. Transaction confirmations will continue to update as before.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204536619363924