### PR TITLE
Work with React Native bridgeless mode on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Work with React Native bridgeless mode on Android.
+
 ## 2.9.1 (2024-07-24)
 
 - fixed: Edge case for filtering transactions with empty txs (zero amount & fee)

--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.4.1)
+project("edge-core-js")
 
 add_compile_options(-fvisibility=hidden -w)
 

--- a/android/src/main/java/app/edge/reactnative/core/EdgeCoreWebView.java
+++ b/android/src/main/java/app/edge/reactnative/core/EdgeCoreWebView.java
@@ -70,7 +70,8 @@ class EdgeCoreWebView extends WebView {
 
     @JavascriptInterface
     public void postMessage(String message) {
-      RCTEventEmitter emitter = mContext.getJSModule(RCTEventEmitter.class);
+      RCTEventEmitter emitter =
+          mContext.getReactApplicationContext().getJSModule(RCTEventEmitter.class);
       WritableMap event = Arguments.createMap();
       event.putString("message", message);
       emitter.receiveEvent(getId(), "onMessage", event);
@@ -78,7 +79,8 @@ class EdgeCoreWebView extends WebView {
 
     @JavascriptInterface
     public void scriptError(String source) {
-      RCTEventEmitter emitter = mContext.getJSModule(RCTEventEmitter.class);
+      RCTEventEmitter emitter =
+          mContext.getReactApplicationContext().getJSModule(RCTEventEmitter.class);
       WritableMap event = Arguments.createMap();
       event.putString("source", source);
       emitter.receiveEvent(getId(), "onScriptError", event);


### PR DESCRIPTION
The `ThemedReactContext.getJSModule` method crashes in bridgeless mode. Fortunately, the `ReactApplicationContext.getJSModule` method still works, so use that instead.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207347934635857