### PR TITLE
Upgrade yaob to v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: Upgrade yaob to v0.4.0 to share a single bridge instance with currency plugins (mismatched yaob copies give the bridge separate object-id counters that cross-wire bridged nativeIo objects).
+
 ## 2.46.0 (2026-06-18)
 
 - added: `EdgeCurrencyWallet.walletSettings` and `EdgeCurrencyWallet.changeWalletSettings`, plus matching engine plumbing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "rfc4648": "^1.5.3",
         "scrypt-js": "^2.0.3",
         "serverlet": "^0.1.2",
-        "yaob": "^0.3.12",
+        "yaob": "^0.4.0",
         "yavent": "^0.1.5"
       },
       "devDependencies": {
@@ -10868,9 +10868,10 @@
       }
     },
     "node_modules/yaob": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/yaob/-/yaob-0.3.12.tgz",
-      "integrity": "sha1-+zfaR0nxICzJbe3rh2MILJFLXjU= sha512-HVXUb7s4ZawrEtpAEpuNwsD6oHCqapY9aCnMEeZnk3lIAlTO85Gw7pT2xzmYy3Q4CKPcG9pCW3h2rgf9vBTuqg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/yaob/-/yaob-0.4.0.tgz",
+      "integrity": "sha512-xJhZ4xV221tp2NWdWtHClMVQ1HoDpdThhSqmideyemiyEEArwrdmgOzKiQUQMGpDnLtr2DvxrjAigwHjuqj6VQ==",
+      "license": "MIT",
       "dependencies": {
         "rfc4648": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "rfc4648": "^1.5.3",
     "scrypt-js": "^2.0.3",
     "serverlet": "^0.1.2",
-    "yaob": "^0.3.12",
+    "yaob": "^0.4.0",
     "yavent": "^0.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps `yaob` to `^0.4.0` so edge-core-js and the currency plugins (which have also moved to v0.4.0 — see EdgeApp/edge-currency-accountbased#1064) resolve a **single shared yaob instance**.

After the yarn→npm migration, npm installed a separate `yaob` copy under each package (edge-core-js, edge-currency-accountbased, …). Each yaob module has its own module-level `nextLocalId` counter, so the per-coin native ios (bridged with one copy) and the edge-core-js bridge serializer (another copy) handed out **colliding object ids** — cross-wiring `nativeIo` entries in the host app (`env.nativeIo.zcash` resolved to the monero io), crashing ZEC / Pirate Chain wallet creation (`undefined is not an object (evaluating 'this.nativeTools.getBirthdayHeight')`). Converging every package on `yaob@^0.4.0` lets npm dedupe to one copy → one counter → no collision.

yaob 0.4.0 is a **non-breaking minor** (its changelog is "yarn→npm build tooling" + "security dep upgrades"; public API byte-identical to 0.3.12).

Companion PR: EdgeApp/edge-currency-accountbased#1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no source changes; intended as a non-breaking yaob minor aligned with companion currency-plugin PRs for npm deduplication.
> 
> **Overview**
> Bumps **`yaob`** from `^0.3.12` to **`^0.4.0`** in `package.json` and `package-lock.json`, with an **Unreleased** changelog entry.
> 
> The goal is for npm to **dedupe** to one `yaob` instance when edge-core-js and currency plugins (also on `^0.4.0`) are installed together. Separate copies each maintain their own bridge **object-id** counter, which can **cross-wire** bridged `nativeIo` objects and break wallet creation for some coins. Aligning versions restores a single shared bridge; **yaob 0.4.0** is described as API-identical to 0.3.12 aside from build/security tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f10a640b8497d253942223feeea24925d723dd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216014204513629