### PR TITLE
Better propagate `EdgeTransaction.feeRateUsed`

### DIFF
--- a/src/core/currency/wallet/currency-wallet-api.ts
+++ b/src/core/currency/wallet/currency-wallet-api.ts
@@ -677,6 +677,7 @@ export function combineTxWithFile(
     blockHeight: tx.blockHeight,
     confirmations: tx.confirmations,
     currencyCode,
+    feeRateUsed: tx.feeRateUsed,
     date: tx.date,
     isSend: tx.isSend,
     memos: tx.memos,
@@ -713,7 +714,9 @@ export function combineTxWithFile(
         out.requestedCustomFee = file.feeRateRequested
       }
     }
-    out.feeRateUsed = file.feeRateUsed
+    if (out.feeRateUsed == null) {
+      out.feeRateUsed = file.feeRateUsed
+    }
 
     if (file.payees != null) {
       out.spendTargets = file.payees.map(payee => ({

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -598,11 +598,13 @@ export interface EdgeTransaction {
   /** App-provided action data for all assets in a transaction */
   savedAction?: EdgeTxAction
 
+  /** This has the same format as the `customNetworkFee` */
+  feeRateUsed?: JsonObject
+
   // Spend-specific metadata:
   deviceDescription?: string
   networkFeeOption?: 'high' | 'standard' | 'low' | 'custom'
   requestedCustomFee?: JsonObject
-  feeRateUsed?: JsonObject
   spendTargets?: Array<{
     readonly currencyCode: string // Saved for future reference
     readonly nativeAmount: string


### PR DESCRIPTION
If we don't have this saved on disk, let the engine's one pass through.

At the moment, the feeRateUsed will only appear if the makeSpend returns it, and we successfully save it to disk. With this PR, we reflect whatever the engine sends, but will fall back to disk if we have that.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207292594289949