### PR TITLE
Fix accidental duress stash creation in loginWithKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fixed: Bug causing duress account creation from `loginWithKey` while in duress mode.
 - fixed: Clean the Android build folder, so leftover files don't get published.
 
 ## 2.27.2 (2025-05-08)

--- a/src/core/context/context-api.ts
+++ b/src/core/context/context-api.ts
@@ -150,6 +150,13 @@ export function makeContextApi(ai: ApiInput): EdgeContext {
         throw new Error(`Cannot find requested appId: "${appId}"`)
       }
 
+      // Get the duress stash for existence check:
+      const duressAppId = appId + '.duress'
+      const duressStash = searchTree(
+        stashTree,
+        stash => stash.appId === duressAppId
+      )
+
       let sessionKey: SessionKey
       try {
         sessionKey = {
@@ -161,9 +168,6 @@ export function makeContextApi(ai: ApiInput): EdgeContext {
         makeAuthJson(stashTree, sessionKey)
       } catch (error) {
         if (error instanceof Error && error.message === 'Invalid checksum') {
-          const duressStash = searchTree(stashTree, stash =>
-            stash.appId.endsWith('.duress')
-          )
           if (duressStash == null) {
             throw error
           }
@@ -188,7 +192,8 @@ export function makeContextApi(ai: ApiInput): EdgeContext {
 
       return await makeAccount(ai, sessionKey, 'keyLogin', {
         ...opts,
-        duressMode: inDuressMode
+        // We must require that the duress account exists:
+        duressMode: inDuressMode && duressStash != null
       })
     },
 

--- a/test/core/login/login.test.ts
+++ b/test/core/login/login.test.ts
@@ -523,6 +523,50 @@ describe('duress', function () {
     expect(topicAccount.isDuressAccount).equals(true)
   })
 
+  it('Avoid creating duress account when using loginWithPassword', async function () {
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
+    const context = await world.makeEdgeContext(contextOptions)
+    const otherAccount = await context.createAccount({
+      username: 'new-user',
+      pin: '1111'
+    })
+    // Create duress account:
+    await otherAccount.changePin({ pin: '0000', forDuressAccount: true })
+    await otherAccount.logout()
+    // Activate duress mode:
+    const duressAccount = await context.loginWithPIN('new-user', '0000')
+    await duressAccount.logout()
+
+    // Login to the main account using password:
+    const topicAccount = await context.loginWithPassword(
+      fakeUser.username,
+      fakeUser.password
+    )
+    expect(topicAccount.isDuressAccount).equals(false)
+  })
+
+  it('Avoid creating duress account when using loginWithPIN', async function () {
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
+    const context = await world.makeEdgeContext(contextOptions)
+    const otherAccount = await context.createAccount({
+      username: 'new-user',
+      pin: '1111'
+    })
+    // Create duress account:
+    await otherAccount.changePin({ pin: '0000', forDuressAccount: true })
+    await otherAccount.logout()
+    // Activate duress mode:
+    const duressAccount = await context.loginWithPIN('new-user', '0000')
+    await duressAccount.logout()
+
+    // Login to the main account using password:
+    const topicAccount = await context.loginWithPIN(
+      fakeUser.username,
+      fakeUser.pin
+    )
+    expect(topicAccount.isDuressAccount).equals(false)
+  })
+
   it('persist duress mode when using loginWithKey', async function () {
     const world = await makeFakeEdgeWorld([fakeUser], quiet)
     const context = await world.makeEdgeContext(contextOptions)


### PR DESCRIPTION
The `loginWithKey` method has a bug where it will call `ensureAccountExists` for the duress account if `duressMode` option is set to true. If we don't have a duress account for the account being logged into, then we shouldn't be creating an duress account from within `loginWithKey`.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210230037447340