### PR TITLE
Add support for engines' otherMethodsWithKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: `EdgeCurrencyEngine.otherMethodsWithKeys`. These methods will be added to `EdgeCurrencyEngine.otherMethods`, but the core will insert private keys as the first parameter.
+
 ## 2.11.0 (2024-08-07)
 
 - added: `EdgeCurrencyTools.getDisplayPublicKeys` to get the master public keys for a wallet.

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -986,6 +986,7 @@ export interface EdgeCurrencyEngine {
 
   // Escape hatch:
   readonly otherMethods?: EdgeOtherMethods
+  readonly otherMethodsWithKeys?: EdgeOtherMethods
 
   /** @deprecated Replaced by changeEnabledTokenIds */
   readonly enableTokens?: (tokens: string[]) => Promise<void>


### PR DESCRIPTION
Same as otherMethods, but also passes private keys to the engine method.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208012757376983