### PR TITLE
Fix an error while changing the PIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Do not error when changing the PIN on accounts with children.
+
 ## 2.20.1 (2024-10-30)
 
 - fixed: Correctly update info-server payload in the background.

--- a/src/core/login/login.ts
+++ b/src/core/login/login.ts
@@ -495,10 +495,10 @@ export function decryptChildKey(
   loginId: Uint8Array
 ): SessionKey {
   function searchChildren(
-    children: LoginStash[],
+    childList: LoginStash[],
     loginKey: Uint8Array
   ): SessionKey | undefined {
-    for (const child of children) {
+    for (const child of childList) {
       // This will never happen, but TypeScript doesn't know that:
       if (child.parentBox == null) continue
 


### PR DESCRIPTION
We used to have two variables with the same name, `children`, but existing in separate scopes. Unfortunately, the minifier mis-compiled this code, referring to the inner variable instead of the outer variable. To fix this, we just give the outer variable a different name, forcing the minifier to refer to the correct one.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208730396207695