### PR TITLE
Fix transpilation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Fixed syncing bug caused by ES5 transpilation.
+
 ## 2.33.1 (2025-07-24)
 
 - fixed: By-pass pin-wait period special case caused by duress mode feature.

--- a/src/core/currency/currency-pixie.ts
+++ b/src/core/currency/currency-pixie.ts
@@ -314,7 +314,12 @@ export const currency: TamePixie<RootProps> = combinePixies({
           subscriptionUpdates.set(walletId, subscriptions)
         }
 
-        for (const [walletId, subscriptions] of subscriptionUpdates.entries()) {
+        // TODO: Remove the Array.from() once we drop ES5 targeting. This is
+        // need to avoid iterables because looping over iterables are broken
+        // for ES5 targets.
+        const entries = Array.from(subscriptionUpdates.entries())
+
+        for (const [walletId, subscriptions] of entries) {
           input.props.dispatch({
             type: 'CURRENCY_ENGINE_UPDATE_CHANGE_SERVICE_SUBSCRIPTIONS',
             payload: {


### PR DESCRIPTION
Targeting ES5 transpilation causes a bug with looping over iterables. The transpilation assumes all loops are over arrays, and so it loops using `.length` properties. We cannot loop over iterables, therefore we must convert the iterable to an array before looping.

This fixes a major bug with syncing caused by transpilation of the source.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
