### PR TITLE
fix(memory-wallet): expose plugin otherMethods on memory wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: Expose engine otherMethods on EdgeMemoryWallet so memory wallets support custom methods like makeMaxSpend.
+
 ## 2.43.6 (2026-04-02)
 
 - fixed: Upgraded @nymproject/mix-fetch with promised reliability improvements.

--- a/src/core/account/memory-wallet.ts
+++ b/src/core/account/memory-wallet.ts
@@ -147,6 +147,23 @@ export const makeMemoryWalletInner = async (
     syncNetworkTask.start({ wait: false })
   }
 
+  const otherMethods: { [name: string]: (...args: any[]) => any } = {}
+  if (engine.otherMethods != null) {
+    for (const name of Object.keys(engine.otherMethods)) {
+      const method = engine.otherMethods[name]
+      if (typeof method !== 'function') continue
+      otherMethods[name] = method
+    }
+  }
+  if (engine.otherMethodsWithKeys != null) {
+    for (const name of Object.keys(engine.otherMethodsWithKeys)) {
+      const method = engine.otherMethodsWithKeys[name]
+      if (typeof method !== 'function') continue
+      otherMethods[name] = (...args: any[]) => method(walletInfo.keys, ...args)
+    }
+  }
+  bridgifyObject(otherMethods)
+
   const out = bridgifyObject<EdgeMemoryWallet>({
     watch: watchMethod,
     get balanceMap() {
@@ -195,6 +212,8 @@ export const makeMemoryWalletInner = async (
       )
     },
     async saveTx() {},
+
+    otherMethods,
 
     async close() {
       log.warn('killing memory wallet')

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1473,6 +1473,7 @@ export interface EdgeMemoryWallet {
   readonly signTx: (tx: EdgeTransaction) => Promise<EdgeTransaction>
   readonly broadcastTx: (tx: EdgeTransaction) => Promise<EdgeTransaction>
   readonly saveTx: (tx: EdgeTransaction) => Promise<void>
+  readonly otherMethods: EdgeOtherMethods
   readonly close: () => Promise<void>
 
   /** @deprecated Use syncStatus */


### PR DESCRIPTION
Memory wallets need access to plugin-defined methods for flows like max spend estimation that rely on engine-specific capabilities. Exposing and bridgifying both plain and key-aware method variants keeps behavior consistent with full wallets while preserving key handling boundaries.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the public `EdgeMemoryWallet` API and forwards engine-defined methods (including key-aware wrappers), which could affect plugin interoperability and accidentally expose or mis-handle key material if misused.
> 
> **Overview**
> Memory wallets now expose currency engine custom methods via a new `EdgeMemoryWallet.otherMethods` field, matching full-wallet behavior.
> 
> `makeMemoryWalletInner` collects `engine.otherMethods` and `engine.otherMethodsWithKeys`, wraps the key-aware variants to inject `walletInfo.keys`, and bridgifies the resulting method map for use across the Yaob bridge. A CHANGELOG entry documents the new capability (e.g. enabling engine-specific helpers like max-spend variants).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 002bcc94d3a3d3713e9dc1f1c8227c276c033e43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213968564434714