### PR TITLE
Fix incorrect tokenId in swap quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Do not "upgrade" swap quotes to the wrong tokenId.
+
 ## 2.34.1 (2025-09-19)
 
 - fixed: Avoid deprecated Gradle syntax.

--- a/src/types/type-helpers.ts
+++ b/src/types/type-helpers.ts
@@ -37,8 +37,8 @@ export function upgradeCurrencyCode(opts: {
 }
 
 export function upgradeSwapQuote(quote: EdgeSwapQuote): EdgeSwapQuote {
-  if (quote.networkFee != null && quote.networkFee.tokenId == null) {
-    quote.networkFee.tokenId = quote.request.fromTokenId
+  if (quote.networkFee != null && quote.networkFee.tokenId === undefined) {
+    quote.networkFee.tokenId = null
   }
   return quote
 }


### PR DESCRIPTION
The correct tokenId is usually `null`, for the main chain. Sadly, we would "upgrade" this to the wrong thing.

Only do the upgrade if the tokenId is `undefined`, and then use the right tokenId when we do the upgrade.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust `upgradeSwapQuote` to set `networkFee.tokenId` to `null` only when it is `undefined`, avoiding wrong tokenId; update CHANGELOG.
> 
> - **Types**:
>   - `src/types/type-helpers.ts`: Update `upgradeSwapQuote` so that when `quote.networkFee.tokenId === undefined`, it sets to `null` (no longer assigns `request.fromTokenId`).
> - **Docs**:
>   - `CHANGELOG.md`: Note fix for not "upgrading" swap quotes to the wrong `tokenId`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d3e29f6341400a1d5e3041a8e7b39c9e194c06a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211511240281950