### PR TITLE
Randomize polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: Randomize data-sync start times.
+
 ## 2.9.2 (2024-07-25)
 
 - fixed: Work with React Native bridgeless mode on iOS and Android.

--- a/src/core/account/account-pixie.ts
+++ b/src/core/account/account-pixie.ts
@@ -20,7 +20,11 @@ import { snooze } from '../../util/snooze'
 import { syncLogin } from '../login/login'
 import { waitForPlugins } from '../plugins/plugins-selectors'
 import { RootProps, toApiInput } from '../root-pixie'
-import { addStorageWallet, syncStorageWallet } from '../storage/storage-actions'
+import {
+  addStorageWallet,
+  SYNC_INTERVAL,
+  syncStorageWallet
+} from '../storage/storage-actions'
 import { makeAccountApi } from './account-api'
 import { loadAllWalletStates, reloadPluginSettings } from './account-files'
 import { AccountState, initialCustomTokens } from './account-reducer'
@@ -143,8 +147,8 @@ const accountPixie: TamePixie<AccountProps> = combinePixies({
       }
 
       // We don't report sync failures, since that could be annoying:
-      const dataTask = makePeriodicTask(doDataSync, 30 * 1000)
-      const loginTask = makePeriodicTask(doLoginSync, 30 * 1000, {
+      const dataTask = makePeriodicTask(doDataSync, SYNC_INTERVAL)
+      const loginTask = makePeriodicTask(doLoginSync, SYNC_INTERVAL, {
         onError(error) {
           // Only send OTP errors to the GUI:
           const otpError = asMaybeOtpError(error)
@@ -157,8 +161,8 @@ const accountPixie: TamePixie<AccountProps> = combinePixies({
           if (input.props.accountOutput?.accountApi == null) return
 
           // Start once the EdgeAccount API exists:
-          dataTask.start({ wait: true })
-          loginTask.start({ wait: true })
+          dataTask.start({ wait: SYNC_INTERVAL * (1 + Math.random()) })
+          loginTask.start({ wait: SYNC_INTERVAL * (1 + Math.random()) })
         },
 
         destroy() {

--- a/src/core/currency/wallet/currency-wallet-pixie.ts
+++ b/src/core/currency/wallet/currency-wallet-pixie.ts
@@ -25,6 +25,7 @@ import { getCurrencyTools } from '../../plugins/plugins-selectors'
 import { RootProps, toApiInput } from '../../root-pixie'
 import {
   addStorageWallet,
+  SYNC_INTERVAL,
   syncStorageWallet
 } from '../../storage/storage-actions'
 import {
@@ -295,7 +296,7 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
       }
 
       // We don't report sync failures, since that could be annoying:
-      const task = makePeriodicTask(doSync, 30 * 1000)
+      const task = makePeriodicTask(doSync, SYNC_INTERVAL)
 
       return {
         update() {
@@ -307,7 +308,7 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
             state.storageWallets[walletId] != null &&
             state.storageWallets[walletId].status.lastSync > 0
           ) {
-            task.start({ wait: true })
+            task.start({ wait: SYNC_INTERVAL * (1 + Math.random()) })
           }
         },
 

--- a/src/core/storage/storage-actions.ts
+++ b/src/core/storage/storage-actions.ts
@@ -11,6 +11,8 @@ import {
 } from './repo'
 import { StorageWalletStatus } from './storage-reducer'
 
+export const SYNC_INTERVAL = 30 * 1000
+
 export async function addStorageWallet(
   ai: ApiInput,
   walletInfo: EdgeWalletInfo


### PR DESCRIPTION
This staggers the polling post-login. However, we still sync every wallet immediately at start-up time.

We might want a follow-up task to skip / delay the initial sync as well, which was not in the task description. It's likely that the "Investigate mad disklet use on login" task is actually related to the initial sync.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207731582557648