### PR TITLE
Work with React Native bridgeless mode on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fixed: Work with React Native bridgeless mode on Android.
+- fixed: Work with React Native bridgeless mode on iOS and Android.
 
 ## 2.9.1 (2024-07-24)
 

--- a/ios/EdgeCoreWebViewManager.swift
+++ b/ios/EdgeCoreWebViewManager.swift
@@ -4,7 +4,8 @@
 
   @objc func runJs(_ reactTag: NSNumber, js: String) {
     bridge.uiManager.addUIBlock({ (uiManager, viewRegistry) in
-      if let webView = viewRegistry?[reactTag] as? EdgeCoreWebView {
+      let view = uiManager?.view(forReactTag: reactTag)
+      if let webView = view as? EdgeCoreWebView {
         webView.runJs(js: js)
       }
     })


### PR DESCRIPTION
The view registry doesn't contain legacy components in bridgeless mode. Use the `UIManager` view lookup method instead.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207885931800589