### PR TITLE
Log HTTP 409 error responses with breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: Log HTTP 409 errors from login server with breadcrumbs.
+
 ## 2.13.1 (2024-08-23)
 
 - fixed: Use full URI to determine whether a request has previously succeeded CORS

--- a/src/core/account/account-api.ts
+++ b/src/core/account/account-api.ts
@@ -350,6 +350,9 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
     // ----------------------------------------------------------------
 
     async fetchLobby(lobbyId: string): Promise<EdgeLobby> {
+      // For crash errors:
+      ai.props.log.breadcrumb('EdgeAccount.fetchLobby', {})
+
       lockdown()
       return await makeLobbyApi(ai, accountId, lobbyId)
     },
@@ -380,6 +383,9 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
     },
 
     async createWallet(walletType: string, keys?: object): Promise<string> {
+      // For crash errors:
+      ai.props.log.breadcrumb('EdgeAccount.createWallet', {})
+
       const { login, loginTree } = accountState()
 
       const walletInfo = await makeCurrencyWalletKeys(ai, walletType, { keys })
@@ -493,6 +499,9 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
       walletType: string,
       opts: EdgeCreateCurrencyWalletOptions = {}
     ): Promise<EdgeCurrencyWallet> {
+      // For crash errors:
+      ai.props.log.breadcrumb('EdgeAccount.createCurrencyWallet', {})
+
       const { login, loginTree } = accountState()
 
       const walletInfo = await makeCurrencyWalletKeys(ai, walletType, opts)
@@ -515,6 +524,9 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
     async createCurrencyWallets(
       createWallets: EdgeCreateCurrencyWallet[]
     ): Promise<Array<EdgeResult<EdgeCurrencyWallet>>> {
+      // For crash errors:
+      ai.props.log.breadcrumb('EdgeAccount.makeMemoryWallet', {})
+
       const { login, loginTree } = accountState()
 
       // Create the keys:

--- a/src/core/account/account-init.ts
+++ b/src/core/account/account-init.ts
@@ -68,16 +68,23 @@ export async function ensureAccountExists(
   loginTree: LoginTree,
   appId: string
 ): Promise<LoginTree> {
+  // For crash errors:
+  ai.props.log.breadcrumb('ensureAccountExists', {})
+
   const accountType = makeAccountType(appId)
 
   // If there is no app login, make that:
   const login = searchTree(loginTree, login => login.appId === appId)
   if (login == null) {
+    // For crash errors:
+    ai.props.log.breadcrumb('createChildLogin', {})
     return await createChildLogin(ai, loginTree, loginTree, appId)
   }
 
   // Otherwise, make the repo:
   if (findFirstKey(login.keyInfos, accountType) == null) {
+    // For crash errors:
+    ai.props.log.breadcrumb('createAccountRepo', {})
     checkLogin(login)
     const keyInfo = makeKeyInfo(
       accountType,
@@ -101,6 +108,9 @@ export async function makeAccount(
   loginType: LoginType,
   opts: EdgeAccountOptions
 ): Promise<EdgeAccount> {
+  // For crash errors:
+  ai.props.log.breadcrumb('makeAccount', {})
+
   const { pauseWallets = false } = opts
   const { log } = ai.props
   log.warn(

--- a/src/core/account/lobby-api.ts
+++ b/src/core/account/lobby-api.ts
@@ -70,6 +70,9 @@ async function approveLoginRequest(
   lobbyId: string,
   lobbyJson: EdgeLobbyRequest
 ): Promise<void> {
+  // For crash errors:
+  ai.props.log.breadcrumb('approveLoginRequest', {})
+
   const { login, loginTree } = ai.props.state.accounts[accountId]
 
   // Ensure that the login object & account repo exist:
@@ -153,6 +156,9 @@ async function unpackLoginRequest(
   lobbyJson: EdgeLobbyRequest,
   appId: string
 ): Promise<EdgeLoginRequest> {
+  // For crash errors:
+  ai.props.log.breadcrumb('unpackLoginRequest', {})
+
   const info = await fetchAppIdInfo(ai, appId)
 
   // Make the API:

--- a/src/core/context/context-api.ts
+++ b/src/core/context/context-api.ts
@@ -78,6 +78,9 @@ export function makeContextApi(ai: ApiInput): EdgeContext {
     async createAccount(
       opts: EdgeCreateAccountOptions & EdgeAccountOptions
     ): Promise<EdgeAccount> {
+      // For crash errors:
+      ai.props.log.breadcrumb('EdgeContext.createAccount', {})
+
       if (opts.username != null) {
         opts.username = fixUsername(opts.username)
       }
@@ -116,6 +119,9 @@ export function makeContextApi(ai: ApiInput): EdgeContext {
       password: string,
       opts: EdgeAccountOptions = {}
     ): Promise<EdgeAccount> {
+      // For crash errors:
+      ai.props.log.breadcrumb('EdgeContext.loginWithPassword', {})
+
       username = fixUsername(username)
       const stashTree = getStashByUsername(ai, username)
       const loginTree = await loginPassword(
@@ -134,6 +140,9 @@ export function makeContextApi(ai: ApiInput): EdgeContext {
       pin: string,
       opts = {}
     ): Promise<EdgeAccount> {
+      // For crash errors:
+      ai.props.log.breadcrumb('EdgeContext.loginWithPIN', {})
+
       const { useLoginId = false } = opts
 
       const stashTree = useLoginId
@@ -153,6 +162,9 @@ export function makeContextApi(ai: ApiInput): EdgeContext {
       answers: string[],
       opts: EdgeAccountOptions = {}
     ): Promise<EdgeAccount> {
+      // For crash errors:
+      ai.props.log.breadcrumb('EdgeContext.loginWithRecovery2', {})
+
       username = fixUsername(username)
       const stashTree = getStashByUsername(ai, username)
       const loginTree = await loginRecovery2(
@@ -176,6 +188,9 @@ export function makeContextApi(ai: ApiInput): EdgeContext {
     async requestEdgeLogin(
       opts?: EdgeAccountOptions
     ): Promise<EdgePendingEdgeLogin> {
+      // For crash errors:
+      ai.props.log.breadcrumb('EdgeContext.requestEdgeLogin', {})
+
       return await requestEdgeLogin(ai, appId, opts)
     },
 

--- a/src/core/login/create.ts
+++ b/src/core/login/create.ts
@@ -52,6 +52,9 @@ export async function makeCreateKit(
   appId: string,
   opts: LoginCreateOpts
 ): Promise<LoginKit> {
+  // For crash errors:
+  ai.props.log.breadcrumb('makeCreateKit', {})
+
   const { keyInfo, password, pin, username } = opts
   const { io } = ai.props
 
@@ -144,6 +147,9 @@ export async function createLogin(
   accountOpts: EdgeAccountOptions,
   opts: LoginCreateOpts
 ): Promise<LoginTree> {
+  // For crash errors:
+  ai.props.log.breadcrumb('createLogin', {})
+
   const { now = new Date() } = accountOpts
 
   const kit = await makeCreateKit(ai, undefined, '', opts)

--- a/src/core/login/edge.ts
+++ b/src/core/login/edge.ts
@@ -39,6 +39,9 @@ async function unpackAccount(
   appId: string,
   opts: EdgeAccountOptions
 ): Promise<EdgeAccount> {
+  // For crash errors:
+  ai.props.log.breadcrumb('unpackAccount', {})
+
   const { now = new Date() } = opts
   const { loginKey, loginStash: stashTree } = payload
 

--- a/src/core/login/keys.ts
+++ b/src/core/login/keys.ts
@@ -64,6 +64,9 @@ export function makeKeysKit(
   login: LoginTree,
   keyInfos: EdgeWalletInfo[]
 ): LoginKit {
+  // For crash errors:
+  ai.props.log.breadcrumb('makeKeysKit', {})
+
   const { io } = ai.props
   const keyBoxes = keyInfos.map(info =>
     encrypt(

--- a/src/core/login/login-fetch.ts
+++ b/src/core/login/login-fetch.ts
@@ -88,6 +88,13 @@ export function loginFetch(
     response => {
       const time = Date.now() - start
       log(`${method} ${fullUri} returned ${response.status} in ${time}ms`)
+
+      if (response.status === 409) {
+        log.crash(`Login API conflict error`, {
+          path
+        })
+      }
+
       return response.json().then(parseReply, () => {
         throw new Error(`Invalid reply JSON, HTTP status ${response.status}`)
       })


### PR DESCRIPTION
The breadcrumbs were left in places leading up to `/v2/login/create` and
`/v2/login/keys` endpoints to the login server.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201238254464016