### PR TITLE
Correctly handle `null` as the native fetch body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Correctly handle `null` fetch bodies on Android.
+
 ## 2.8.1 (2024-07-11)
 
 - fixed: Filter transactions with empty (zero) nativeAmount and networkFee

--- a/android/src/main/java/app/edge/reactnative/core/EdgeNative.java
+++ b/android/src/main/java/app/edge/reactnative/core/EdgeNative.java
@@ -115,7 +115,7 @@ class EdgeNative {
     String uri = args.getString(0);
     String method = args.getString(1);
     JSONObject headers = args.getJSONObject(2);
-    String body = args.optString(3);
+    @Nullable Object body = args.opt(3);
     boolean bodyIsBase64 = args.optBoolean(4);
 
     HttpURLConnection connection = null;
@@ -141,11 +141,12 @@ class EdgeNative {
       }
 
       // Add the body:
-      if (body.length() > 0) {
+      if (body instanceof String) {
+        String bodyText = (String) body;
         byte[] bodyData =
             bodyIsBase64
-                ? Base64.decode(body, Base64.DEFAULT)
-                : body.getBytes(StandardCharsets.UTF_8);
+                ? Base64.decode(bodyText, Base64.DEFAULT)
+                : bodyText.getBytes(StandardCharsets.UTF_8);
         connection.setRequestProperty("Content-Length", Integer.toString(bodyData.length));
         connection.setDoOutput(true);
         OutputStream outStream = connection.getOutputStream();

--- a/ios/EdgeNative.swift
+++ b/ios/EdgeNative.swift
@@ -66,13 +66,13 @@ class EdgeNative {
       let method = args[1] as? String,
       let headers = args[2] as? NSDictionary
     {
-      let body = args[3] as? String
+      let body = args[3]
       let bodyIsBase64 = args[4] as? Bool
       return handleFetch(
         uri: uri,
         method: method,
         headers: headers,
-        body: body ?? "",
+        body: body,
         bodyIsBase64: bodyIsBase64 ?? false,
         promise: promise)
     }
@@ -115,7 +115,7 @@ class EdgeNative {
     uri: String,
     method: String,
     headers: NSDictionary,
-    body: String,
+    body: Any,
     bodyIsBase64: Bool,
     promise: PendingCall
   ) {
@@ -136,8 +136,11 @@ class EdgeNative {
     }
 
     // Add the body:
-    if body.count > 0 {
-      request.httpBody = bodyIsBase64 ? Data.init(base64Encoded: body) : body.data(using: .utf8)
+    if let bodyText = body as? String {
+      request.httpBody =
+        bodyIsBase64
+        ? Data.init(base64Encoded: bodyText)
+        : bodyText.data(using: .utf8)
     }
 
     // Set up the response callback:
@@ -152,7 +155,7 @@ class EdgeNative {
       let out = NSMutableDictionary()
       out["status"] = httpResponse.statusCode
 
-      // Read the headers:
+      // Read the response headers:
       let headers = NSMutableDictionary()
       for (key, value) in httpResponse.allHeaderFields {
         if let keyString = key as? String,
@@ -163,7 +166,7 @@ class EdgeNative {
       }
       out["headers"] = headers
 
-      // Read the body:
+      // Read the response body:
       if let bodyData = data {
         if let body = String(bytes: bodyData, encoding: .utf8) {
           out["body"] = body


### PR DESCRIPTION
The `JSONObject` class was stringifying `null` values as `'null'`, which we don't want.

To fix this, allow `body` to be the native equivalent of `any` until we are ready to actually read the value.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207817959691619