### PR TITLE
Track URI status for the CORS bouncer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Use full URI to determine whether a request has previously succeeded CORS
+
 ## 2.13.0 (2024-08-12)
 
 - added: `EdgeStreamTransactionOptions.spamThreshold`.

--- a/src/io/react-native/react-native-worker.ts
+++ b/src/io/react-native/react-native-worker.ts
@@ -22,8 +22,8 @@ import { hideProperties } from '../hidden-properties'
 import { makeNativeBridge } from './native-bridge'
 import { WorkerApi, YAOB_THROTTLE_MS } from './react-native-types'
 
-// Tracks the status of different domains for the CORS bouncer:
-const hostnameCorsState = new Map<
+// Tracks the status of different URI endpoints for the CORS bouncer:
+const endpointCorsState = new Map<
   string,
   {
     // The window.fetch worked:
@@ -179,13 +179,14 @@ async function makeIo(): Promise<EdgeIo> {
       uri: string,
       opts: EdgeFetchOptions = {}
     ): Promise<EdgeFetchResponse> {
-      const { hostname } = new URL(uri)
-      const state = hostnameCorsState.get(hostname) ?? {
+      const { protocol, host, pathname } = new URL(uri)
+      const endpoint = `${protocol}//${host}${pathname}`
+      const state = endpointCorsState.get(endpoint) ?? {
         windowSuccess: false,
         nativeSuccess: false
       }
-      if (!hostnameCorsState.has(hostname)) {
-        hostnameCorsState.set(hostname, state)
+      if (!endpointCorsState.has(endpoint)) {
+        endpointCorsState.set(endpoint, state)
       }
 
       // If the native fetch worked,


### PR DESCRIPTION
A host can and has returned different CORS headers per HTTP endpoint.
Because of this, we cannot reliably assume that the entire hostname is
either CORS-safe or not.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
