### PR TITLE
Add support for multiple memos per transaction

### DIFF
--- a/src/core/account/plugin-api.ts
+++ b/src/core/account/plugin-api.ts
@@ -22,7 +22,9 @@ const emptyTokenIds: string[] = []
 /**
  * Access to an individual currency plugin's methods.
  */
-export class CurrencyConfig extends Bridgeable<EdgeCurrencyConfig> {
+export class CurrencyConfig
+  extends Bridgeable<EdgeCurrencyConfig>
+  implements EdgeCurrencyConfig {
   _ai: ApiInput
   _accountId: string
   _pluginId: string

--- a/src/core/currency/wallet/currency-wallet-reducer.ts
+++ b/src/core/currency/wallet/currency-wallet-reducer.ts
@@ -4,6 +4,7 @@ import { buildReducer, filterReducer, memoizeReducer } from 'redux-keto'
 import {
   EdgeBalances,
   EdgeCurrencyInfo,
+  EdgeMemo,
   EdgeStakingStatus,
   EdgeTransaction,
   EdgeWalletInfo,
@@ -44,6 +45,7 @@ export interface MergedTransaction {
   currencyCode: string
   date: number
   isSend: boolean
+  memos: EdgeMemo[]
   otherParams?: JsonObject
   ourReceiveAddresses: string[]
   signedTx: string
@@ -397,6 +399,7 @@ const defaultTx: MergedTransaction = {
   currencyCode: '',
   date: 0,
   isSend: false,
+  memos: [],
   ourReceiveAddresses: [],
   signedTx: '',
   txid: '',
@@ -414,7 +417,8 @@ export function mergeTx(
 ): MergedTransaction {
   const {
     currencyCode = defaultCurrency,
-    isSend = lt(tx.nativeAmount, '0')
+    isSend = lt(tx.nativeAmount, '0'),
+    memos
   } = tx
 
   const out = {
@@ -422,6 +426,7 @@ export function mergeTx(
     confirmations: tx.confirmations ?? 'unconfirmed',
     currencyCode,
     date: tx.date,
+    memos,
     otherParams: tx.otherParams,
     ourReceiveAddresses: tx.ourReceiveAddresses,
     signedTx: tx.signedTx,

--- a/src/core/currency/wallet/upgrade-memos.ts
+++ b/src/core/currency/wallet/upgrade-memos.ts
@@ -1,0 +1,67 @@
+import { EdgeCurrencyInfo, EdgeMemo, EdgeSpendInfo } from '../../../types/types'
+
+/**
+ * Upgrades the memo fields inside an EdgeSpendTarget,
+ * so any combination of legacy or modern apps or plugins will work.
+ */
+export function upgradeMemos(
+  spendInfo: EdgeSpendInfo,
+  currencyInfo: EdgeCurrencyInfo
+): EdgeSpendInfo {
+  const legacyMemos: EdgeMemo[] = []
+
+  // If this chain supports legacy memos, grab those:
+  const { memoType } = currencyInfo
+  if (memoType === 'hex' || memoType === 'number' || memoType === 'text') {
+    for (const target of spendInfo.spendTargets) {
+      if (target.memo != null) {
+        legacyMemos.push({
+          type: memoType,
+          value: target.memo
+        })
+      } else if (target.uniqueIdentifier != null) {
+        legacyMemos.push({
+          type: memoType,
+          value: target.uniqueIdentifier
+        })
+      } else if (typeof target.otherParams?.uniqueIdentifier === 'string') {
+        legacyMemos.push({
+          type: memoType,
+          value: target.otherParams.uniqueIdentifier
+        })
+      }
+    }
+  }
+
+  // Make a modern, legacy-free spend target:
+  const out: EdgeSpendInfo = {
+    ...spendInfo,
+
+    // Delete any legacy memo fields:
+    spendTargets: spendInfo.spendTargets.map(target => ({
+      ...target,
+      memo: undefined,
+      uniqueIdentifier: undefined
+    })),
+
+    // Only use the legacy memos if new ones are missing:
+    memos: spendInfo.memos ?? legacyMemos
+  }
+
+  // If we have exactly one memo, copy it to the legacy fields
+  // to support out-dated currency plugins:
+  if (out.memos?.length === 1 && out.spendTargets.length >= 1) {
+    const [memo] = out.memos
+    if (memo.type === currencyInfo.memoType) {
+      const [target] = out.spendTargets
+      target.memo = memo.value
+      target.uniqueIdentifier = memo.value
+      target.otherParams = {
+        ...target.otherParams,
+        uniqueIdenfitifer: memo.value
+      }
+    }
+  }
+
+  return out
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -857,6 +857,7 @@ export interface EdgeCurrencyEngine {
 
 // currency plugin -----------------------------------------------------
 
+/** @deprecated Use EdgeCurrencyInfo.memoOptions instead */
 export interface EdgeMemoRules {
   passed: boolean
   tooLarge?: boolean // Too large numerically
@@ -902,7 +903,7 @@ export interface EdgeCurrencyTools {
     customTokens?: EdgeMetaToken[]
   ) => Promise<string>
 
-  // Transaction memos:
+  /** @deprecated Use EdgeCurrencyInfo.memoOptions instead */
   readonly validateMemo?: (memo: string) => Promise<EdgeMemoRules>
 }
 
@@ -1015,7 +1016,6 @@ export interface EdgeCurrencyWallet {
     nativeAmount: string,
     currencyCode: string
   ) => Promise<string>
-  readonly validateMemo: (memo: string) => Promise<EdgeMemoRules>
 
   // Chain state:
   readonly balances: EdgeBalances
@@ -1098,6 +1098,9 @@ export interface EdgeCurrencyWallet {
 
   // Generic:
   readonly otherMethods: EdgeOtherMethods
+
+  /** @deprecated Use EdgeCurrencyInfo.memoOptions instead */
+  readonly validateMemo: (memo: string) => Promise<EdgeMemoRules>
 }
 
 // ---------------------------------------------------------------------

--- a/test/fake/fake-currency-plugin.ts
+++ b/test/fake/fake-currency-plugin.ts
@@ -28,17 +28,21 @@ import { compare } from '../../src/util/compare'
 const GENESIS_BLOCK = 1231006505000
 
 const fakeCurrencyInfo: EdgeCurrencyInfo = {
-  // Basic currency information:
   currencyCode: 'FAKE',
   displayName: 'Fake Coin',
   pluginId: 'fakecoin',
+  walletType: 'wallet:fakecoin',
+
+  // Explorers:
+  addressExplorer: 'https://edge.app',
+  transactionExplorer: 'https://edge.app',
+
   denominations: [
     { multiplier: '10', name: 'SMALL' },
     { multiplier: '100', name: 'FAKE' }
   ],
-  walletType: 'wallet:fakecoin',
 
-  // Configuration options:
+  // Deprecated:
   defaultSettings: {},
   metaTokens: [
     {
@@ -49,10 +53,7 @@ const fakeCurrencyInfo: EdgeCurrencyInfo = {
         '0XF98103E9217F099208569D295C1B276F1821348636C268C854BB2A086E0037CD'
     }
   ],
-
-  // Explorers:
-  addressExplorer: 'https://edge.app',
-  transactionExplorer: 'https://edge.app'
+  memoType: 'text'
 }
 
 interface State {
@@ -269,6 +270,7 @@ class FakeCurrencyEngine implements EdgeCurrencyEngine {
       date: GENESIS_BLOCK,
       feeRateUsed: { fakePrice: 0 },
       isSend: false,
+      memos: [],
       nativeAmount: total,
       networkFee: '0',
       otherParams: {},
@@ -375,6 +377,7 @@ const blankTx: EdgeTransaction = {
   currencyCode: 'FAKE',
   date: GENESIS_BLOCK,
   isSend: false,
+  memos: [],
   nativeAmount: '0',
   networkFee: '0',
   ourReceiveAddresses: [],


### PR DESCRIPTION
### CHANGELOG

- added: Add an `EdgeTransaction.memos` field to report on-chain memos.
- added: Accept `EdgeSpendInfo.memos` to specify outgoing memos more precisely.
- deprecated: `EdgeSpendTarget.memo`. Use `EdgeSpendInfo.memos` instead.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205270927030443