### PR TITLE
Create wallets in the correct location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fixed: Create wallets in the correct location when using non-default appId's.
 - fixed: Log changes to the `enabledTokenId` array.
 
 ## 2.26.0 (2025-02-20)

--- a/test/core/login/login.test.ts
+++ b/test/core/login/login.test.ts
@@ -111,7 +111,11 @@ describe('creation', function () {
     this.timeout(15000)
     const now = new Date()
     const world = await makeFakeEdgeWorld([], quiet)
-    const contextOptions = { apiKey: '', appId: 'test' }
+    const contextOptions = {
+      apiKey: '',
+      appId: 'test',
+      plugins: { fakecoin: true }
+    }
     const context = await world.makeEdgeContext(contextOptions)
     const remote = await world.makeEdgeContext(contextOptions)
     const username = 'some fancy user'
@@ -139,6 +143,10 @@ describe('creation', function () {
 
     const loginKey = await account.getLoginKey()
     await Promise.all([
+      account.createCurrencyWallet('wallet:fakecoin', {
+        fiatCurrencyCode: 'iso:USD',
+        name: 'Wallet creation works'
+      }),
       context.loginWithPIN(username, pin),
       remote.loginWithPassword(username, password),
       context.loginWithKey(username, loginKey)


### PR DESCRIPTION
Wallets belong on the child login with the correct appId, even if the login credentials belong to the outer parent wallet.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209488312133577