### PR TITLE
Export the `EdgeObjectTemplate` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Export the `EdgeObjectTemplate` type.
+
 ## 2.4.0 (2024-03-25)
 
 - added: New `'failed'` value to confirmations field on `EdgeTransactions`

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -419,7 +419,7 @@ export interface EdgeTokenInfo {
 
 // currency info -------------------------------------------------------
 
-type EdgeObjectTemplate = Array<
+export type EdgeObjectTemplate = Array<
   | {
       type: 'nativeAmount'
       key: string


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

We forgot to export this type, deep in the past.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206924839994707