### PR TITLE
Fix syncing races between periodic and change-server syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- added: Added `usesChangeServer` flag to `EdgeCurrencyInfo` to optimize syncing for engines which subscribe to the change-server.
+- fixed: Race condition between engine change-server subscription and periodic sync.
+
 ## 2.32.1 (2025-07-18)
 
 - fixed: Don't write the enabled tokens file until after we've read it from disk.

--- a/src/core/currency/currency-pixie.ts
+++ b/src/core/currency/currency-pixie.ts
@@ -217,7 +217,9 @@ export const currency: TamePixie<RootProps> = combinePixies({
       if (changeService?.connected === true && changeServiceConnected) {
         const filteredWallets = supportedWallets.filter(([, wallet]) =>
           wallet.changeServiceSubscriptions.some(
-            subscription => subscription.status === 'subscribing'
+            subscription =>
+              subscription.status === 'subscribing' ||
+              subscription.status === 'resubscribing'
           )
         )
         const indexToWalletId: Array<{
@@ -282,7 +284,7 @@ export const currency: TamePixie<RootProps> = combinePixies({
             // subscribe to the address:
             case 0:
               // Try subscribing again later:
-              status = 'subscribing'
+              status = 'resubscribing'
               break
             // Change server does support this wallet plugin, and there are no
             // changes for the address:
@@ -298,15 +300,13 @@ export const currency: TamePixie<RootProps> = combinePixies({
               break
           }
 
-          // The status for the subscription is already set to subscribing, so
-          // we don't need to update it:
-          if (status === 'subscribing') {
-            continue
-          }
-
           // Update the status for the subscription:
           const subscriptions = wallet.changeServiceSubscriptions
-            .filter(subscription => subscription.status === 'subscribing')
+            .filter(
+              subscription =>
+                subscription.status === 'subscribing' ||
+                subscription.status === 'resubscribing'
+            )
             .map(subscription => ({
               ...subscription,
               status

--- a/src/core/currency/wallet/currency-wallet-pixie.ts
+++ b/src/core/currency/wallet/currency-wallet-pixie.ts
@@ -373,12 +373,12 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
       !props.state.paused &&
       !props.walletState.paused &&
       props.walletState.engineStarted &&
-      (props.walletState.changeServiceSubscriptions.length === 0 ||
+      (props.walletState.currencyInfo.usesChangeServer !== true ||
         props.walletState.changeServiceSubscriptions.some(
           subscription =>
             subscription.status === 'avoiding' ||
-            subscription.status === 'subscribing' ||
-            subscription.status === 'reconnecting'
+            subscription.status === 'reconnecting' ||
+            subscription.status === 'resubscribing'
         ))
         ? props
         : undefined

--- a/src/core/currency/wallet/currency-wallet-reducer.ts
+++ b/src/core/currency/wallet/currency-wallet-reducer.ts
@@ -106,6 +106,7 @@ export type ChangeServiceSubscriptionStatus =
   | 'listening' // The wallet is connected and listening for changes
   | 'reconnecting' // The wallet is reconnecting to the change service while its not available
   | 'subscribing' // The wallet is in the process of subscribing (supported)
+  | 'resubscribing' // The wallet is in the process of resubscribing due to a change-server issue (supported)
   | 'syncing' // The wallet is syncing historical data
 
 export interface CurrencyWalletNext {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -505,6 +505,7 @@ export interface EdgeCurrencyInfo {
   unsafeBroadcastTx?: boolean
   unsafeMakeSpend?: boolean
   unsafeSyncNetwork?: boolean
+  usesChangeServer?: boolean
 
   /** @deprecated The default user settings are always `{}` */
   defaultSettings?: JsonObject


### PR DESCRIPTION
This fixes the race between periodic syncing and change-server subscriptions by introducing a `usesChangeServer` flag on `EdgeCurrencyInfo` which tells the core to not invoke periodic syncing.

In addition, we introduce a `resubscribing` state to the subscription status to differentiate initial `subscription` with intermittent subscription issues from the change server.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210744859078593