### PR TITLE
Remove unnecessary action from deleteRemoteAccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fixed: Disable duress pin mistakenly disables pin-login for entire account.
+- fixed: Make `deleteRemoteAccount` a no-op while in duress mode.
 
 ## 2.27.3 (2025-05-12)
 

--- a/src/core/account/account-api.ts
+++ b/src/core/account/account-api.ts
@@ -443,14 +443,6 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
     async deleteRemoteAccount(): Promise<void> {
       const { loginTree } = accountState()
       if (this.isDuressAccount) {
-        await this.logout()
-        setTimeout(() => {
-          ai.props.output.context.api
-            .forgetAccount(this.rootLoginId)
-            .catch(err =>
-              ai.props.log.error('EdgeAccount.deleteRemoteAccount', err)
-            )
-        }, 100)
         return
       }
       await deleteLogin(ai, loginTree)


### PR DESCRIPTION
Rendering `deleteRemoteAccount` a no-op when in duress mode is all that is needed. The client should already call into the core to logout and forget the account anyway.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210202021745114