### PR TITLE
Fix saving tokens at wallet creation time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Correctly save `enabledTokenIds` when creating a new wallet.
+
 ## 2.2.0 (2024-02-12)
 
 - added: Accept an `enabledTokens` parameter to the `createCurrencyWallets` method.

--- a/src/core/currency/wallet/currency-wallet-files.ts
+++ b/src/core/currency/wallet/currency-wallet-files.ts
@@ -235,23 +235,25 @@ export async function loadTokensFile(
     disklet,
     LEGACY_TOKENS_FILE
   )
-  const { accountId, currencyInfo, pluginId } = input.props.walletState
-  const accountState = input.props.state.accounts[accountId]
-  const tokenIds = currencyCodesToTokenIds(
-    accountState.builtinTokens[pluginId],
-    accountState.customTokens[pluginId],
-    currencyInfo,
-    legacyCurrencyCodes ?? []
-  )
+  if (legacyCurrencyCodes != null) {
+    const { accountId, currencyInfo, pluginId } = input.props.walletState
+    const accountState = input.props.state.accounts[accountId]
+    const tokenIds = currencyCodesToTokenIds(
+      accountState.builtinTokens[pluginId],
+      accountState.customTokens[pluginId],
+      currencyInfo,
+      legacyCurrencyCodes
+    )
 
-  dispatch({
-    type: 'CURRENCY_WALLET_LOADED_TOKEN_FILE',
-    payload: {
-      walletId: input.props.walletId,
-      detectedTokenIds: [],
-      enabledTokenIds: tokenIds
-    }
-  })
+    dispatch({
+      type: 'CURRENCY_WALLET_LOADED_TOKEN_FILE',
+      payload: {
+        walletId: input.props.walletId,
+        detectedTokenIds: [],
+        enabledTokenIds: tokenIds
+      }
+    })
+  }
 }
 
 /**

--- a/test/core/account/account.test.ts
+++ b/test/core/account/account.test.ts
@@ -115,12 +115,14 @@ describe('account', function () {
     const wallet = await account.createCurrencyWallet('wallet:fakecoin', {
       fiatCurrencyCode: 'iso:JPY',
       migratedFromWalletId: 'asdf',
-      name: 'test wallet'
+      name: 'test wallet',
+      enabledTokenIds: ['badf00d5']
     })
     expect(wallet.name).equals('test wallet')
     expect(wallet.fiatCurrencyCode).equals('iso:JPY')
     const walletInfo = account.allKeys.find(info => info.id === wallet.id)
     expect(walletInfo?.migratedFromWalletId).equals('asdf')
+    expect(wallet.enabledTokenIds).deep.equals(['badf00d5'])
   })
 
   it('list keys', async function () {


### PR DESCRIPTION
This was a race condition between loading the tokens file off disk and writing the tokens file at wallet creation time. We solve the race condition by skipping the `dispatch` if there is no file on disk. That way, when we create a brand-new wallet, the initial tokens always win.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206640311415482