### PR TITLE
Add `'failed'` variant to EdgeTransaction `confirmations` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: New `'failed'` value to confirmations field on `EdgeTransactions`
+
 ## 2.3.0 (2024-03-23)
 
 - added: `EdgeCorePluginOptions.infoPayload`, containing arbitrary JSON provided by the info server.

--- a/src/core/currency/wallet/currency-wallet-callbacks.ts
+++ b/src/core/currency/wallet/currency-wallet-callbacks.ts
@@ -223,7 +223,7 @@ export function makeCurrencyWalletCallbacks(
                 input.props.walletState.currencyInfo
               const { height } = input.props.walletState
 
-              reduxTx.confirmations = validateConfirmations(
+              reduxTx.confirmations = determineConfirmations(
                 reduxTx,
                 height,
                 requiredConfirmations
@@ -325,7 +325,7 @@ export function makeCurrencyWalletCallbacks(
           const { requiredConfirmations } = input.props.walletState.currencyInfo
           const { height } = input.props.walletState
 
-          tx.confirmations = validateConfirmations(
+          tx.confirmations = determineConfirmations(
             tx,
             height,
             requiredConfirmations
@@ -413,7 +413,7 @@ export function watchCurrencyWallet(input: CurrencyWalletInput): void {
   checkChangesLoop()
 }
 
-export const validateConfirmations = (
+export const determineConfirmations = (
   tx: { blockHeight: number }, // Either EdgeTransaction or MergedTransaction
   blockHeight: number,
   requiredConfirmations: number = 1 // Default confirmation rule is 1 block

--- a/src/core/currency/wallet/currency-wallet-callbacks.ts
+++ b/src/core/currency/wallet/currency-wallet-callbacks.ts
@@ -417,7 +417,11 @@ export function watchCurrencyWallet(input: CurrencyWalletInput): void {
 const shouldCoreDetermineConfirmations = (
   confirmations: EdgeConfirmationState | undefined
 ): boolean => {
-  return confirmations !== 'confirmed' && confirmations !== 'dropped'
+  return (
+    confirmations !== 'confirmed' &&
+    confirmations !== 'dropped' &&
+    confirmations !== 'failed'
+  )
 }
 
 export const determineConfirmations = (

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -546,6 +546,9 @@ export type EdgeConfirmationState =
   | 'confirmed'
   // Dropped from the network without confirmations:
   | 'dropped'
+  // Confirmed, but failed on-chain execution (exceeded gas limit,
+  // smart-contract failure, etc):
+  | 'failed'
   // We don't know the chain height yet:
   | 'syncing'
   // No confirmations yet:

--- a/test/core/currency/confirmations.test.ts
+++ b/test/core/currency/confirmations.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { describe, it } from 'mocha'
 
-import { validateConfirmations } from '../../../src/core/currency/wallet/currency-wallet-callbacks'
+import { determineConfirmations } from '../../../src/core/currency/wallet/currency-wallet-callbacks'
 
 describe('confirmations API', function () {
   const helper = (
@@ -12,7 +12,7 @@ describe('confirmations API', function () {
   ): void => {
     const tx = { blockHeight: txBlockHeight }
     expect(
-      validateConfirmations(tx, netBlockHeight, required),
+      determineConfirmations(tx, netBlockHeight, required),
       `Expected tx with blockHeight of ${txBlockHeight} to be ${expected} at network blockHeight ${netBlockHeight} with ${required} required confs`
     ).equals(expected)
   }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206892270756769