### PR TITLE
Upgrade NYM mix-fetch to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: Upgrade `@nymproject/mix-fetch` to v2, which routes NYM mixnet traffic through the new smolmix-wasm tunnel (`@nymproject/mix-tunnel`). The v2 wasm + worker are inlined into the bundle, so the build no longer copies sibling `.wasm`/`web-worker-*.js` assets.
+
 ## 2.46.1 (2026-06-29)
 
 - changed: Upgrade yaob to v0.4.0 to share a single bridge instance with currency plugins (mismatched yaob copies give the bridge separate object-id counters that cross-wire bridged nativeIo objects).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.46.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@nymproject/mix-fetch": "^1.4.4",
+        "@nymproject/mix-fetch": "^2.0.0",
         "aes-js": "^3.1.0",
         "base-x": "^4.0.1",
         "biggystring": "^4.2.3",
@@ -2153,9 +2153,19 @@
       }
     },
     "node_modules/@nymproject/mix-fetch": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@nymproject/mix-fetch/-/mix-fetch-1.4.4.tgz",
-      "integrity": "sha1-8Q+94XJVwW+d6MPdboyPScTRLIg= sha512-sdyXXJG7sYv2OFOEf6FYm7HglKfMvJmJjrQC3Rbusy5rH5C2ajg2KyuBbZReLgIIbkkx3mK8sc5WRUOKTcKt2Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nymproject/mix-fetch/-/mix-fetch-2.0.0.tgz",
+      "integrity": "sha512-dTHPMpd1Zhj4ZauN8vnxOq7gzO3N/ikaQoNvWwl1Xq6niQxqoLw/gKbsKxwrgvbRodhjkKrCqW++0zumTfi7pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nymproject/mix-tunnel": "0.1.0"
+      }
+    },
+    "node_modules/@nymproject/mix-tunnel": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nymproject/mix-tunnel/-/mix-tunnel-0.1.0.tgz",
+      "integrity": "sha512-olm+nue1rW7PyR9hMHbOdEZ/ytRXjEqHh1kGPfw8ZWKV/e+5Gh43mngyxFrZYqlQMVntlRXwkiJkB9bYWFTxxw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@pkgr/utils": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "*.{js,jsx,ts,tsx}": "eslint"
   },
   "dependencies": {
-    "@nymproject/mix-fetch": "^1.4.4",
+    "@nymproject/mix-fetch": "^2.0.0",
     "aes-js": "^3.1.0",
     "base-x": "^4.0.1",
     "biggystring": "^4.2.3",

--- a/src/io/browser/browser-io.ts
+++ b/src/io/browser/browser-io.ts
@@ -3,7 +3,7 @@ import { makeLocalStorageDisklet } from 'disklet'
 import { LogBackend, makeLog } from '../../core/log/log'
 import { EdgeFetchOptions, EdgeFetchResponse, EdgeIo } from '../../types/types'
 import { scrypt } from '../../util/crypto/scrypt'
-import { initMixFetch, mixFetchOptions } from '../../util/nym'
+import { initMixFetch } from '../../util/nym'
 import { fetchCorsProxy } from './fetch-cors-proxy'
 
 // Only try CORS proxy/bridge techniques up to 5 times
@@ -50,14 +50,7 @@ export function makeBrowserIo(logBackend: LogBackend): EdgeIo {
 
       if (privacy === 'nym') {
         const nymFetch = await initMixFetch(log)
-        return await nymFetch(
-          uri,
-          {
-            ...opts,
-            mode: 'unsafe-ignore-cors' as RequestMode
-          },
-          mixFetchOptions
-        )
+        return await nymFetch(uri, opts)
       }
       if (corsBypass === 'always') {
         return await fetchCorsProxy(uri, opts)

--- a/src/io/react-native/react-native-worker.ts
+++ b/src/io/react-native/react-native-worker.ts
@@ -17,7 +17,7 @@ import {
   EdgeFetchResponse,
   EdgeIo
 } from '../../types/types'
-import { initMixFetch, mixFetchOptions } from '../../util/nym'
+import { initMixFetch } from '../../util/nym'
 import { hideProperties } from '../hidden-properties'
 import { makeNativeBridge } from './native-bridge'
 import { WorkerApi, YAOB_THROTTLE_MS } from './react-native-types'
@@ -177,15 +177,7 @@ async function makeIo(logBackend: LogBackend): Promise<EdgeIo> {
 
       if (privacy === 'nym') {
         const nymFetch = await initMixFetch(log)
-        const response = await nymFetch(
-          uri,
-          {
-            ...opts,
-            mode: 'unsafe-ignore-cors' as RequestMode
-          },
-          mixFetchOptions
-        )
-        return response
+        return await nymFetch(uri, opts)
       }
       if (corsBypass === 'always') {
         return await nativeFetch(uri, opts)

--- a/src/util/nym.ts
+++ b/src/util/nym.ts
@@ -1,56 +1,53 @@
 import {
   createMixFetch,
-  disconnectMixFetch,
-  IMixFetch,
-  IMixFetchFn,
-  SetupMixFetchOps
+  disconnectMixTunnel,
+  SetupMixTunnelOpts
 } from '@nymproject/mix-fetch'
 
 import { EdgeLog } from '../types/types'
 
+/** The fetch-bound function `createMixFetch` resolves to. */
+type MixFetchFn = (url: string, init?: RequestInit) => Promise<Response>
+
 /**
- * Configuration options for the NYM mixFetch client.
+ * Configuration options for the NYM mixFetch tunnel.
  */
-export const mixFetchOptions: SetupMixFetchOps = {
+export const mixFetchOptions: SetupMixTunnelOpts = {
   clientId: 'edge-core-js-2026-03-10',
-  preferredGateway: '5rXcNe2a44vXisK3uqLHCzpzvEwcnsijDMU7hg4fcYk8', // with WSS
-  preferredNetworkRequester:
-    '5x6q9UfVHs5AohKMUqeivj7a556kVVy7QwoKige8xHxh.6CFoB3kJaDbYz6oafPJxNxNjzahpT2NtgtytcSyN9EvF@5rXcNe2a44vXisK3uqLHCzpzvEwcnsijDMU7hg4fcYk8',
   forceTls: true, // force WSS
-  mixFetchOverride: {
-    requestTimeoutMs: 300000
-  }
+  // Mixnet round trips are slow, so give the tunnel handshake plenty of time.
+  // v1 tuned a 5 min `requestTimeoutMs`; v2 exposes no per-request timeout, but
+  // the tunnel setup is where mixnet latency bites, so restore that 5 min
+  // budget here to avoid premature failures during the handshake.
+  connectTimeoutMs: 300000
 }
 
 // MixFetch initialization state
-let mixFetchInitPromise: Promise<IMixFetch> | null = null
+let mixFetchInitPromise: Promise<MixFetchFn> | null = null
 
 /**
  * Initialize the NYM mixFetch client. Must be called before using mixFetch.
  * Safe to call multiple times - subsequent calls return the same promise.
  */
-export async function initMixFetch(log: EdgeLog): Promise<IMixFetchFn> {
+export async function initMixFetch(log: EdgeLog): Promise<MixFetchFn> {
   if (mixFetchInitPromise == null) {
     log('Initializing mixFetch...')
     mixFetchInitPromise = createMixFetch(mixFetchOptions)
-      .then(mixFetchModule => {
+      .then(mixFetch => {
         log('mixFetch initialized successfully')
-        return mixFetchModule
+        return mixFetch
       })
       .catch(async error => {
-        // Clean up stale global state left by the failed init so the
-        // next createMixFetch call starts fresh instead of reusing a
+        // Tear down any partially-established tunnel left by the failed init
+        // so the next createMixFetch call starts fresh instead of reusing a
         // broken singleton.
         try {
-          await disconnectMixFetch()
+          await disconnectMixTunnel()
         } catch {}
-        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-        delete (window as any).__mixFetchGlobal
         mixFetchInitPromise = null
         log.error('mixFetch initialization failed:', error)
         throw error
       })
   }
-  const mixFetchModule = await mixFetchInitPromise
-  return mixFetchModule.mixFetch
+  return await mixFetchInitPromise
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,9 +50,6 @@ module.exports = {
     static: bundlePath
   },
   entry: './src/io/react-native/react-native-worker.ts',
-  experiments: {
-    asyncWebAssembly: true
-  },
   mode: debug ? 'development' : 'production',
   module: {
     rules: [
@@ -75,10 +72,6 @@ module.exports = {
           loader: 'babel-loader',
           options: { presets: ['@babel/preset-env'] }
         }
-      },
-      {
-        test: /\.wasm$/,
-        type: 'webassembly/async'
       }
     ]
   },
@@ -92,29 +85,12 @@ module.exports = {
   plugins: [
     new webpack.ProvidePlugin({ Buffer: ['buffer', 'Buffer'] }),
     new webpack.ProvidePlugin({ process: ['process'] }),
-    // Copy static files and mix-fetch WASM/worker files
     new CopyPlugin({
       patterns: [
         // HTML entry point
         {
           from: path.resolve(__dirname, 'src/index.html'),
           to: 'index.html'
-        },
-        // mix-fetch WASM files for NYM mixnet support
-        {
-          from: path.resolve(
-            __dirname,
-            'node_modules/@nymproject/mix-fetch/*.wasm'
-          ),
-          to: '[name][ext]'
-        },
-        // mix-fetch web worker files
-        {
-          from: path.resolve(
-            __dirname,
-            'node_modules/@nymproject/mix-fetch/web-worker-*.js'
-          ),
-          to: '[name][ext]'
         }
       ]
     })


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

Bumps `@nymproject/mix-fetch` `^1.4.4` -> `^2.0.0` (pulls transitive `@nymproject/mix-tunnel@0.1.0`). none other.

### Description

Migrates the NYM mixnet integration to mix-fetch v2. v2 is a rewrite on the smolmix-wasm Rust stack (replacing the v1 Go-based stack) with a different API surface and a single inlined-wasm ESM package.

Changes:

- `src/util/nym.ts`: switch to the v2 imports (`disconnectMixTunnel`, `SetupMixTunnelOpts`). `createMixFetch` now resolves to the fetch function directly (v1 returned a module object with a `.mixFetch` member), so `initMixFetch` returns that function. `mixFetchOptions` drops the removed v1 fields (`preferredGateway`, `preferredNetworkRequester`, `mixFetchOverride.requestTimeoutMs`) and keeps `clientId` + `forceTls`; v2 auto-discovers IPR exits, so no gateway pin is set. Init-failure cleanup calls `disconnectMixTunnel()` and drops the v1 `window.__mixFetchGlobal` reset.
- `src/io/react-native/react-native-worker.ts` and `src/io/browser/browser-io.ts`: the `privacy: 'nym'` branch now uses the v2 2-arg `mixFetch(uri, opts)` call (drops the `mode: 'unsafe-ignore-cors'` flag, which v2 does not use, and the trailing options arg).
- `webpack.config.js`: remove the two CopyPlugin patterns that copied `@nymproject/mix-fetch/*.wasm` and `web-worker-*.js`. v2 inlines its wasm + worker into the ESM bundle, so those sibling files no longer exist (copy-webpack-plugin errors on a pattern that matches nothing).

Verification: `tsc`, ESLint, and the full `verify-repo` (all builds + mocha) pass. The webpack bundle builds with the v2 wasm inlined. The change was linked into edge-react-gui via `updot` and the app was rebuilt on the iOS simulator with the v2 core embedded; the Nym Mixnet privacy setting enables and persists per currency, and a funded Fantom wallet operates with it on. See the test-evidence screenshots.

Asana: https://app.asana.com/0/1215088146871429/1216018838183217

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes the privacy mixnet networking path and drops pinned gateways in favor of v2 auto-discovery; regressions could affect wallet sync when Nym privacy is enabled, though scope is limited to that fetch path and the build.
> 
> **Overview**
> Upgrades **`@nymproject/mix-fetch`** from v1 to v2 so NYM **`privacy: 'nym'`** traffic uses the new **smolmix-wasm** tunnel (`@nymproject/mix-tunnel`) instead of the v1 stack.
> 
> **`src/util/nym.ts`** adopts the v2 API: `createMixFetch` resolves to the fetch function directly (no `.mixFetch` wrapper), tunnel options use **`SetupMixTunnelOpts`** with **`connectTimeoutMs: 300000`** in place of v1’s per-request timeout and removed gateway/IPR pins; failed init cleanup calls **`disconnectMixTunnel()`** instead of **`disconnectMixFetch()`** and no longer clears **`window.__mixFetchGlobal`**.
> 
> **`browser-io.ts`** and **`react-native-worker.ts`** call **`nymFetch(uri, opts)`** only—dropping v1’s **`unsafe-ignore-cors`** mode and the extra options argument.
> 
> **`webpack.config.js`** drops async WASM handling and **CopyPlugin** patterns for sibling **`.wasm`** / **`web-worker-*.js`** assets because v2 inlines wasm and workers in the bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 816be23626a6748fb5b96d41cfa08b3153938187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216438166625538