### PR TITLE
Added `allowChainedPending` flag to `EdgeSpendInfo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: `allowChainedPending` flag in `EdgeSpendInfo` to bypass the single pending tx restriction
+
 ## 2.33.0 (2025-07-21)
 
 - added: Added `usesChangeServer` flag to `EdgeCurrencyInfo` to optimize syncing for engines which subscribe to the change-server.
@@ -1962,3 +1964,9 @@ Fixes:
 - Removed `asmcrypto.js`
 - Made the CLI executable & installable
 - Pruned the list of files we publish to NPM
+
+## 2.17.0 (2024-12-18)
+
+### Fixed
+
+- Pass `allowChainedPending` from EdgeSpendInfo to currency engine's makeSpend method

--- a/src/core/currency/wallet/currency-wallet-api.ts
+++ b/src/core/currency/wallet/currency-wallet-api.ts
@@ -528,7 +528,8 @@ export function makeCurrencyWalletApi(
         savedAction,
         skipChecks,
         spendTargets = [],
-        swapData
+        swapData,
+        allowChainedPending = false
       } = spendInfo
 
       // Figure out which asset this is:
@@ -586,7 +587,8 @@ export function makeCurrencyWalletApi(
           pendingTxs,
           rbfTxid,
           skipChecks,
-          spendTargets: cleanTargets
+          spendTargets: cleanTargets,
+          allowChainedPending
         },
         { privateKeys }
       )

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -702,6 +702,8 @@ export interface EdgeSpendInfo {
   /** @deprecated Use EdgeCurrencyWallet.accelerate instead */
   rbfTxid?: string
   skipChecks?: boolean
+  /** Allow creating transactions with chained nonces even if pending transactions exist */
+  allowChainedPending?: boolean
 
   // Core:
   assetAction?: EdgeAssetAction


### PR DESCRIPTION
To allow spends with chained nonces despite existing pending transactions.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210803607950460