### PR TITLE
Add `avoidCors` API to `EdgeFetchFunction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: Added `fetchCorsForced` for access to nativeFetch in React Native.
+
 ## 2.21.0 (2024-12-02)
 
 - added: Added `networkFees` to `EdgeTransaction`.

--- a/src/core/account/lobby-api.ts
+++ b/src/core/account/lobby-api.ts
@@ -44,7 +44,7 @@ export async function fetchAppIdInfo(
   try {
     const [infoServerUri] = shuffle(ai.props.state.infoServers)
     const url = `${infoServerUri}/v1/appIdInfo/${appId}`
-    const response = await ai.props.io.fetch(url)
+    const response = await ai.props.io.fetch(url, { corsBypass: 'never' })
     if (response.status === 404) {
       return { appName: appId }
     }

--- a/src/core/login/login-fetch.ts
+++ b/src/core/login/login-fetch.ts
@@ -91,7 +91,8 @@ export function loginFetch(
       'content-type': 'application/json',
       accept: 'application/json',
       authorization
-    }
+    },
+    corsBypass: 'never'
   }
 
   const start = Date.now()

--- a/src/core/root.ts
+++ b/src/core/root.ts
@@ -146,7 +146,7 @@ export async function makeContext(
   // Create sync client:
   const syncClient = makeSyncClient({
     log,
-    fetch: io.fetch,
+    fetch: (uri, opts) => io.fetch(uri, { ...opts, corsBypass: 'never' }),
     edgeServers: { infoServers, syncServers }
   })
 

--- a/src/io/react-native/react-native-worker.ts
+++ b/src/io/react-native/react-native-worker.ts
@@ -172,13 +172,15 @@ async function makeIo(): Promise<EdgeIo> {
       uri: string,
       opts?: EdgeFetchOptions
     ): Promise<EdgeFetchResponse> {
-      return await window.fetch(uri, opts)
-    },
+      const { corsBypass = 'auto' } = opts ?? {}
 
-    async fetchCors(
-      uri: string,
-      opts: EdgeFetchOptions = {}
-    ): Promise<EdgeFetchResponse> {
+      if (corsBypass === 'always') {
+        return await nativeFetch(uri, opts)
+      }
+      if (corsBypass === 'never') {
+        return await window.fetch(uri, opts)
+      }
+
       const { protocol, host, pathname } = new URL(uri)
       const endpoint = `${protocol}//${host}${pathname}`
       const state = endpointCorsState.get(endpoint) ?? {
@@ -208,6 +210,13 @@ async function makeIo(): Promise<EdgeIo> {
       const response = await nativeFetch(uri, opts)
       state.nativeSuccess = true
       return response
+    },
+
+    async fetchCors(
+      uri: string,
+      opts: EdgeFetchOptions = {}
+    ): Promise<EdgeFetchResponse> {
+      return await this.fetch(uri, opts)
     }
   }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,10 +1,5 @@
 import type { Disklet } from 'disklet'
-import type {
-  FetchFunction,
-  FetchHeaders,
-  FetchOptions,
-  FetchResponse
-} from 'serverlet'
+import type { FetchHeaders, FetchOptions, FetchResponse } from 'serverlet'
 import type { Subscriber } from 'yaob'
 
 export * from './error'
@@ -54,10 +49,15 @@ export type EdgeScryptFunction = (
 ) => Promise<Uint8Array>
 
 // The subset of the fetch function Edge expects:
-export type EdgeFetchOptions = FetchOptions
+export type EdgeFetchOptions = FetchOptions & {
+  corsBypass?: 'auto' | 'always' | 'never'
+}
 export type EdgeFetchHeaders = FetchHeaders
 export type EdgeFetchResponse = FetchResponse
-export type EdgeFetchFunction = FetchFunction
+export type EdgeFetchFunction = (
+  uri: string,
+  opts?: EdgeFetchOptions
+) => Promise<EdgeFetchResponse>
 
 /**
  * Access to platform-specific resources.
@@ -76,6 +76,8 @@ export interface EdgeIo {
   /**
    * This is like `fetch`, but will try to avoid CORS limitations
    * on platforms where that may be a problem.
+   *
+   * @deprecated Use EdgeIo.fetch instead, which now includes CORS avoidance by default
    */
   readonly fetchCors: EdgeFetchFunction
 }


### PR DESCRIPTION
This is to be able to to access `nativeFetch` in React Native
environements. This `fetchCorsForced` method will also forcibly use the
CORS servers in browser environemnts. It's idompodent in Node
environements.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208940233901583