### PR TITLE
Add wallet settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added: `EdgeCurrencyWallet.walletSettings` and `EdgeCurrencyWallet.changeWalletSettings`, plus matching engine plumbing.
 - removed: All Flow tooling. TypeScript is the type system of record, and nothing in the Edge codebase consumes the generated Flow types. This drops the `flow-bin` devDependency, the root `.flowconfig`, the `build.types` script and its `make-types.ts` generator, the `rollup-plugin-flow-entry` plugin, the `eslint-plugin-flowtype` config, the `flow-typed` directory, and the published `types.js.flow` artifact. The `flow-bin` package shipped an x86_64-only binary that failed with EBADARCH on arm64 hosts. Note: dropping `types.js.flow` is a breaking change for any downstream consumer that imports this package via Flow.
 
 ## 2.45.0 (2026-06-12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - added: `EdgeCurrencyWallet.walletSettings` and `EdgeCurrencyWallet.changeWalletSettings`, plus matching engine plumbing.
+- added: `EdgeCurrencyWallet.imported` flag, indicating a wallet created by importing keys.
 - removed: All Flow tooling. TypeScript is the type system of record, and nothing in the Edge codebase consumes the generated Flow types. This drops the `flow-bin` devDependency, the root `.flowconfig`, the `build.types` script and its `make-types.ts` generator, the `rollup-plugin-flow-entry` plugin, the `eslint-plugin-flowtype` config, the `flow-typed` directory, and the published `types.js.flow` artifact. The `flow-bin` package shipped an x86_64-only binary that failed with EBADARCH on arm64 hosts. Note: dropping `types.js.flow` is a breaking change for any downstream consumer that imports this package via Flow.
 
 ## 2.45.0 (2026-06-12)

--- a/src/core/account/account-api.ts
+++ b/src/core/account/account-api.ts
@@ -25,11 +25,13 @@ import {
   EdgeSwapQuote,
   EdgeSwapRequest,
   EdgeSwapRequestOptions,
+  EdgeWalletInfo,
   EdgeWalletInfoFull,
   EdgeWalletStates
 } from '../../types/types'
 import { makeEdgeResult } from '../../util/edgeResult'
 import { base58 } from '../../util/encoding'
+import { saveWalletSettings } from '../currency/wallet/currency-wallet-files'
 import { getPublicWalletInfo } from '../currency/wallet/currency-wallet-pixie'
 import {
   finishWalletCreation,
@@ -55,13 +57,14 @@ import {
 import { changePin, checkPin2, deletePin } from '../login/pin2'
 import { changeRecovery, deleteRecovery } from '../login/recovery2'
 import { listSplittableWalletTypes, splitWalletInfo } from '../login/splitting'
+import { asEdgeStorageKeys } from '../login/storage-keys'
 import { changeVoucherStatus } from '../login/vouchers'
 import {
   findCurrencyPluginId,
   getCurrencyTools
 } from '../plugins/plugins-selectors'
 import { ApiInput } from '../root-pixie'
-import { makeLocalDisklet } from '../storage/repo'
+import { makeLocalDisklet, makeRepoPaths } from '../storage/repo'
 import { makeStorageWalletApi } from '../storage/storage-api'
 import { fetchSwapQuotes } from '../swap/swap-api'
 import { changeWalletStates } from './account-files'
@@ -71,6 +74,26 @@ import { makeDataStoreApi } from './data-store-api'
 import { makeLobbyApi } from './lobby-api'
 import { makeMemoryWalletInner } from './memory-wallet'
 import { CurrencyConfig, SwapConfig } from './plugin-api'
+
+async function prewriteWalletSettings(
+  ai: ApiInput,
+  walletInfo: EdgeWalletInfo,
+  walletSettings: object
+): Promise<void> {
+  // Only persist settings for currencies that actually support them. Otherwise
+  // the data would be written to disk but never loaded or exposed, since the
+  // wallet layer reads settings only when `currencyInfo.hasWalletSettings`:
+  const { currency } = ai.props.state.plugins
+  const pluginId = findCurrencyPluginId(currency, walletInfo.type)
+  const { hasWalletSettings = false } = currency[pluginId].currencyInfo
+  if (!hasWalletSettings) return
+
+  const { io } = ai.props
+  const storageKeys = asEdgeStorageKeys(walletInfo.keys)
+  const { disklet } = makeRepoPaths(io, storageKeys)
+
+  await saveWalletSettings(disklet, walletSettings)
+}
 
 /**
  * Creates an unwrapped account API object around an account state object.
@@ -642,6 +665,9 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
       ai.props.log.breadcrumb('EdgeAccount.createCurrencyWallet', {})
 
       const walletInfo = await makeCurrencyWalletKeys(ai, walletType, opts)
+      if (opts.walletSettings != null) {
+        await prewriteWalletSettings(ai, walletInfo, opts.walletSettings)
+      }
       const childKey = decryptChildKey(stashTree, sessionKey, login.loginId)
       await applyKit(ai, sessionKey, makeKeysKit(ai, childKey, [walletInfo]))
       return await finishWalletCreation(ai, accountId, walletInfo.id, opts)
@@ -673,6 +699,14 @@ export function makeAccountApi(ai: ApiInput, accountId: string): EdgeAccount {
           async opts => await makeCurrencyWalletKeys(ai, opts.walletType, opts)
         )
       )
+
+      // Prewrite wallet settings before applyKit triggers the pixie:
+      for (let i = 0; i < walletInfos.length; i++) {
+        const { walletSettings } = createWallets[i]
+        if (walletSettings != null) {
+          await prewriteWalletSettings(ai, walletInfos[i], walletSettings)
+        }
+      }
 
       // Store the keys on the server:
       const childKey = decryptChildKey(stashTree, sessionKey, login.loginId)

--- a/src/core/account/memory-wallet.ts
+++ b/src/core/account/memory-wallet.ts
@@ -28,7 +28,7 @@ export const makeMemoryWalletInner = async (
   walletType: string,
   opts: EdgeCreateCurrencyWalletOptions = {}
 ): Promise<EdgeMemoryWallet> => {
-  const { keys } = opts
+  const { keys, walletSettings = {} } = opts
   if (keys == null) throw new Error('No keys provided')
 
   const walletId = `memorywallet-${memoryWalletCount++}`
@@ -113,6 +113,7 @@ export const makeMemoryWalletInner = async (
     lightMode: true,
     log,
     userSettings: { ...(config.userSettings ?? {}) },
+    walletSettings,
     walletLocalDisklet: makeMemoryDisklet(),
     walletLocalEncryptedDisklet: makeMemoryDisklet()
   })

--- a/src/core/actions.ts
+++ b/src/core/actions.ts
@@ -11,7 +11,8 @@ import {
   EdgeTokenMap,
   EdgeTransaction,
   EdgeWalletInfo,
-  EdgeWalletStates
+  EdgeWalletStates,
+  JsonObject
 } from '../types/types'
 import { SwapSettings } from './account/account-types'
 import { ClientInfo } from './context/client-file'
@@ -357,6 +358,20 @@ export type RootAction =
       type: 'CURRENCY_WALLET_SAVED_TOKEN_FILE'
       payload: {
         walletId: string
+      }
+    }
+  | {
+      type: 'CURRENCY_WALLET_CHANGED_WALLET_SETTINGS'
+      payload: {
+        walletId: string
+        walletSettings: JsonObject
+      }
+    }
+  | {
+      type: 'CURRENCY_WALLET_LOADED_WALLET_SETTINGS_FILE'
+      payload: {
+        walletId: string
+        walletSettings: JsonObject
       }
     }
   | {

--- a/src/core/currency/wallet/currency-wallet-api.ts
+++ b/src/core/currency/wallet/currency-wallet-api.ts
@@ -40,7 +40,8 @@ import {
   EdgeTokenId,
   EdgeTokenIdOptions,
   EdgeTransaction,
-  EdgeWalletInfo
+  EdgeWalletInfo,
+  JsonObject
 } from '../../../types/types'
 import { makeMetaTokens } from '../../account/custom-tokens'
 import { splitWalletInfo } from '../../login/splitting'
@@ -63,6 +64,7 @@ import {
   loadTxFiles,
   renameCurrencyWallet,
   saveTxMetadataFile,
+  saveWalletSettingsFile,
   setCurrencyWalletFiat,
   setupNewTxMetadata,
   updateCurrencyWalletTxMetadata
@@ -191,6 +193,17 @@ export function makeCurrencyWalletApi(
         currencyCode
       )
       return div(nativeAmount, multiplier, multiplier.length)
+    },
+
+    // User settings for this wallet:
+    get walletSettings(): JsonObject {
+      return input.props.walletState.walletSettings
+    },
+    async changeWalletSettings(settings: JsonObject): Promise<void> {
+      if (input.props.walletState.currencyInfo.hasWalletSettings !== true) {
+        throw new Error('Wallet settings unsupported')
+      }
+      await saveWalletSettingsFile(input, settings)
     },
 
     // Chain state:

--- a/src/core/currency/wallet/currency-wallet-api.ts
+++ b/src/core/currency/wallet/currency-wallet-api.ts
@@ -137,6 +137,9 @@ export function makeCurrencyWalletApi(
     get id(): string {
       return storageWalletApi.id
     },
+    get imported(): boolean {
+      return walletInfo.imported === true
+    },
     get localDisklet(): Disklet {
       return storageWalletApi.localDisklet
     },

--- a/src/core/currency/wallet/currency-wallet-cleaners.ts
+++ b/src/core/currency/wallet/currency-wallet-cleaners.ts
@@ -308,6 +308,10 @@ export const asTokensFile = asObject({
   detectedTokenIds: asArray(asString)
 })
 
+export const asWalletSettingsFile = asObject({
+  walletSettings: asOptional(asJsonObject, () => ({}))
+})
+
 const asTransactionAsset = asObject<TransactionAsset>({
   assetAction: asOptional(asEdgeAssetAction),
   metadata: asEdgeMetadata,

--- a/src/core/currency/wallet/currency-wallet-files.ts
+++ b/src/core/currency/wallet/currency-wallet-files.ts
@@ -8,7 +8,8 @@ import {
   EdgeSubscribedAddress,
   EdgeTokenId,
   EdgeTransaction,
-  EdgeTxAction
+  EdgeTxAction,
+  JsonObject
 } from '../../../types/types'
 import { makeJsonFile } from '../../../util/file-helpers'
 import { fetchAppIdInfo } from '../../account/lobby-api'
@@ -30,6 +31,7 @@ import {
   asTransactionFile,
   asWalletFiatFile,
   asWalletNameFile,
+  asWalletSettingsFile,
   LegacyTransactionFile,
   TransactionAsset,
   TransactionFile
@@ -45,6 +47,7 @@ const LEGACY_TOKENS_FILE = 'EnabledTokens.json'
 const SEEN_TX_CHECKPOINT_FILE = 'seenTxCheckpoint.json'
 const TOKENS_FILE = 'Tokens.json'
 const WALLET_NAME_FILE = 'WalletName.json'
+const WALLET_SETTINGS_FILE = 'WalletSettings.json'
 
 const legacyAddressFile = makeJsonFile(asLegacyAddressFile)
 const legacyMapFile = makeJsonFile(asLegacyMapFile)
@@ -55,6 +58,7 @@ const tokensFile = makeJsonFile(asTokensFile)
 const transactionFile = makeJsonFile(asTransactionFile)
 const walletFiatFile = makeJsonFile(asWalletFiatFile)
 const walletNameFile = makeJsonFile(asWalletNameFile)
+const walletSettingsFile = makeJsonFile(asWalletSettingsFile)
 
 /**
  * Updates the enabled tokens on a wallet.
@@ -281,6 +285,52 @@ export async function loadTokensFile(
       detectedTokenIds: [],
       enabledTokenIds: []
     }
+  })
+}
+
+/**
+ * Loads wallet-specific settings.
+ */
+export async function loadWalletSettingsFile(
+  input: CurrencyWalletInput
+): Promise<void> {
+  const { dispatch, state, walletId } = input.props
+  const disklet = getStorageWalletDisklet(state, walletId)
+
+  const clean = await walletSettingsFile.load(disklet, WALLET_SETTINGS_FILE)
+  dispatch({
+    type: 'CURRENCY_WALLET_LOADED_WALLET_SETTINGS_FILE',
+    payload: {
+      walletId,
+      walletSettings: clean?.walletSettings ?? {}
+    }
+  })
+}
+
+/**
+ * Persists wallet settings to disk.
+ */
+export async function saveWalletSettingsFile(
+  input: CurrencyWalletInput,
+  walletSettings: JsonObject
+): Promise<void> {
+  const { dispatch, state, walletId } = input.props
+  const disklet = getStorageWalletDisklet(state, walletId)
+
+  await saveWalletSettings(disklet, walletSettings)
+
+  dispatch({
+    type: 'CURRENCY_WALLET_CHANGED_WALLET_SETTINGS',
+    payload: { walletId, walletSettings }
+  })
+}
+
+export async function saveWalletSettings(
+  disklet: Disklet,
+  walletSettings: JsonObject
+): Promise<void> {
+  await walletSettingsFile.save(disklet, WALLET_SETTINGS_FILE, {
+    walletSettings
   })
 }
 
@@ -696,6 +746,10 @@ export async function reloadWalletFiles(
 ): Promise<void> {
   if (changes.includes(TOKENS_FILE) || changes.includes(LEGACY_TOKENS_FILE)) {
     await loadTokensFile(input)
+  }
+  const { hasWalletSettings = false } = input.props.walletState.currencyInfo
+  if (hasWalletSettings && changes.includes(WALLET_SETTINGS_FILE)) {
+    await loadWalletSettingsFile(input)
   }
   if (changes.includes(CURRENCY_FILE)) {
     await loadFiatFile(input)

--- a/src/core/currency/wallet/currency-wallet-pixie.ts
+++ b/src/core/currency/wallet/currency-wallet-pixie.ts
@@ -14,7 +14,8 @@ import {
   EdgeCurrencyTools,
   EdgeCurrencyWallet,
   EdgeTokenMap,
-  EdgeWalletInfo
+  EdgeWalletInfo,
+  JsonObject
 } from '../../../types/types'
 import { makeJsonFile } from '../../../util/file-helpers'
 import { makePeriodicTask, PeriodicTask } from '../../../util/periodic-task'
@@ -45,9 +46,14 @@ import {
   loadSeenTxCheckpointFile,
   loadTokensFile,
   loadTxFileNames,
+  loadWalletSettingsFile,
   writeTokensFile
 } from './currency-wallet-files'
-import { CurrencyWalletState, initialTokenIds } from './currency-wallet-reducer'
+import {
+  CurrencyWalletState,
+  initialTokenIds,
+  initialWalletSettings
+} from './currency-wallet-reducer'
 import { tokenIdsToCurrencyCodes, uniqueStrings } from './enabled-tokens'
 
 export interface CurrencyWalletOutput {
@@ -118,6 +124,11 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
       // so the engine can start in the right state:
       await loadTokensFile(input)
 
+      const { hasWalletSettings = false } = walletState.currencyInfo
+      if (hasWalletSettings) {
+        await loadWalletSettingsFile(input)
+      }
+
       // Start the engine:
       const accountState = state.accounts[accountId]
       const engine = await plugin.makeCurrencyEngine(publicWalletInfo, {
@@ -138,7 +149,8 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
         // User settings:
         customTokens: accountState.customTokens[pluginId] ?? {},
         enabledTokenIds: input.props.walletState.allEnabledTokenIds,
-        userSettings: accountState.userSettings[pluginId] ?? {}
+        userSettings: accountState.userSettings[pluginId] ?? {},
+        walletSettings: input.props.walletState.walletSettings
       })
       input.onOutput(engine)
 
@@ -462,7 +474,8 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
 
   watcher(input: CurrencyWalletInput) {
     let lastState: CurrencyWalletState | undefined
-    let lastSettings: object = {}
+    let lastUserSettings: object = {}
+    let lastWalletSettings: JsonObject = initialWalletSettings
     let lastTokens: EdgeTokenMap = {}
     let lastEnabledTokenIds: string[] = initialTokenIds
 
@@ -480,11 +493,12 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
       lastState = walletState
 
       // Update engine settings:
-      const userSettings = accountState.userSettings[pluginId] ?? lastSettings
-      if (lastSettings !== userSettings && engine != null) {
+      const userSettings =
+        accountState.userSettings[pluginId] ?? lastUserSettings
+      if (lastUserSettings !== userSettings && engine != null) {
         await engine.changeUserSettings(userSettings)
       }
-      lastSettings = userSettings
+      lastUserSettings = userSettings
 
       // Update the custom tokens:
       const customTokens = accountState.customTokens[pluginId] ?? lastTokens
@@ -504,6 +518,22 @@ export const walletPixie: TamePixie<CurrencyWalletProps> = combinePixies({
         } // else { no token support }
       }
       lastTokens = customTokens
+
+      // Update wallet-scoped settings:
+      const { hasWalletSettings = false } = walletState.currencyInfo
+      const { walletSettings } = walletState
+      const settingsChanged = lastWalletSettings !== walletSettings
+
+      if (
+        settingsChanged &&
+        engine?.changeWalletSettings != null &&
+        hasWalletSettings
+      ) {
+        await engine.changeWalletSettings(walletSettings).catch(error => {
+          input.props.onError(error)
+        })
+      }
+      lastWalletSettings = walletSettings
 
       // Update enabled tokens:
       const { allEnabledTokenIds } = walletState

--- a/src/core/currency/wallet/currency-wallet-reducer.ts
+++ b/src/core/currency/wallet/currency-wallet-reducer.ts
@@ -13,7 +13,8 @@ import {
   EdgeTransaction,
   EdgeTxAction,
   EdgeWalletInfo,
-  EdgeWalletInfoFull
+  EdgeWalletInfoFull,
+  JsonObject
 } from '../../../types/types'
 import { compare } from '../../../util/compare'
 import { RootAction } from '../../actions'
@@ -75,6 +76,7 @@ export interface CurrencyWalletState {
   readonly enabledTokenIds: string[]
   readonly tokenFileDirty: boolean
   readonly tokenFileLoaded: boolean
+  readonly walletSettings: JsonObject
   readonly engineFailure: Error | null
   readonly engineStarted: boolean
   readonly fiat: string
@@ -117,6 +119,8 @@ export interface CurrencyWalletNext {
   readonly root: RootState
   readonly self: CurrencyWalletState
 }
+
+export const initialWalletSettings: JsonObject = {}
 
 // Used for detectedTokenIds & enabledTokenIds:
 export const initialTokenIds: string[] = []
@@ -245,6 +249,16 @@ const currencyWalletInner = buildReducer<
 
       case 'CURRENCY_ENGINE_CLEARED':
         return false
+      default:
+        return state
+    }
+  },
+
+  walletSettings(state = initialWalletSettings, action): JsonObject {
+    switch (action.type) {
+      case 'CURRENCY_WALLET_LOADED_WALLET_SETTINGS_FILE':
+      case 'CURRENCY_WALLET_CHANGED_WALLET_SETTINGS':
+        return action.payload.walletSettings
       default:
         return state
     }

--- a/src/core/login/splitting.ts
+++ b/src/core/login/splitting.ts
@@ -172,18 +172,14 @@ export async function splitWalletInfo(
   // Restore anything that has simply been deleted:
   if (toRestore.length > 0) {
     const newStates: EdgeWalletStates = {}
-    let hasChanges = false
     for (const existingWalletInfo of toRestore) {
-      if (existingWalletInfo.archived || existingWalletInfo.deleted) {
-        hasChanges = true
-        newStates[existingWalletInfo.id] = {
-          archived: false,
-          deleted: false,
-          migratedFromWalletId: existingWalletInfo.migratedFromWalletId
-        }
+      newStates[existingWalletInfo.id] = {
+        archived: false,
+        deleted: false,
+        migratedFromWalletId: existingWalletInfo.migratedFromWalletId
       }
     }
-    if (hasChanges) await changeWalletStates(ai, accountId, newStates)
+    await changeWalletStates(ai, accountId, newStates)
   }
 
   // Add the keys to the login:

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1332,6 +1332,7 @@ export interface EdgeCurrencyWallet {
   readonly created: Date | undefined
   readonly disklet: Disklet
   readonly id: string
+  readonly imported: boolean
   readonly localDisklet: Disklet
   readonly publicWalletInfo: EdgeWalletInfo
   readonly sync: () => Promise<void>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -543,6 +543,7 @@ export interface EdgeCurrencyInfo {
   unsafeMakeSpend?: boolean
   unsafeSyncNetwork?: boolean
   usesChangeServer?: boolean
+  hasWalletSettings?: boolean
 
   /** Show the total sync percentage with this many decimal digits */
   syncDisplayPrecision?: number
@@ -1043,10 +1044,12 @@ export interface EdgeCurrencyEngineOptions {
   customTokens: EdgeTokenMap
   enabledTokenIds: string[]
   userSettings: JsonObject | undefined
+  walletSettings: JsonObject
 }
 
 export interface EdgeCurrencyEngine {
   readonly changeUserSettings: (settings: JsonObject) => Promise<void>
+  readonly changeWalletSettings?: (settings: JsonObject) => Promise<void>
 
   /**
    * Starts any persistent resources the engine needs, such as WebSockets.
@@ -1345,6 +1348,10 @@ export interface EdgeCurrencyWallet {
   // Currency info:
   readonly currencyConfig: EdgeCurrencyConfig // eslint-disable-line no-use-before-define
   readonly currencyInfo: EdgeCurrencyInfo
+
+  // User settings for this wallet:
+  readonly walletSettings: JsonObject
+  readonly changeWalletSettings: (settings: JsonObject) => Promise<void>
 
   // Chain state:
   readonly balanceMap: EdgeBalanceMap
@@ -1652,6 +1659,7 @@ export interface EdgeCreateCurrencyWalletOptions {
   enabledTokenIds?: string[]
   fiatCurrencyCode?: string
   name?: string
+  walletSettings?: JsonObject
 
   // Create a private key from some text:
   importText?: string


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wallet creation, persistence, and engine configuration paths; impact is limited to plugins that set `hasWalletSettings`, but incorrect settings handling could affect engine behavior at runtime.
> 
> **Overview**
> Introduces **wallet-scoped settings** for currencies that opt in via `EdgeCurrencyInfo.hasWalletSettings`. Settings are stored in `WalletSettings.json`, loaded at engine startup, exposed as `walletSettings` / `changeWalletSettings` on `EdgeCurrencyWallet`, and passed through to engines (including optional `changeWalletSettings`). `createCurrencyWallet` and `createCurrencyWallets` accept `walletSettings` in options and **prewrite** them to the wallet repo before `applyKit` so the pixie sees them on first load.
> 
> Memory wallets now receive `walletSettings` in engine options. Sync reload picks up `WalletSettings.json` when supported.
> 
> Also exposes **`EdgeCurrencyWallet.imported`** (`walletInfo.imported === true`) for key-imported wallets.
> 
> **Split restore:** when un-archiving split wallets, `changeWalletStates` is always invoked for the restore set (drops the previous no-op when nothing was archived/deleted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0434eeef48bfae806b9463b7bb58c8f1e8f7514f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214464583383395