### PR TITLE
Fix compatibility with TypeScript v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fixed: Export the `EdgeObjectTemplate` type.
+- fixed: TypeScript v5 compatibility.
 
 ## 2.4.0 (2024-03-25)
 

--- a/package.json
+++ b/package.json
@@ -27,12 +27,14 @@
   "exports": {
     ".": {
       "import": "./lib/node/index.mjs",
-      "require": "./lib/node/index.js"
+      "require": "./lib/node/index.js",
+      "types": "./src/types/exports.ts"
     },
     "./package.json": "./package.json",
     "./types": {
       "import": "./types.mjs",
-      "require": "./types.js"
+      "require": "./types.js",
+      "types": "./src/types/types.ts"
     }
   },
   "main": "./lib/node/index.js",

--- a/src/types/exports.ts
+++ b/src/types/exports.ts
@@ -108,7 +108,7 @@ export interface EdgeFakeWorldProps extends CommonProps {
 type ComponentType<Props> = (props: Props) => {
   type: any
   props: any
-  key: string | number | null
+  key: string | null
 }
 
 /**


### PR DESCRIPTION
Now that TypeScript understands the `exports` field, we need to add types there too.

Also, the definition of a JSX element has changed slightly.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206953938020012