### PR TITLE
New enableRbf field on EdgeSpendInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: New `enableRbf` field on `EdgeSpendInfo`
+
 ## 2.6.1 (2024-05-23)
 
 - fixed: Add missing Swift import statement.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - added: New `enableRbf` field on `EdgeSpendInfo`
+- changed: Deprecated `rbfTxid` field on `EdgeSpendInfo`
 
 ## 2.6.1 (2024-05-23)
 

--- a/src/core/currency/wallet/currency-wallet-api.ts
+++ b/src/core/currency/wallet/currency-wallet-api.ts
@@ -459,6 +459,7 @@ export function makeCurrencyWalletApi(
       const {
         assetAction,
         customNetworkFee,
+        enableRbf,
         memos,
         metadata,
         networkFeeOption = 'standard',
@@ -518,6 +519,7 @@ export function makeCurrencyWalletApi(
         {
           ...upgradedCurrency,
           customNetworkFee,
+          enableRbf,
           memos,
           metadata,
           networkFeeOption,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -670,6 +670,7 @@ export interface EdgeSpendInfo {
   /** Enables RBF on chains where RBF is optional */
   enableRbf?: boolean
   pendingTxs?: EdgeTransaction[]
+  /** @deprecated Use EdgeCurrencyWallet.accelerate instead */
   rbfTxid?: string
   skipChecks?: boolean
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -667,6 +667,8 @@ export interface EdgeSpendInfo {
   noUnconfirmed?: boolean
   networkFeeOption?: 'high' | 'standard' | 'low' | 'custom'
   customNetworkFee?: JsonObject // Some kind of currency-specific JSON
+  /** Enables RBF on chains where RBF is optional */
+  enableRbf?: boolean
   pendingTxs?: EdgeTransaction[]
   rbfTxid?: string
   skipChecks?: boolean


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205841634636330
  - https://app.asana.com/0/0/1205841634636328