### PR TITLE
Remove NYM mixFetch per-host queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: Remove NYM mixFetch per-host request queue now that `@nymproject/mix-fetch` handles concurrency natively.
+
 ## 2.43.1 (2026-02-23)
 
 - changed: Upgrade `@nymproject/mix-fetch` to improve performance with new concurrency changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- changed: Increase NYM mixFetch timeout to 120s for improved XMR makeSpend reliability.
 - changed: Remove NYM mixFetch per-host request queue now that `@nymproject/mix-fetch` handles concurrency natively.
 
 ## 2.43.1 (2026-02-23)

--- a/src/io/browser/browser-io.ts
+++ b/src/io/browser/browser-io.ts
@@ -1,9 +1,10 @@
+import { mixFetch } from '@nymproject/mix-fetch'
 import { makeLocalStorageDisklet } from 'disklet'
 
 import { LogBackend, makeLog } from '../../core/log/log'
 import { EdgeFetchOptions, EdgeFetchResponse, EdgeIo } from '../../types/types'
 import { scrypt } from '../../util/crypto/scrypt'
-import { initMixFetch, queueMixFetch } from '../../util/nym'
+import { initMixFetch, mixFetchOptions } from '../../util/nym'
 import { fetchCorsProxy } from './fetch-cors-proxy'
 
 // Only try CORS proxy/bridge techniques up to 5 times
@@ -51,10 +52,14 @@ export function makeBrowserIo(logBackend: LogBackend): EdgeIo {
       if (privacy === 'nym') {
         // Ensure mixFetch is initialized before use
         await initMixFetch(log)
-        return await queueMixFetch(uri, {
-          ...opts,
-          mode: 'unsafe-ignore-cors' as RequestMode
-        })
+        return await mixFetch(
+          uri,
+          {
+            ...opts,
+            mode: 'unsafe-ignore-cors' as RequestMode
+          },
+          mixFetchOptions
+        )
       }
       if (corsBypass === 'always') {
         return await fetchCorsProxy(uri, opts)

--- a/src/io/browser/browser-io.ts
+++ b/src/io/browser/browser-io.ts
@@ -51,7 +51,6 @@ export function makeBrowserIo(logBackend: LogBackend): EdgeIo {
       if (privacy === 'nym') {
         // Ensure mixFetch is initialized before use
         await initMixFetch(log)
-        // Use queued fetch to handle mixFetch's one-request-per-host limitation
         return await queueMixFetch(uri, {
           ...opts,
           mode: 'unsafe-ignore-cors' as RequestMode

--- a/src/io/react-native/react-native-worker.ts
+++ b/src/io/react-native/react-native-worker.ts
@@ -178,7 +178,6 @@ async function makeIo(logBackend: LogBackend): Promise<EdgeIo> {
       if (privacy === 'nym') {
         // Ensure mixFetch is initialized before use
         await initMixFetch(log)
-        // Use queued fetch to handle mixFetch's one-request-per-host limitation
         const response = await queueMixFetch(uri, {
           ...opts,
           mode: 'unsafe-ignore-cors' as RequestMode

--- a/src/io/react-native/react-native-worker.ts
+++ b/src/io/react-native/react-native-worker.ts
@@ -1,3 +1,4 @@
+import { mixFetch } from '@nymproject/mix-fetch'
 import hashjs from 'hash.js'
 import HmacDRBG from 'hmac-drbg'
 import { base64 } from 'rfc4648'
@@ -17,7 +18,7 @@ import {
   EdgeFetchResponse,
   EdgeIo
 } from '../../types/types'
-import { initMixFetch, queueMixFetch } from '../../util/nym'
+import { initMixFetch, mixFetchOptions } from '../../util/nym'
 import { hideProperties } from '../hidden-properties'
 import { makeNativeBridge } from './native-bridge'
 import { WorkerApi, YAOB_THROTTLE_MS } from './react-native-types'
@@ -178,10 +179,14 @@ async function makeIo(logBackend: LogBackend): Promise<EdgeIo> {
       if (privacy === 'nym') {
         // Ensure mixFetch is initialized before use
         await initMixFetch(log)
-        const response = await queueMixFetch(uri, {
-          ...opts,
-          mode: 'unsafe-ignore-cors' as RequestMode
-        })
+        const response = await mixFetch(
+          uri,
+          {
+            ...opts,
+            mode: 'unsafe-ignore-cors' as RequestMode
+          },
+          mixFetchOptions
+        )
         return response
       }
       if (corsBypass === 'always') {

--- a/src/util/nym.ts
+++ b/src/util/nym.ts
@@ -17,24 +17,6 @@ export const mixFetchOptions: SetupMixFetchOps = {
 // MixFetch initialization state
 let mixFetchInitPromise: Promise<IMixFetch> | null = null
 
-// Per-host request queue to handle mixFetch's one-request-per-host limitation
-// Maps host -> Promise that resolves when current request completes (for chaining)
-const hostRequestChains = new Map<string, Promise<Response>>()
-
-/**
- * Extract the host:port from a URI for queue keying
- */
-function getHostKey(uri: string): string {
-  try {
-    const url = new URL(uri)
-    const port =
-      url.port !== '' ? url.port : url.protocol === 'https:' ? '443' : '80'
-    return `${url.hostname}:${port}`
-  } catch {
-    return uri
-  }
-}
-
 /**
  * Initialize the NYM mixFetch client. Must be called before using mixFetch.
  * Safe to call multiple times - subsequent calls return the same promise.
@@ -58,31 +40,11 @@ export async function initMixFetch(log: EdgeLog): Promise<IMixFetch> {
 }
 
 /**
- * Queue-wrapped mixFetch that serializes requests per host.
- * mixFetch only allows one concurrent request per host, so we chain them.
+ * Thin wrapper around mixFetch with pre-configured options.
  */
 export async function queueMixFetch(
   uri: string,
   opts: RequestInit & { mode?: string }
 ): Promise<Response> {
-  const hostKey = getHostKey(uri)
-
-  // Get the current chain for this host (or resolved promise if none)
-  const previousChain = hostRequestChains.get(hostKey) ?? Promise.resolve()
-
-  // Chain our request after the previous one
-  const ourWork = previousChain
-    .catch(() => {}) // Ignore errors from previous request
-    .then(async () => await mixFetch(uri, opts, mixFetchOptions))
-    .finally(() => {
-      // Clean up if we're still the chain tail
-      if (hostRequestChains.get(hostKey) === ourWork) {
-        hostRequestChains.delete(hostKey)
-      }
-    })
-
-  // Store our chain BEFORE awaiting - ensures subsequent requests wait for us
-  hostRequestChains.set(hostKey, ourWork)
-
-  return await ourWork
+  return await mixFetch(uri, opts, mixFetchOptions)
 }

--- a/src/util/nym.ts
+++ b/src/util/nym.ts
@@ -1,7 +1,6 @@
 import {
   createMixFetch,
   IMixFetch,
-  mixFetch,
   SetupMixFetchOps
 } from '@nymproject/mix-fetch'
 
@@ -37,14 +36,4 @@ export async function initMixFetch(log: EdgeLog): Promise<IMixFetch> {
       })
   }
   return await mixFetchInitPromise
-}
-
-/**
- * Thin wrapper around mixFetch with pre-configured options.
- */
-export async function queueMixFetch(
-  uri: string,
-  opts: RequestInit & { mode?: string }
-): Promise<Response> {
-  return await mixFetch(uri, opts, mixFetchOptions)
 }

--- a/src/util/nym.ts
+++ b/src/util/nym.ts
@@ -10,7 +10,10 @@ import { EdgeLog } from '../types/types'
  * Configuration options for the NYM mixFetch client.
  */
 export const mixFetchOptions: SetupMixFetchOps = {
-  forceTls: true // force WSS
+  forceTls: true, // force WSS
+  mixFetchOverride: {
+    requestTimeoutMs: 120000
+  }
 }
 
 // MixFetch initialization state


### PR DESCRIPTION
## Summary
- remove custom per-host request serialization in 
- keep  export as a thin pass-through to 
- remove stale comments at NYM callsites in browser/react-native IO
- add changelog note under Unreleased

## Why
 was upgraded in 2.43.1 for native concurrency improvements. Keeping our own host queue can unnecessarily serialize NYM traffic and increase timeout risk.

## Validation
- 
- 

## Risk
- behavior changes from serialized per-host to library-managed concurrency; relies on current mix-fetch behavior.