### PR TITLE
Add missing Swift import statment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Add missing Swift import statement.
+
 ## 2.6.0 (2024-05-21)
 
 - added: Better documentation comments for the `EdgeObjectTemplate` types.

--- a/ios/EdgeCoreWebView.swift
+++ b/ios/EdgeCoreWebView.swift
@@ -1,3 +1,5 @@
+import WebKit
+
 class EdgeCoreWebView: RCTView, WKNavigationDelegate, WKScriptMessageHandler {
   let queue = DispatchQueue(label: "app.edge.reactnative.core")
   let disklet = Disklet()


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

I have no idea how this was ever working, but React Native 0.74 exposed the error.