### PR TITLE
Add makeMaxSpend wallet API with core fallback shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- added: `EdgeCurrencyWallet.makeMaxSpend` and `EdgeMemoryWallet.makeMaxSpend`, which atomically build a transaction that spends the maximum amount. The core falls back to `getMaxSpendable` + `makeSpend` for engines that don't implement `EdgeCurrencyEngine.makeMaxSpend`.
+- deprecated: `EdgeCurrencyWallet.getMaxSpendable` and `EdgeMemoryWallet.getMaxSpendable`. Use `makeMaxSpend` to build a max-spend transaction.
+
 ## 2.46.0 (2026-06-18)
 
 - added: `EdgeCurrencyWallet.walletSettings` and `EdgeCurrencyWallet.changeWalletSettings`, plus matching engine plumbing.

--- a/src/core/account/memory-wallet.ts
+++ b/src/core/account/memory-wallet.ts
@@ -203,6 +203,34 @@ export const makeMemoryWalletInner = async (
         unsafeMakeSpend ? privateKeys : undefined
       )
     },
+    async makeMaxSpend(spendInfo: EdgeSpendInfo) {
+      if (engine.makeMaxSpend != null) {
+        return await engine.makeMaxSpend(
+          spendInfo,
+          unsafeMakeSpend ? privateKeys : undefined
+        )
+      }
+
+      // Fallback shim for engines without a native `makeMaxSpend`: compute the
+      // maximum spendable amount, then build a normal spend for that amount.
+      const maxNativeAmount = await getMaxSpendableInner(
+        spendInfo,
+        plugin,
+        engine,
+        config.allTokens,
+        walletInfo
+      )
+      const maxSpendInfo: EdgeSpendInfo = {
+        ...spendInfo,
+        spendTargets: spendInfo.spendTargets.map((target, index) =>
+          index === 0 ? { ...target, nativeAmount: maxNativeAmount } : target
+        )
+      }
+      return await engine.makeSpend(
+        maxSpendInfo,
+        unsafeMakeSpend ? privateKeys : undefined
+      )
+    },
     async signTx(tx: EdgeTransaction) {
       return await engine.signTx(tx, privateKeys)
     },

--- a/src/core/currency/wallet/currency-wallet-api.ts
+++ b/src/core/currency/wallet/currency-wallet-api.ts
@@ -1,4 +1,4 @@
-import { abs, div, lt, mul } from 'biggystring'
+import { abs, div, lt, mul, sub } from 'biggystring'
 import { Disklet } from 'disklet'
 import { base64 } from 'rfc4648'
 import { bridgifyObject, emit, onMethod, watchMethod } from 'yaob'
@@ -23,6 +23,7 @@ import {
   EdgeCurrencyWallet,
   EdgeDataDump,
   EdgeEncodeUri,
+  EdgeEnginePrivateKeyOptions,
   EdgeGetReceiveAddressOptions,
   EdgeGetTransactionsOptions,
   EdgeParsedUri,
@@ -122,6 +123,124 @@ export function makeCurrencyWalletApi(
     }
   }
   bridgifyObject(otherMethods)
+
+  /**
+   * Shared implementation for `makeSpend` and `makeMaxSpend`. Performs all the
+   * common spend-info preparation and transaction post-processing, delegating
+   * the actual transaction construction to `makeEngineTx`.
+   */
+  const makeSpendInner = async (
+    spendInfo: EdgeSpendInfo,
+    makeEngineTx: (
+      engineSpendInfo: EdgeSpendInfo,
+      opts: EdgeEnginePrivateKeyOptions
+    ) => Promise<EdgeTransaction>,
+    isMaxSpend: boolean = false
+  ): Promise<EdgeTransaction> => {
+    spendInfo = upgradeMemos(spendInfo, plugin.currencyInfo)
+    const {
+      assetAction,
+      customNetworkFee,
+      enableRbf,
+      memos,
+      metadata,
+      networkFeeOption = 'standard',
+      noUnconfirmed = false,
+      otherParams,
+      pendingTxs,
+      rbfTxid,
+      savedAction,
+      skipChecks,
+      spendTargets = [],
+      swapData
+    } = spendInfo
+
+    // Figure out which asset this is:
+    const upgradedCurrency = upgradeCurrencyCode({
+      allTokens: input.props.state.accounts[accountId].allTokens[pluginId],
+      currencyInfo: plugin.currencyInfo,
+      tokenId: spendInfo.tokenId
+    })
+
+    // Check the spend targets:
+    const cleanTargets: EdgeSpendTarget[] = []
+    const savedTargets: SavedSpendTargets = []
+    for (const target of spendTargets) {
+      const {
+        memo,
+        publicAddress,
+        nativeAmount = '0',
+        otherParams = {}
+      } = target
+      if (publicAddress == null) continue
+
+      cleanTargets.push({
+        memo,
+        nativeAmount,
+        otherParams,
+        publicAddress,
+        uniqueIdentifier: memo
+      })
+      savedTargets.push({
+        currencyCode: upgradedCurrency.currencyCode,
+        memo,
+        nativeAmount,
+        publicAddress,
+        uniqueIdentifier: memo
+      })
+    }
+
+    if (spendInfo.privateKeys != null) {
+      throw new TypeError('Only sweepPrivateKeys takes private keys')
+    }
+
+    // Only provide wallet info if currency requires it:
+    const privateKeys = unsafeMakeSpend ? walletInfo.keys : undefined
+
+    const tx: EdgeTransaction = await makeEngineTx(
+      {
+        ...upgradedCurrency,
+        customNetworkFee,
+        enableRbf,
+        memos,
+        metadata,
+        networkFeeOption,
+        noUnconfirmed,
+        otherParams,
+        pendingTxs,
+        rbfTxid,
+        skipChecks,
+        spendTargets: cleanTargets
+      },
+      { privateKeys }
+    )
+
+    // For a max spend the engine owns the final amount, so backfill the saved
+    // target from the resulting transaction (the caller passed `0`):
+    if (isMaxSpend && savedTargets.length === 1) {
+      const sentNativeAmount =
+        tx.tokenId == null
+          ? sub(abs(tx.nativeAmount), tx.networkFee)
+          : abs(tx.nativeAmount)
+      savedTargets[0] = { ...savedTargets[0], nativeAmount: sentNativeAmount }
+    }
+
+    upgradeTxNetworkFees(tx)
+    tx.networkFeeOption = networkFeeOption
+    tx.requestedCustomFee = customNetworkFee
+    tx.spendTargets = savedTargets
+    tx.currencyCode = upgradedCurrency.currencyCode
+    tx.tokenId = upgradedCurrency.tokenId
+    if (metadata != null) tx.metadata = metadata
+    if (swapData != null) tx.swapData = asEdgeTxSwap(swapData)
+    if (savedAction != null) tx.savedAction = asEdgeTxAction(savedAction)
+    if (assetAction != null) tx.assetAction = asEdgeAssetAction(assetAction)
+    if (input.props.state.login.deviceInfo.deviceDescription != null)
+      tx.deviceDescription =
+        input.props.state.login.deviceInfo.deviceDescription
+
+    return tx
+  }
 
   const out: EdgeCurrencyWallet & InternalWalletMethods = {
     on: onMethod,
@@ -540,98 +659,44 @@ export function makeCurrencyWalletApi(
       return await engine.getPaymentProtocolInfo(paymentProtocolUrl)
     },
     async makeSpend(spendInfo: EdgeSpendInfo): Promise<EdgeTransaction> {
-      spendInfo = upgradeMemos(spendInfo, plugin.currencyInfo)
-      const {
-        assetAction,
-        customNetworkFee,
-        enableRbf,
-        memos,
-        metadata,
-        networkFeeOption = 'standard',
-        noUnconfirmed = false,
-        otherParams,
-        pendingTxs,
-        rbfTxid,
-        savedAction,
-        skipChecks,
-        spendTargets = [],
-        swapData
-      } = spendInfo
-
-      // Figure out which asset this is:
-      const upgradedCurrency = upgradeCurrencyCode({
-        allTokens: input.props.state.accounts[accountId].allTokens[pluginId],
-        currencyInfo: plugin.currencyInfo,
-        tokenId: spendInfo.tokenId
-      })
-
-      // Check the spend targets:
-      const cleanTargets: EdgeSpendTarget[] = []
-      const savedTargets: SavedSpendTargets = []
-      for (const target of spendTargets) {
-        const {
-          memo,
-          publicAddress,
-          nativeAmount = '0',
-          otherParams = {}
-        } = target
-        if (publicAddress == null) continue
-
-        cleanTargets.push({
-          memo,
-          nativeAmount,
-          otherParams,
-          publicAddress,
-          uniqueIdentifier: memo
-        })
-        savedTargets.push({
-          currencyCode: upgradedCurrency.currencyCode,
-          memo,
-          nativeAmount,
-          publicAddress,
-          uniqueIdentifier: memo
-        })
-      }
-
-      if (spendInfo.privateKeys != null) {
-        throw new TypeError('Only sweepPrivateKeys takes private keys')
-      }
-
-      // Only provide wallet info if currency requires it:
-      const privateKeys = unsafeMakeSpend ? walletInfo.keys : undefined
-
-      const tx: EdgeTransaction = await engine.makeSpend(
-        {
-          ...upgradedCurrency,
-          customNetworkFee,
-          enableRbf,
-          memos,
-          metadata,
-          networkFeeOption,
-          noUnconfirmed,
-          otherParams,
-          pendingTxs,
-          rbfTxid,
-          skipChecks,
-          spendTargets: cleanTargets
-        },
-        { privateKeys }
+      return await makeSpendInner(
+        spendInfo,
+        async (engineSpendInfo, opts) =>
+          await engine.makeSpend(engineSpendInfo, opts)
       )
-      upgradeTxNetworkFees(tx)
-      tx.networkFeeOption = networkFeeOption
-      tx.requestedCustomFee = customNetworkFee
-      tx.spendTargets = savedTargets
-      tx.currencyCode = upgradedCurrency.currencyCode
-      tx.tokenId = upgradedCurrency.tokenId
-      if (metadata != null) tx.metadata = metadata
-      if (swapData != null) tx.swapData = asEdgeTxSwap(swapData)
-      if (savedAction != null) tx.savedAction = asEdgeTxAction(savedAction)
-      if (assetAction != null) tx.assetAction = asEdgeAssetAction(assetAction)
-      if (input.props.state.login.deviceInfo.deviceDescription != null)
-        tx.deviceDescription =
-          input.props.state.login.deviceInfo.deviceDescription
+    },
+    async makeMaxSpend(spendInfo: EdgeSpendInfo): Promise<EdgeTransaction> {
+      const { makeMaxSpend } = engine
+      if (makeMaxSpend != null) {
+        // The engine builds the max-spend transaction atomically:
+        return await makeSpendInner(
+          spendInfo,
+          async (engineSpendInfo, opts) =>
+            await makeMaxSpend(engineSpendInfo, opts),
+          true
+        )
+      }
 
-      return tx
+      // Fallback shim for engines without a native `makeMaxSpend`: compute the
+      // maximum spendable amount, then build a normal spend for that amount.
+      const maxNativeAmount = await getMaxSpendableInner(
+        spendInfo,
+        plugin,
+        engine,
+        input.props.state.accounts[accountId].allTokens[pluginId],
+        walletInfo
+      )
+      const maxSpendInfo: EdgeSpendInfo = {
+        ...spendInfo,
+        spendTargets: spendInfo.spendTargets.map((target, index) =>
+          index === 0 ? { ...target, nativeAmount: maxNativeAmount } : target
+        )
+      }
+      return await makeSpendInner(
+        maxSpendInfo,
+        async (engineSpendInfo, opts) =>
+          await engine.makeSpend(engineSpendInfo, opts)
+      )
     },
     async saveTx(transaction: EdgeTransaction): Promise<void> {
       if (input.props.walletState.txs[transaction.txid] == null) {

--- a/src/core/currency/wallet/currency-wallet-api.ts
+++ b/src/core/currency/wallet/currency-wallet-api.ts
@@ -1,4 +1,4 @@
-import { abs, div, lt, mul } from 'biggystring'
+import { abs, div, lt, mul, sub } from 'biggystring'
 import { Disklet } from 'disklet'
 import { base64 } from 'rfc4648'
 import { bridgifyObject, emit, onMethod, watchMethod } from 'yaob'
@@ -23,6 +23,7 @@ import {
   EdgeCurrencyWallet,
   EdgeDataDump,
   EdgeEncodeUri,
+  EdgeEnginePrivateKeyOptions,
   EdgeGetReceiveAddressOptions,
   EdgeGetTransactionsOptions,
   EdgeParsedUri,
@@ -122,6 +123,124 @@ export function makeCurrencyWalletApi(
     }
   }
   bridgifyObject(otherMethods)
+
+  /**
+   * Shared implementation for `makeSpend` and `makeMaxSpend`. Performs all the
+   * common spend-info preparation and transaction post-processing, delegating
+   * the actual transaction construction to `makeEngineTx`.
+   */
+  const makeSpendInner = async (
+    spendInfo: EdgeSpendInfo,
+    makeEngineTx: (
+      engineSpendInfo: EdgeSpendInfo,
+      opts: EdgeEnginePrivateKeyOptions
+    ) => Promise<EdgeTransaction>,
+    isMaxSpend: boolean = false
+  ): Promise<EdgeTransaction> => {
+    spendInfo = upgradeMemos(spendInfo, plugin.currencyInfo)
+    const {
+      assetAction,
+      customNetworkFee,
+      enableRbf,
+      memos,
+      metadata,
+      networkFeeOption = 'standard',
+      noUnconfirmed = false,
+      otherParams,
+      pendingTxs,
+      rbfTxid,
+      savedAction,
+      skipChecks,
+      spendTargets = [],
+      swapData
+    } = spendInfo
+
+    // Figure out which asset this is:
+    const upgradedCurrency = upgradeCurrencyCode({
+      allTokens: input.props.state.accounts[accountId].allTokens[pluginId],
+      currencyInfo: plugin.currencyInfo,
+      tokenId: spendInfo.tokenId
+    })
+
+    // Check the spend targets:
+    const cleanTargets: EdgeSpendTarget[] = []
+    const savedTargets: SavedSpendTargets = []
+    for (const target of spendTargets) {
+      const {
+        memo,
+        publicAddress,
+        nativeAmount = '0',
+        otherParams = {}
+      } = target
+      if (publicAddress == null) continue
+
+      cleanTargets.push({
+        memo,
+        nativeAmount,
+        otherParams,
+        publicAddress,
+        uniqueIdentifier: memo
+      })
+      savedTargets.push({
+        currencyCode: upgradedCurrency.currencyCode,
+        memo,
+        nativeAmount,
+        publicAddress,
+        uniqueIdentifier: memo
+      })
+    }
+
+    if (spendInfo.privateKeys != null) {
+      throw new TypeError('Only sweepPrivateKeys takes private keys')
+    }
+
+    // Only provide wallet info if currency requires it:
+    const privateKeys = unsafeMakeSpend ? walletInfo.keys : undefined
+
+    const tx: EdgeTransaction = await makeEngineTx(
+      {
+        ...upgradedCurrency,
+        customNetworkFee,
+        enableRbf,
+        memos,
+        metadata,
+        networkFeeOption,
+        noUnconfirmed,
+        otherParams,
+        pendingTxs,
+        rbfTxid,
+        skipChecks,
+        spendTargets: cleanTargets
+      },
+      { privateKeys }
+    )
+
+    // For a max spend the engine owns the final amount, so backfill the saved
+    // target from the resulting transaction (the caller passed `0`):
+    if (isMaxSpend && savedTargets.length === 1) {
+      const sentNativeAmount =
+        tx.tokenId == null
+          ? sub(abs(tx.nativeAmount), tx.networkFee)
+          : abs(tx.nativeAmount)
+      savedTargets[0] = { ...savedTargets[0], nativeAmount: sentNativeAmount }
+    }
+
+    upgradeTxNetworkFees(tx)
+    tx.networkFeeOption = networkFeeOption
+    tx.requestedCustomFee = customNetworkFee
+    tx.spendTargets = savedTargets
+    tx.currencyCode = upgradedCurrency.currencyCode
+    tx.tokenId = upgradedCurrency.tokenId
+    if (metadata != null) tx.metadata = metadata
+    if (swapData != null) tx.swapData = asEdgeTxSwap(swapData)
+    if (savedAction != null) tx.savedAction = asEdgeTxAction(savedAction)
+    if (assetAction != null) tx.assetAction = asEdgeAssetAction(assetAction)
+    if (input.props.state.login.deviceInfo.deviceDescription != null)
+      tx.deviceDescription =
+        input.props.state.login.deviceInfo.deviceDescription
+
+    return tx
+  }
 
   const out: EdgeCurrencyWallet & InternalWalletMethods = {
     on: onMethod,
@@ -540,98 +659,45 @@ export function makeCurrencyWalletApi(
       return await engine.getPaymentProtocolInfo(paymentProtocolUrl)
     },
     async makeSpend(spendInfo: EdgeSpendInfo): Promise<EdgeTransaction> {
-      spendInfo = upgradeMemos(spendInfo, plugin.currencyInfo)
-      const {
-        assetAction,
-        customNetworkFee,
-        enableRbf,
-        memos,
-        metadata,
-        networkFeeOption = 'standard',
-        noUnconfirmed = false,
-        otherParams,
-        pendingTxs,
-        rbfTxid,
-        savedAction,
-        skipChecks,
-        spendTargets = [],
-        swapData
-      } = spendInfo
-
-      // Figure out which asset this is:
-      const upgradedCurrency = upgradeCurrencyCode({
-        allTokens: input.props.state.accounts[accountId].allTokens[pluginId],
-        currencyInfo: plugin.currencyInfo,
-        tokenId: spendInfo.tokenId
-      })
-
-      // Check the spend targets:
-      const cleanTargets: EdgeSpendTarget[] = []
-      const savedTargets: SavedSpendTargets = []
-      for (const target of spendTargets) {
-        const {
-          memo,
-          publicAddress,
-          nativeAmount = '0',
-          otherParams = {}
-        } = target
-        if (publicAddress == null) continue
-
-        cleanTargets.push({
-          memo,
-          nativeAmount,
-          otherParams,
-          publicAddress,
-          uniqueIdentifier: memo
-        })
-        savedTargets.push({
-          currencyCode: upgradedCurrency.currencyCode,
-          memo,
-          nativeAmount,
-          publicAddress,
-          uniqueIdentifier: memo
-        })
-      }
-
-      if (spendInfo.privateKeys != null) {
-        throw new TypeError('Only sweepPrivateKeys takes private keys')
-      }
-
-      // Only provide wallet info if currency requires it:
-      const privateKeys = unsafeMakeSpend ? walletInfo.keys : undefined
-
-      const tx: EdgeTransaction = await engine.makeSpend(
-        {
-          ...upgradedCurrency,
-          customNetworkFee,
-          enableRbf,
-          memos,
-          metadata,
-          networkFeeOption,
-          noUnconfirmed,
-          otherParams,
-          pendingTxs,
-          rbfTxid,
-          skipChecks,
-          spendTargets: cleanTargets
-        },
-        { privateKeys }
+      return await makeSpendInner(
+        spendInfo,
+        async (engineSpendInfo, opts) =>
+          await engine.makeSpend(engineSpendInfo, opts)
       )
-      upgradeTxNetworkFees(tx)
-      tx.networkFeeOption = networkFeeOption
-      tx.requestedCustomFee = customNetworkFee
-      tx.spendTargets = savedTargets
-      tx.currencyCode = upgradedCurrency.currencyCode
-      tx.tokenId = upgradedCurrency.tokenId
-      if (metadata != null) tx.metadata = metadata
-      if (swapData != null) tx.swapData = asEdgeTxSwap(swapData)
-      if (savedAction != null) tx.savedAction = asEdgeTxAction(savedAction)
-      if (assetAction != null) tx.assetAction = asEdgeAssetAction(assetAction)
-      if (input.props.state.login.deviceInfo.deviceDescription != null)
-        tx.deviceDescription =
-          input.props.state.login.deviceInfo.deviceDescription
+    },
+    async makeMaxSpend(spendInfo: EdgeSpendInfo): Promise<EdgeTransaction> {
+      const { makeMaxSpend } = engine
+      if (makeMaxSpend != null) {
+        // The engine builds the max-spend transaction atomically. Call the
+        // method on the engine, since engines are classes that need `this`:
+        return await makeSpendInner(
+          spendInfo,
+          async (engineSpendInfo, opts) =>
+            await makeMaxSpend.call(engine, engineSpendInfo, opts),
+          true
+        )
+      }
 
-      return tx
+      // Fallback shim for engines without a native `makeMaxSpend`: compute the
+      // maximum spendable amount, then build a normal spend for that amount.
+      const maxNativeAmount = await getMaxSpendableInner(
+        spendInfo,
+        plugin,
+        engine,
+        input.props.state.accounts[accountId].allTokens[pluginId],
+        walletInfo
+      )
+      const maxSpendInfo: EdgeSpendInfo = {
+        ...spendInfo,
+        spendTargets: spendInfo.spendTargets.map((target, index) =>
+          index === 0 ? { ...target, nativeAmount: maxNativeAmount } : target
+        )
+      }
+      return await makeSpendInner(
+        maxSpendInfo,
+        async (engineSpendInfo, opts) =>
+          await engine.makeSpend(engineSpendInfo, opts)
+      )
     },
     async saveTx(transaction: EdgeTransaction): Promise<void> {
       if (input.props.walletState.txs[transaction.txid] == null) {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1121,6 +1121,15 @@ export interface EdgeCurrencyEngine {
     spendInfo: EdgeSpendInfo,
     opts?: EdgeEnginePrivateKeyOptions
   ) => Promise<EdgeTransaction>
+  /**
+   * Atomically builds a transaction that spends the maximum amount.
+   * Engines that don't implement this get a core fallback that combines
+   * `getMaxSpendable` and `makeSpend`.
+   */
+  readonly makeMaxSpend?: (
+    spendInfo: EdgeSpendInfo,
+    opts?: EdgeEnginePrivateKeyOptions
+  ) => Promise<EdgeTransaction>
   readonly signTx: (
     transaction: EdgeTransaction,
     privateKeys: JsonObject
@@ -1390,11 +1399,18 @@ export interface EdgeCurrencyWallet {
 
   // Sending:
   readonly broadcastTx: (tx: EdgeTransaction) => Promise<EdgeTransaction>
+  /** @deprecated Use `makeMaxSpend` to build a max-spend transaction. */
   readonly getMaxSpendable: (spendInfo: EdgeSpendInfo) => Promise<string>
   readonly getPaymentProtocolInfo: (
     paymentProtocolUrl: string
   ) => Promise<EdgePaymentProtocolInfo>
   readonly makeSpend: (spendInfo: EdgeSpendInfo) => Promise<EdgeTransaction>
+  /**
+   * Atomically builds a transaction that spends the maximum amount.
+   * Same signature as `makeSpend`. Always available: the core provides a
+   * fallback for engines that don't implement it natively.
+   */
+  readonly makeMaxSpend: (spendInfo: EdgeSpendInfo) => Promise<EdgeTransaction>
   readonly saveTx: (tx: EdgeTransaction) => Promise<void>
   readonly saveTxAction: (opts: EdgeSaveTxActionOptions) => Promise<void>
   readonly saveTxMetadata: (opts: EdgeSaveTxMetadataOptions) => Promise<void>
@@ -1476,8 +1492,10 @@ export interface EdgeMemoryWallet {
   readonly syncStatus: EdgeSyncStatus
   readonly changeEnabledTokenIds: (tokenIds: string[]) => Promise<void>
   readonly startEngine: () => Promise<void>
+  /** @deprecated Use `makeMaxSpend` to build a max-spend transaction. */
   readonly getMaxSpendable: (spendInfo: EdgeSpendInfo) => Promise<string>
   readonly makeSpend: (spendInfo: EdgeSpendInfo) => Promise<EdgeTransaction>
+  readonly makeMaxSpend: (spendInfo: EdgeSpendInfo) => Promise<EdgeTransaction>
   readonly signTx: (tx: EdgeTransaction) => Promise<EdgeTransaction>
   readonly broadcastTx: (tx: EdgeTransaction) => Promise<EdgeTransaction>
   readonly saveTx: (tx: EdgeTransaction) => Promise<void>

--- a/test/core/currency/wallet/currency-wallet.test.ts
+++ b/test/core/currency/wallet/currency-wallet.test.ts
@@ -457,6 +457,28 @@ describe('currency wallets', function () {
     )
   })
 
+  it('can make max spend', async function () {
+    const { wallet, config } = await makeFakeCurrencyWallet()
+    await config.changeUserSettings({ balance: 50 })
+
+    // The fake engine does not implement `makeMaxSpend`, so this exercises the
+    // core fallback shim (getMaxSpendable + makeSpend):
+    const tx = await wallet.makeMaxSpend({
+      tokenId: null,
+      spendTargets: [{ publicAddress: 'somewhere' }]
+    })
+    expect(tx.nativeAmount).equals('50')
+    expect(tx.spendTargets).deep.equals([
+      {
+        currencyCode: 'FAKE',
+        memo: undefined,
+        nativeAmount: '50',
+        publicAddress: 'somewhere',
+        uniqueIdentifier: undefined
+      }
+    ])
+  })
+
   it('converts number formats', async function () {
     const { wallet } = await makeFakeCurrencyWallet()
     expect(await wallet.denominationToNative('0.1', 'SMALL')).equals('1')

--- a/test/core/currency/wallet/currency-wallet.test.ts
+++ b/test/core/currency/wallet/currency-wallet.test.ts
@@ -457,6 +457,52 @@ describe('currency wallets', function () {
     )
   })
 
+  it('can make max spend', async function () {
+    const { wallet, config } = await makeFakeCurrencyWallet()
+    await config.changeUserSettings({ balance: 50 })
+
+    // The fake engine does not implement `makeMaxSpend`, so this exercises the
+    // core fallback shim (getMaxSpendable + makeSpend):
+    const tx = await wallet.makeMaxSpend({
+      tokenId: null,
+      spendTargets: [{ publicAddress: 'somewhere' }]
+    })
+    expect(tx.nativeAmount).equals('50')
+    expect(tx.spendTargets).deep.equals([
+      {
+        currencyCode: 'FAKE',
+        memo: undefined,
+        nativeAmount: '50',
+        publicAddress: 'somewhere',
+        uniqueIdentifier: undefined
+      }
+    ])
+  })
+
+  it('can make max spend with a native engine method', async function () {
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
+    const context = await world.makeEdgeContext({
+      ...contextOptions,
+      plugins: { maxcoin: true }
+    })
+    const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
+    const wallet = await account.createCurrencyWallet('wallet:maxcoin', {
+      fiatCurrencyCode: 'iso:USD',
+      name: 'max wallet'
+    })
+    await account.currencyConfig.maxcoin.changeUserSettings({ balance: 50 })
+
+    // The maxcoin engine implements `makeMaxSpend`, so the core delegates to
+    // it instead of using the fallback shim. The engine implementation reads
+    // `this`, so an unbound call from the core would throw here:
+    const tx = await wallet.makeMaxSpend({
+      tokenId: null,
+      spendTargets: [{ publicAddress: 'somewhere' }]
+    })
+    expect(tx.otherParams?.engineMaxSpend).equals(true)
+    expect(tx.nativeAmount).equals('27') // Balance 50 minus the fee of 23
+  })
+
   it('converts number formats', async function () {
     const { wallet } = await makeFakeCurrencyWallet()
     expect(await wallet.denominationToNative('0.1', 'SMALL')).equals('1')

--- a/test/fake/fake-currency-plugin.ts
+++ b/test/fake/fake-currency-plugin.ts
@@ -1,4 +1,4 @@
-import { add, lt } from 'biggystring'
+import { add, lt, sub } from 'biggystring'
 import { asNumber, asObject, asOptional, asString } from 'cleaners'
 
 import {
@@ -26,6 +26,7 @@ import {
 import { upgradeCurrencyCode } from '../../src/types/type-helpers'
 
 const GENESIS_BLOCK = 1231006505
+const FAKE_NETWORK_FEE = '23'
 
 const fakeTokens: EdgeTokenMap = {
   badf00d5: {
@@ -303,7 +304,7 @@ class FakeCurrencyEngine implements EdgeCurrencyEngine {
       isSend: false,
       memos,
       nativeAmount: total,
-      networkFee: '23',
+      networkFee: FAKE_NETWORK_FEE,
       networkFees: [],
       otherParams: {},
       ourReceiveAddresses: [],
@@ -332,6 +333,31 @@ class FakeCurrencyEngine implements EdgeCurrencyEngine {
     transaction: EdgeTransaction
   ): Promise<EdgeTransaction | null> {
     return null
+  }
+}
+
+/**
+ * An engine that implements the optional `makeMaxSpend` engine method, so
+ * tests can exercise the core's engine-delegating branch. The plain
+ * `FakeCurrencyEngine` deliberately lacks the method, which is what makes it
+ * exercise the core's fallback shim.
+ *
+ * The implementation reads `this`, so the core must invoke this as a method on
+ * the engine. An unbound call throws.
+ */
+class FakeMaxSpendCurrencyEngine extends FakeCurrencyEngine {
+  async makeMaxSpend(spendInfo: EdgeSpendInfo): Promise<EdgeTransaction> {
+    const { spendTargets, tokenId = null } = spendInfo
+    const maxNativeAmount = sub(this.getBalance({ tokenId }), FAKE_NETWORK_FEE)
+    const tx = await this.makeSpend({
+      ...spendInfo,
+      spendTargets: spendTargets.map((spendTarget, index) =>
+        index === 0
+          ? { ...spendTarget, nativeAmount: maxNativeAmount }
+          : spendTarget
+      )
+    })
+    return { ...tx, otherParams: { engineMaxSpend: true } }
   }
 }
 
@@ -386,10 +412,20 @@ class FakeCurrencyTools implements EdgeCurrencyTools {
   }
 }
 
+interface FakeCurrencyPluginOptions {
+  /** Implement the optional `makeMaxSpend` engine method. */
+  nativeMaxSpend?: boolean
+}
+
 export function makeFakeCurrencyPlugin(
-  overrides: Partial<EdgeCurrencyInfo> = {}
+  overrides: Partial<EdgeCurrencyInfo> = {},
+  pluginOptions: FakeCurrencyPluginOptions = {}
 ): EdgeCurrencyPlugin {
+  const { nativeMaxSpend = false } = pluginOptions
   const currencyInfo: EdgeCurrencyInfo = { ...fakeCurrencyInfo, ...overrides }
+  const Engine = nativeMaxSpend
+    ? FakeMaxSpendCurrencyEngine
+    : FakeCurrencyEngine
 
   return {
     currencyInfo,
@@ -402,9 +438,7 @@ export function makeFakeCurrencyPlugin(
       walletInfo: EdgeWalletInfo,
       opts: EdgeCurrencyEngineOptions
     ): Promise<EdgeCurrencyEngine> {
-      return Promise.resolve(
-        new FakeCurrencyEngine(walletInfo, opts, currencyInfo)
-      )
+      return Promise.resolve(new Engine(walletInfo, opts, currencyInfo))
     },
 
     makeCurrencyTools(): Promise<EdgeCurrencyTools> {

--- a/test/fake/fake-plugins.ts
+++ b/test/fake/fake-plugins.ts
@@ -11,6 +11,17 @@ export const allPlugins = {
   },
   'broken-engine': brokenEnginePlugin,
   fakecoin: fakeCurrencyPlugin,
+  maxcoin: makeFakeCurrencyPlugin(
+    {
+      assetDisplayName: 'Max Coin',
+      chainDisplayName: 'Max Chain',
+      currencyCode: 'MAX',
+      displayName: 'Max Coin',
+      pluginId: 'maxcoin',
+      walletType: 'wallet:maxcoin'
+    },
+    { nativeMaxSpend: true }
+  ),
   tulipcoin: makeFakeCurrencyPlugin({
     assetDisplayName: 'Tulip Coin',
     chainDisplayName: 'Tulip Chain',


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Add a `makeMaxSpend` method to `EdgeCurrencyWallet` and `EdgeMemoryWallet`. It has the same signature as `makeSpend` but builds a transaction that atomically spends the maximum amount, avoiding the race that affects separate `getMaxSpendable` + `makeSpend` calls when network state changes between them.

The wallet API routes to `EdgeCurrencyEngine.makeMaxSpend` when the engine implements it. For engines that don't, the core provides a fallback shim that combines `getMaxSpendable` and `makeSpend` (so every wallet gets `makeMaxSpend` regardless of engine support). `EdgeCurrencyEngine.makeMaxSpend` is therefore optional.

`getMaxSpendable` is now deprecated on the public `EdgeCurrencyWallet` and `EdgeMemoryWallet` APIs. The engine-level `getMaxSpendable` remains (the fallback shim still uses it as a building block).

`makeSpend`'s implementation was extracted into a shared `makeSpendInner` helper that both `makeSpend` and `makeMaxSpend` delegate to. For a max spend the saved spend targets are backfilled from the resulting transaction so the recorded amount reflects the real send.

The engine method is invoked with the engine as its receiver (`makeMaxSpend.call(engine, ...)`). Engines are classes whose `makeMaxSpend` reads `this`, so an unbound call would throw.

Asana: https://app.asana.com/0/1215088146871429/1207967192999590

### Testing

- `npm run types` (tsc) clean; `verify-repo.sh --base origin/master` passes (changelog, install, prepare, eslint, mocha).
- `npm test` (mocha), 164 passing. Two tests cover the two routes: `can make max spend` exercises the core fallback shim, and `can make max spend with a native engine method` exercises the engine-delegating branch via a `maxcoin` fake plugin whose engine implementation reads `this`. Reverting the receiver fix makes that second test fail with `TypeError: Cannot read properties of undefined`.
- Exercised live in the running app (iOS sim), engine branch: a Send Max on a Base ETH wallet, with this branch and the matching `edge-currency-accountbased` branch linked into the app, routes `coreWallet.makeMaxSpend` into `EthereumEngine.makeMaxSpend`. It built 0.001369728606416941 ETH plus a 0.00004218448132393 fee, exactly the wallet's full balance, and the transaction broadcast to the success screen. Screenshots are attached in a comment below.
- Also exercised the fallback shim route live in the prior round: tapping "Max" on a BTC Send screen built the max-spend transaction (balance minus network fee) and rendered it ready to send.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the spending API and transaction metadata for max sends; the non-atomic fallback still exists for engines without native makeMaxSpend, so incorrect max amounts remain possible in that path until engines adopt the new method.
> 
> **Overview**
> Adds **`makeMaxSpend`** on **`EdgeCurrencyWallet`** and **`EdgeMemoryWallet`** so apps can build a max-spend transaction in one call instead of **`getMaxSpendable`** followed by **`makeSpend`**, which can race when fees or UTXO state change between steps.
> 
> When a currency engine implements optional **`EdgeCurrencyEngine.makeMaxSpend`**, the core delegates with a bound method call and runs shared prep/post-processing via a new **`makeSpendInner`** helper (also used by **`makeSpend`**). For other engines, the core falls back to **`getMaxSpendableInner`** plus **`makeSpend`**. On the full wallet API, max spends **backfill** the saved **`spendTargets`** amount from the built transaction (native sends subtract **`networkFee`**).
> 
> Public **`getMaxSpendable`** on wallets is **deprecated** in favor of **`makeMaxSpend`**; engine-level **`getMaxSpendable`** remains for the shim. Tests cover both the fallback path and a **`maxcoin`** fake plugin with a native **`makeMaxSpend`** implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecb4774d0e7bc6e783daaca9d056af4cb7732010. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- agent-test-evidence:start -->
### Test evidence

<table>
<tr>
<td rowspan="1" width="170" valign="top"><a href="https://github.com/EdgeApp/edge-core-js/pull/727/commits/ecb4774d0e7bc6e783daaca9d056af4cb7732010"><code>ecb4774</code></a><br><sub>Add makeMaxSpend wallet API with core fallback shim</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-core-js/pr-727/20260908-175252-agent-proof-1207967192999590-01-eth-max-spend-built.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-core-js/pr-727/20260908-175252-agent-proof-1207967192999590-01-eth-max-spend-built.png" width="200"></a><br><sub>eth max spend built</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-core-js/pr-727/20260908-175252-agent-proof-1207967192999590-02-eth-max-spend-sent.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-core-js/pr-727/20260908-175252-agent-proof-1207967192999590-02-eth-max-spend-sent.png" width="200"></a><br><sub>eth max spend sent</sub></td>
<td width="210"></td>
</tr>
</table>
<!-- agent-test-evidence:end -->