### PR TITLE
Fix in-memory metadata stomping bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fixed: Metadata stomping bug in memory caused by new EdgeTransaction objects from the engine.
 - fixed: Support the `loginServer` prop on the `MakeEdgeContext` component.
 
 ## 2.25.1 (2025-01-16)

--- a/src/core/currency/wallet/currency-wallet-callbacks.ts
+++ b/src/core/currency/wallet/currency-wallet-callbacks.ts
@@ -351,7 +351,15 @@ export function makeCurrencyWalletCallbacks(
 
         // Ensure the transaction has metadata:
         const txidHash = hashStorageWalletFilename(state, walletId, txid)
-        if (isNew) {
+
+        // Setup the metadata in memory only if we don't have if for the
+        // transaction. Transaction metadata share a single file with the core,
+        // so we only need to do this once (regardless of whether the
+        // transaction is new).
+        // TODO: Remove this once the core is refactored to no longer depend on
+        // this state being in memory to get its job done for transaction
+        // related routines.
+        if (input.props.walletState.fileNames[txidHash] == null) {
           setupNewTxMetadata(input, tx).catch(error =>
             input.props.onError(error)
           )


### PR DESCRIPTION
We only need to setup a new metadata file in memory for the transaction
if there doesn't already exists a file for the transaction. We only need
to do this so that the state is present for other places in the core
which depend on this state being present and deal with transaction
state.

In a future refactor, we can remove the setup entirely so long as we
remove the dependency on this state always being present for
transactions.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209372298561898