### PR TITLE
Add core-side synthetic destination for swap-to-address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- added: Accept an optional `toAddressInfo` descriptor on `EdgeSwapRequest` as an alternative to `toWallet`, so a swap can target a pasted destination address. The core builds a synthetic, bridgified destination wallet from the descriptor, backed by the real `currencyConfig`, leaving swap plugins unchanged. Exactly one of `toWallet` or `toAddressInfo` is required.
+- added: Optional `toMemos` on `EdgeSwapToAddressInfo` for memo-required payout chains (e.g. an XRP destination tag). Swap plugins read the memos off the synthetic destination wallet's `getMemos` method (`EdgeSyntheticDestinationWallet`), never off the descriptor.
+- changed: Make `EdgeTxActionSwap.payoutWalletId` and `EdgeTxSwap.payoutWalletId` optional, since a swap-to-address destination has no payout wallet (`payoutAddress` carries the destination).
+
 ## 2.46.1 (2026-06-29)
 
 - changed: Upgrade yaob to v0.4.0 to share a single bridge instance with currency plugins (mismatched yaob copies give the bridge separate object-id counters that cross-wire bridged nativeIo objects).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- added: `EdgeSwapRequest.toAddressInfo`, for swaps that pay out to an address instead of a wallet
+- added: `EdgeSwapToAddressInfo.toMemos` for memo-required payout chains
+- added: `EdgeTxActionSwap.swapType`, naming the send-shaped swap flows
+- added: `EdgeSwapRequest.privacy`, restricting quotes to routes that keep the sender unlinkable
+- added: `EdgeSwapRequestOptions.forceEnabled`, for querying plugins the user switched off
+- changed: `payoutWalletId` is optional on `EdgeTxActionSwap` and `EdgeTxSwap`
+
 ## 2.48.1 (2026-08-31)
 
 - fixed: Stop rebuilding the NYM mixFetch client on every request while its gateway is failing. Each attempt spawns a web worker holding megabytes of WASM that the library gives no way to terminate, so a poll loop retrying every few seconds exhausted the host's memory and killed the JS context, which on iOS reads to the user as being logged out. A failed setup now starts a cooldown that doubles up to five minutes.

--- a/src/core/currency/wallet/currency-wallet-cleaners.ts
+++ b/src/core/currency/wallet/currency-wallet-cleaners.ts
@@ -146,7 +146,7 @@ export const asEdgeTxSwap = asObject<EdgeTxSwap>({
   payoutCurrencyCode: asString,
   payoutTokenId: asOptional(asEdgeTokenId),
   payoutNativeAmount: asString,
-  payoutWalletId: asString,
+  payoutWalletId: asOptional(asString),
   refundAddress: asOptional(asString)
 })
 
@@ -190,7 +190,7 @@ export const asEdgeTxActionSwap = asObject<EdgeTxActionSwap>({
   canBePartial: asOptional(asBoolean),
   fromAsset: asEdgeAssetAmount,
   toAsset: asEdgeAssetAmount,
-  payoutWalletId: asString,
+  payoutWalletId: asOptional(asString),
   payoutAddress: asString,
   refundAddress: asOptional(asString)
 })

--- a/src/core/currency/wallet/currency-wallet-cleaners.ts
+++ b/src/core/currency/wallet/currency-wallet-cleaners.ts
@@ -192,7 +192,8 @@ export const asEdgeTxActionSwap = asObject<EdgeTxActionSwap>({
   toAsset: asEdgeAssetAmount,
   payoutWalletId: asOptional(asString),
   payoutAddress: asString,
-  refundAddress: asOptional(asString)
+  refundAddress: asOptional(asString),
+  swapType: asOptional(asValue('swapSend', 'stealthSend', 'stealthSwapSend'))
 })
 
 export const asEdgeTxActionStake = asObject<EdgeTxActionStake>({

--- a/src/core/swap/swap-api.ts
+++ b/src/core/swap/swap-api.ts
@@ -14,10 +14,13 @@ import {
   EdgeSwapPlugin,
   EdgeSwapQuote,
   EdgeSwapRequest,
-  EdgeSwapRequestOptions
+  EdgeSwapRequestOptions,
+  EdgeSwapToAddressInfo
 } from '../../types/types'
 import { fuzzyTimeout, timeout } from '../../util/promise'
+import { CurrencyConfig } from '../account/plugin-api'
 import { ApiInput } from '../root-pixie'
+import { makeSyntheticDestinationWallet } from './synthetic-wallet'
 
 /**
  * Fetch quotes from all plugins, and sorts the best ones to the front.
@@ -41,12 +44,24 @@ export async function fetchSwapQuotes(
   const { swapSettings, userSettings } = account
   const swapPlugins = state.plugins.swap
 
+  // Resolve the destination. A normal swap provides `toWallet`; a
+  // swap-to-address (private send) request provides `toAddressInfo` instead, and
+  // the core builds a synthetic destination wallet from it so plugins receive an
+  // `EdgeCurrencyWallet` unchanged.
+  const swapRequest = resolveSwapRequest(ai, accountId, request)
+
   log.warn(
     'Requesting swap quotes for: ',
     {
-      ...request,
-      fromWallet: request.fromWallet.id,
-      toWallet: request.toWallet.id
+      ...swapRequest,
+      fromWallet: swapRequest.fromWallet.id,
+      toWallet: swapRequest.toWallet?.id,
+      // Never log the pasted destination address or its memos
+      // (private-send privacy):
+      toAddressInfo:
+        swapRequest.toAddressInfo == null
+          ? undefined
+          : redactToAddressInfo(swapRequest.toAddressInfo)
     },
     { preferPluginId, promoCodes }
   )
@@ -63,14 +78,24 @@ export async function fetchSwapQuotes(
     pendingIds.add(pluginId)
     promises.push(
       swapPlugins[pluginId]
-        .fetchSwapQuote(request, userSettings[pluginId], {
+        .fetchSwapQuote(swapRequest, userSettings[pluginId], {
           infoPayload: state.infoCache.corePlugins?.[pluginId] ?? {},
           promoCode: promoCodes[pluginId]
         })
         .then(
           quote => {
             upgradeSwapQuote(quote)
-            const { fromWallet, toWallet, ...request } = quote.request ?? {}
+            const { fromWallet, toWallet, toAddressInfo, ...rest } =
+              quote.request ?? {}
+            // Never log the pasted destination address or its memos
+            // (private-send privacy):
+            const request =
+              toAddressInfo == null
+                ? rest
+                : {
+                    ...rest,
+                    toAddressInfo: redactToAddressInfo(toAddressInfo)
+                  }
             const cleaned = { ...quote, request }
             pendingIds.delete(pluginId)
             log.warn(`${pluginId} gave swap quote:`, cleaned)
@@ -86,12 +111,12 @@ export async function fetchSwapQuotes(
                 swapPluginId: pluginId,
                 request: {
                   // Stringify to include "null"
-                  fromToken: String(request.fromTokenId),
-                  fromWalletType: request.fromWallet.type,
+                  fromToken: String(swapRequest.fromTokenId),
+                  fromWalletType: swapRequest.fromWallet.type,
                   // Stringify to include "null"
-                  toToken: String(request.toTokenId),
-                  toWalletType: request.toWallet.type,
-                  quoteFor: request.quoteFor
+                  toToken: String(swapRequest.toTokenId),
+                  toWalletType: swapRequest.toWallet?.type,
+                  quoteFor: swapRequest.quoteFor
                 }
               })
             }
@@ -117,7 +142,7 @@ export async function fetchSwapQuotes(
       )
 
       // Prepare quotes for the bridge:
-      return quotes.map(quote => wrapQuote(swapPlugins, request, quote))
+      return quotes.map(quote => wrapQuote(swapPlugins, swapRequest, quote))
     },
     (errors: unknown[]) => {
       log.warn(`All ${promises.length} swap quotes rejected.`)
@@ -127,6 +152,69 @@ export async function fetchSwapQuotes(
 
   if (noResponseMs == null) return await promise
   return await timeout(promise, noResponseMs)
+}
+
+/**
+ * Strips the private pieces (destination address and memos) out of a
+ * `toAddressInfo` descriptor so it can be logged.
+ */
+function redactToAddressInfo(
+  toAddressInfo: EdgeSwapToAddressInfo
+): EdgeSwapToAddressInfo {
+  const { toMemos } = toAddressInfo
+  return {
+    ...toAddressInfo,
+    toAddress: '[redacted]',
+    toMemos:
+      toMemos == null
+        ? undefined
+        : toMemos.map(memo => ({ ...memo, value: '[redacted]' }))
+  }
+}
+
+/**
+ * Validates the destination on a swap request and resolves it to a request that
+ * always carries a `toWallet`. Exactly one of `toWallet` or `toAddressInfo` must
+ * be present; when it is `toAddressInfo`, a synthetic destination wallet is built
+ * core-side from the descriptor.
+ */
+function resolveSwapRequest(
+  ai: ApiInput,
+  accountId: string,
+  request: EdgeSwapRequest
+): EdgeSwapRequest {
+  const { toWallet, toAddressInfo } = request
+
+  if ((toWallet == null) === (toAddressInfo == null)) {
+    throw new Error(
+      'Swap request must include exactly one of `toWallet` or `toAddressInfo`'
+    )
+  }
+  if (toAddressInfo == null) return request
+
+  const { toPluginId, toAddress, toMemos } = toAddressInfo
+  const { toTokenId } = request
+  if (ai.props.state.plugins.currency[toPluginId] == null) {
+    throw new Error(
+      `Cannot build swap destination: no currency plugin "${toPluginId}"`
+    )
+  }
+  const currencyConfig = new CurrencyConfig(ai, accountId, toPluginId)
+  if (toTokenId != null && currencyConfig.allTokens[toTokenId] == null) {
+    throw new Error(
+      `Cannot build swap destination: no token "${toTokenId}" on plugin "${toPluginId}"`
+    )
+  }
+
+  // Drop the descriptor from the resolved request so it keeps exactly one
+  // destination: a resolved request that rides back to the caller inside
+  // `quote.request` must be re-submittable without tripping the
+  // exactly-one-of rule above.
+  return {
+    ...request,
+    toAddressInfo: undefined,
+    toWallet: makeSyntheticDestinationWallet(currencyConfig, toAddress, toMemos)
+  }
 }
 
 function wrapQuote(

--- a/src/core/swap/swap-api.ts
+++ b/src/core/swap/swap-api.ts
@@ -14,10 +14,12 @@ import {
   EdgeSwapPlugin,
   EdgeSwapQuote,
   EdgeSwapRequest,
-  EdgeSwapRequestOptions
+  EdgeSwapRequestOptions,
+  EdgeSwapToAddressInfo
 } from '../../types/types'
 import { fuzzyTimeout, timeout } from '../../util/promise'
 import { ApiInput } from '../root-pixie'
+import { makeSyntheticDestinationWallet } from './synthetic-wallet'
 
 /**
  * Fetch quotes from all plugins, and sorts the best ones to the front.
@@ -41,12 +43,42 @@ export async function fetchSwapQuotes(
   const { swapSettings, userSettings } = account
   const swapPlugins = state.plugins.swap
 
+  // Resolve the destination. A normal swap provides `toWallet`; a
+  // swap-to-address (private send) request provides `toAddressInfo` instead, and
+  // the core builds a synthetic destination wallet from it so plugins receive an
+  // `EdgeCurrencyWallet` unchanged.
+  const swapRequest = resolveSwapRequest(ai, accountId, request)
+
+  // A swap-to-address request builds ONE synthetic destination wallet, shared
+  // by every quote this call produces. It is bridgified, so yaob keeps it in
+  // the account's object table until something closes it, and the caller
+  // reaches it through `quote.request.toWallet`. Release it once the LAST
+  // quote carrying it has been closed, and right away when no quote survives
+  // to carry it: without that, every quote refresh on a swap-to-address screen
+  // leaves another wallet in the table for the life of the account. (The same
+  // reasoning is why `resolveSwapRequest` reuses the account's long-lived
+  // `currencyConfig` rather than building one per request.)
+  const syntheticToWallet =
+    request.toAddressInfo == null ? undefined : swapRequest.toWallet
+  let openQuoteCount = 0
+  const releaseSyntheticToWallet = (): void => {
+    if (syntheticToWallet == null) return
+    if (--openQuoteCount > 0) return
+    close(syntheticToWallet)
+  }
+
   log.warn(
     'Requesting swap quotes for: ',
     {
-      ...request,
-      fromWallet: request.fromWallet.id,
-      toWallet: request.toWallet.id
+      ...swapRequest,
+      fromWallet: swapRequest.fromWallet.id,
+      toWallet: swapRequest.toWallet?.id,
+      // Never log the pasted destination address or its memos
+      // (private-send privacy):
+      toAddressInfo:
+        swapRequest.toAddressInfo == null
+          ? undefined
+          : redactToAddressInfo(swapRequest.toAddressInfo)
     },
     { preferPluginId, promoCodes }
   )
@@ -63,14 +95,24 @@ export async function fetchSwapQuotes(
     pendingIds.add(pluginId)
     promises.push(
       swapPlugins[pluginId]
-        .fetchSwapQuote(request, userSettings[pluginId], {
+        .fetchSwapQuote(swapRequest, userSettings[pluginId], {
           infoPayload: state.infoCache.corePlugins?.[pluginId] ?? {},
           promoCode: promoCodes[pluginId]
         })
         .then(
           quote => {
             upgradeSwapQuote(quote)
-            const { fromWallet, toWallet, ...request } = quote.request ?? {}
+            const { fromWallet, toWallet, toAddressInfo, ...rest } =
+              quote.request ?? {}
+            // Never log the pasted destination address or its memos
+            // (private-send privacy):
+            const request =
+              toAddressInfo == null
+                ? rest
+                : {
+                    ...rest,
+                    toAddressInfo: redactToAddressInfo(toAddressInfo)
+                  }
             const cleaned = { ...quote, request }
             pendingIds.delete(pluginId)
             log.warn(`${pluginId} gave swap quote:`, cleaned)
@@ -86,12 +128,12 @@ export async function fetchSwapQuotes(
                 swapPluginId: pluginId,
                 request: {
                   // Stringify to include "null"
-                  fromToken: String(request.fromTokenId),
-                  fromWalletType: request.fromWallet.type,
+                  fromToken: String(swapRequest.fromTokenId),
+                  fromWalletType: swapRequest.fromWallet.type,
                   // Stringify to include "null"
-                  toToken: String(request.toTokenId),
-                  toWalletType: request.toWallet.type,
-                  quoteFor: request.quoteFor
+                  toToken: String(swapRequest.toTokenId),
+                  toWalletType: swapRequest.toWallet?.type,
+                  quoteFor: swapRequest.quoteFor
                 }
               })
             }
@@ -117,10 +159,17 @@ export async function fetchSwapQuotes(
       )
 
       // Prepare quotes for the bridge:
-      return quotes.map(quote => wrapQuote(swapPlugins, request, quote))
+      openQuoteCount = quotes.length
+      if (syntheticToWallet != null && quotes.length === 0) {
+        close(syntheticToWallet)
+      }
+      return quotes.map(quote =>
+        wrapQuote(swapPlugins, swapRequest, quote, releaseSyntheticToWallet)
+      )
     },
     (errors: unknown[]) => {
       log.warn(`All ${promises.length} swap quotes rejected.`)
+      if (syntheticToWallet != null) close(syntheticToWallet)
       throw pickBestError(errors)
     }
   )
@@ -129,11 +178,91 @@ export async function fetchSwapQuotes(
   return await timeout(promise, noResponseMs)
 }
 
-function wrapQuote(
+/**
+ * Strips the private pieces (destination address and memos) out of a
+ * `toAddressInfo` descriptor so it can be logged.
+ */
+function redactToAddressInfo(
+  toAddressInfo: EdgeSwapToAddressInfo
+): EdgeSwapToAddressInfo {
+  const { toMemos } = toAddressInfo
+  return {
+    ...toAddressInfo,
+    toAddress: '[redacted]',
+    toMemos:
+      toMemos == null
+        ? undefined
+        : toMemos.map(memo => ({ ...memo, value: '[redacted]' }))
+  }
+}
+
+/**
+ * Validates the destination on a swap request and resolves it to a request that
+ * always carries a `toWallet`. Exactly one of `toWallet` or `toAddressInfo` must
+ * be present; when it is `toAddressInfo`, a synthetic destination wallet is built
+ * core-side from the descriptor.
+ */
+function resolveSwapRequest(
+  ai: ApiInput,
+  accountId: string,
+  request: EdgeSwapRequest
+): EdgeSwapRequest {
+  const { toWallet, toAddressInfo } = request
+
+  if ((toWallet == null) === (toAddressInfo == null)) {
+    throw new Error(
+      'Swap request must include exactly one of `toWallet` or `toAddressInfo`'
+    )
+  }
+  if (toAddressInfo == null) return request
+
+  const { toPluginId, toAddress, toMemos } = toAddressInfo
+  const { toTokenId } = request
+  if (ai.props.state.plugins.currency[toPluginId] == null) {
+    throw new Error(
+      `Cannot build swap destination: no currency plugin "${toPluginId}"`
+    )
+  }
+  // The account's own long-lived config, not a fresh one. A per-request
+  // `new CurrencyConfig` would be bridgified into the synthetic wallet and ride
+  // back to the caller inside `quote.request.toWallet`, and nothing closes it,
+  // so every swap-to-address quote would add a duplicate entry to yaob's object
+  // table for the lifetime of the account.
+  const { accountApi } = ai.props.output.accounts[accountId]
+  const currencyConfig = accountApi.currencyConfig[toPluginId]
+  if (toTokenId != null && currencyConfig.allTokens[toTokenId] == null) {
+    throw new Error(
+      `Cannot build swap destination: no token "${toTokenId}" on plugin "${toPluginId}"`
+    )
+  }
+
+  // Drop the descriptor from the resolved request so it keeps exactly one
+  // destination: a resolved request that rides back to the caller inside
+  // `quote.request` must be re-submittable without tripping the
+  // exactly-one-of rule above.
+  return {
+    ...request,
+    toAddressInfo: undefined,
+    toWallet: makeSyntheticDestinationWallet(currencyConfig, toAddress, toMemos)
+  }
+}
+
+/**
+ * Wraps a plugin's quote in a bridgeable object the caller can hold.
+ *
+ * `onClose` fires exactly once per wrapper, however many times the caller
+ * calls `close`, so a caller that double-closes cannot release a shared
+ * resource (the synthetic destination wallet) early. Exported for testing.
+ */
+export function wrapQuote(
   swapPlugins: EdgePluginMap<EdgeSwapPlugin>,
   request: EdgeSwapRequest,
-  quote: EdgeSwapQuote
+  quote: EdgeSwapQuote,
+  onClose: () => void = () => {}
 ): EdgeSwapQuote {
+  // A caller may close the same quote twice. `onClose` releases a shared
+  // resource by reference count, so it must fire exactly once per wrapper.
+  let closed = false
   const out = bridgifyObject<EdgeSwapQuote>({
     canBePartial: quote.canBePartial,
     expirationDate: quote.expirationDate,
@@ -153,6 +282,10 @@ function wrapQuote(
 
     async close() {
       await quote.close()
+      if (!closed) {
+        closed = true
+        onClose()
+      }
       close(out)
     }
   })

--- a/src/core/swap/swap-api.ts
+++ b/src/core/swap/swap-api.ts
@@ -32,6 +32,7 @@ export async function fetchSwapQuotes(
 ): Promise<EdgeSwapQuote[]> {
   const {
     disabled = {},
+    forceEnabled = {},
     noResponseMs,
     preferPluginId,
     promoCodes = {},
@@ -89,7 +90,15 @@ export async function fetchSwapQuotes(
   for (const pluginId of Object.keys(swapPlugins)) {
     const { enabled = true } =
       swapSettings[pluginId] != null ? swapSettings[pluginId] : {}
-    if (!enabled || disabled[pluginId]) continue
+    if (
+      !isSwapPluginQueryable({
+        enabled,
+        forceEnabled: forceEnabled[pluginId],
+        disabled: disabled[pluginId]
+      })
+    ) {
+      continue
+    }
 
     // Start request:
     pendingIds.add(pluginId)
@@ -176,6 +185,30 @@ export async function fetchSwapQuotes(
 
   if (noResponseMs == null) return await promise
   return await timeout(promise, noResponseMs)
+}
+
+/**
+ * Whether one swap plugin should be queried for a request.
+ *
+ * `forceEnabled` reaches a plugin the user switched off in their swap settings,
+ * for a caller whose feature is powered by that one named provider: the setting
+ * answers which providers the aggregator may choose among, not whether a
+ * feature built on a specific provider may work at all. An explicit `disabled`
+ * entry from the same call always wins, since that is the caller narrowing its
+ * own request rather than the user stating a preference.
+ */
+export function isSwapPluginQueryable(opts: {
+  enabled: boolean
+  /**
+   * Optional because both flags are read out of an `EdgePluginMap`, where an
+   * absent plugin reads as `undefined` rather than `false`.
+   */
+  forceEnabled?: boolean
+  disabled?: boolean
+}): boolean {
+  const { enabled, forceEnabled = false, disabled = false } = opts
+  if (disabled) return false
+  return enabled || forceEnabled
 }
 
 /**

--- a/src/core/swap/synthetic-wallet.ts
+++ b/src/core/swap/synthetic-wallet.ts
@@ -1,0 +1,76 @@
+import { bridgifyObject } from 'yaob'
+
+import {
+  EdgeAddress,
+  EdgeCurrencyConfig,
+  EdgeCurrencyWallet,
+  EdgeMemo,
+  EdgeReceiveAddress
+} from '../../types/types'
+
+/**
+ * A prefix marking a synthetic destination wallet's `id`. A swap-to-address
+ * destination has no real payout wallet, so this id does not resolve to one;
+ * it only exists because plugins read `toWallet.id` for order metadata.
+ */
+export const SYNTHETIC_WALLET_ID_PREFIX = 'synthetic://'
+
+/**
+ * Build a synthetic, bridgified destination wallet for a swap-to-address
+ * request. It is backed by the real `currencyConfig` core already holds, so
+ * `currencyInfo` and `currencyConfig.allTokens` are authentic, while
+ * `getAddresses` / `getReceiveAddress` return the pasted destination address.
+ *
+ * It is bridgified here (core-side) so swap-plugin method calls work unchanged
+ * and so it survives the yaob wire format when it rides back to the GUI inside
+ * `quote.request.toWallet`. A GUI-built fake cannot do this: its function
+ * properties fail to cross the bridge (see the Phase 1 verdict).
+ */
+export function makeSyntheticDestinationWallet(
+  currencyConfig: EdgeCurrencyConfig,
+  toAddress: string,
+  toMemos: EdgeMemo[] = []
+): EdgeCurrencyWallet {
+  const { currencyInfo } = currencyConfig
+
+  const addresses: EdgeAddress[] = [
+    { addressType: 'publicAddress', publicAddress: toAddress }
+  ]
+  const receiveAddress: EdgeReceiveAddress = {
+    publicAddress: toAddress,
+    metadata: {},
+    nativeAmount: '0'
+  }
+
+  const wallet = {
+    id: `${SYNTHETIC_WALLET_ID_PREFIX}${currencyInfo.pluginId}`,
+    type: currencyInfo.walletType,
+    currencyConfig,
+    currencyInfo,
+
+    async getAddresses(): Promise<EdgeAddress[]> {
+      return addresses
+    },
+
+    /**
+     * Destination memos (e.g. an XRP destination tag) for the payout.
+     * Not part of `EdgeCurrencyWallet` — see `EdgeSyntheticDestinationWallet`.
+     * Plugins that support destination memos detect this method at runtime.
+     */
+    async getMemos(): Promise<EdgeMemo[]> {
+      return toMemos
+    },
+
+    async getReceiveAddress(): Promise<EdgeReceiveAddress> {
+      return receiveAddress
+    }
+  }
+  bridgifyObject(wallet)
+
+  // The synthetic destination only implements the `EdgeCurrencyWallet` surface
+  // that swap plugins read on `toWallet` (id, type, currencyInfo,
+  // currencyConfig, getAddresses, getReceiveAddress), plus the synthetic-only
+  // `getMemos` (see `EdgeSyntheticDestinationWallet`). It is never used as a
+  // source wallet, so the spend/sign/sync methods are intentionally absent.
+  return wallet as unknown as EdgeCurrencyWallet
+}

--- a/src/core/swap/synthetic-wallet.ts
+++ b/src/core/swap/synthetic-wallet.ts
@@ -1,0 +1,76 @@
+import { bridgifyObject } from 'yaob'
+
+import {
+  EdgeAddress,
+  EdgeCurrencyConfig,
+  EdgeCurrencyWallet,
+  EdgeMemo,
+  EdgeReceiveAddress
+} from '../../types/types'
+
+/**
+ * A prefix marking a synthetic destination wallet's `id`. A swap-to-address
+ * destination has no real payout wallet, so this id does not resolve to one;
+ * it only exists because plugins read `toWallet.id` for order metadata.
+ */
+export const SYNTHETIC_WALLET_ID_PREFIX = 'synthetic://'
+
+/**
+ * Build a synthetic, bridgified destination wallet for a swap-to-address
+ * request. It is backed by the real `currencyConfig` core already holds, so
+ * `currencyInfo` and `currencyConfig.allTokens` are authentic, while
+ * `getAddresses` / `getReceiveAddress` return the pasted destination address.
+ *
+ * It is bridgified here (core-side) so swap-plugin method calls work unchanged
+ * and so it survives the yaob wire format when it rides back to the GUI inside
+ * `quote.request.toWallet`. A GUI-built fake cannot do this: its function
+ * properties fail to cross the bridge (see the Phase 1 verdict).
+ */
+export function makeSyntheticDestinationWallet(
+  currencyConfig: EdgeCurrencyConfig,
+  toAddress: string,
+  toMemos: EdgeMemo[] = []
+): EdgeCurrencyWallet {
+  const { currencyInfo } = currencyConfig
+
+  const addresses: EdgeAddress[] = [
+    { addressType: 'publicAddress', publicAddress: toAddress }
+  ]
+  const receiveAddress: EdgeReceiveAddress = {
+    publicAddress: toAddress,
+    metadata: {},
+    nativeAmount: '0'
+  }
+
+  const wallet = {
+    id: `${SYNTHETIC_WALLET_ID_PREFIX}${currencyInfo.pluginId}`,
+    type: currencyInfo.walletType,
+    currencyConfig,
+    currencyInfo,
+
+    async getAddresses(): Promise<EdgeAddress[]> {
+      return addresses
+    },
+
+    /**
+     * Destination memos (e.g. an XRP destination tag) for the payout.
+     * Not part of `EdgeCurrencyWallet`; see `EdgeSyntheticDestinationWallet`.
+     * Plugins that support destination memos detect this method at runtime.
+     */
+    async getMemos(): Promise<EdgeMemo[]> {
+      return toMemos
+    },
+
+    async getReceiveAddress(): Promise<EdgeReceiveAddress> {
+      return receiveAddress
+    }
+  }
+  bridgifyObject(wallet)
+
+  // The synthetic destination only implements the `EdgeCurrencyWallet` surface
+  // that swap plugins read on `toWallet` (id, type, currencyInfo,
+  // currencyConfig, getAddresses, getReceiveAddress), plus the synthetic-only
+  // `getMemos` (see `EdgeSyntheticDestinationWallet`). It is never used as a
+  // source wallet, so the spend/sign/sync methods are intentionally absent.
+  return wallet as unknown as EdgeCurrencyWallet
+}

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -309,9 +309,13 @@ export class SwapCurrencyError extends Error {
   readonly toTokenId: EdgeTokenId
 
   constructor(swapInfo: EdgeSwapInfo, request: EdgeSwapRequest) {
-    const { fromWallet, toWallet, fromTokenId, toTokenId } = request
+    const { fromWallet, toWallet, toAddressInfo, fromTokenId, toTokenId } =
+      request
     const fromPluginId = fromWallet.currencyConfig.currencyInfo.pluginId
-    const toPluginId = toWallet.currencyConfig.currencyInfo.pluginId
+    const toPluginId =
+      toWallet?.currencyConfig.currencyInfo.pluginId ??
+      toAddressInfo?.toPluginId ??
+      ''
 
     const fromString = `${fromPluginId}:${String(fromTokenId)}`
     const toString = `${toPluginId}:${String(toTokenId)}`

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -284,7 +284,16 @@ export interface EdgeTxActionSwap {
   fromAsset: EdgeAssetAmount
   toAsset: EdgeAssetAmount
   payoutAddress: string
-  payoutWalletId: string
+
+  /**
+   * The wallet that received the payout, for a normal wallet-to-wallet swap.
+   * Optional because a swap-to-address (private send) destination has no payout
+   * wallet; `payoutAddress` carries the destination in that case. GUI
+   * `savedAction` consumers that assume this is always present need a sweep
+   * before relying on it.
+   */
+  payoutWalletId?: string
+
   refundAddress?: string
 }
 
@@ -603,7 +612,14 @@ export interface EdgeTxSwap {
   payoutCurrencyCode: string
   payoutNativeAmount: string
   payoutTokenId?: EdgeTokenId
-  payoutWalletId: string
+
+  /**
+   * The wallet that received the payout, for a normal wallet-to-wallet swap.
+   * Optional because a swap-to-address (private send) destination has no
+   * payout wallet; `payoutAddress` carries the destination in that case.
+   */
+  payoutWalletId?: string
+
   refundAddress?: string
 }
 
@@ -1507,10 +1523,55 @@ export interface EdgeSwapInfo {
   readonly supportEmail: string
 }
 
+/**
+ * An address-only swap destination, used in place of a destination
+ * `toWallet` for "swap-to-address" (e.g. private send). The core builds a
+ * synthetic destination wallet from this descriptor, backed by the real
+ * `currencyConfig` for `toPluginId`, so swap plugins need no changes. The
+ * destination token is taken from the request's `toTokenId`, so it is not
+ * repeated here.
+ */
+export interface EdgeSwapToAddressInfo {
+  toPluginId: string
+  toAddress: string
+
+  /**
+   * Destination memos (e.g. an XRP destination tag) for memo-required payout
+   * chains. This descriptor field is only the GUI-to-core transport: swap
+   * plugins never read it. The core copies it onto the synthetic destination
+   * wallet, which exposes it through `getMemos` (see
+   * `EdgeSyntheticDestinationWallet`), so plugins consume destination memos
+   * through the wallet surface alone.
+   */
+  toMemos?: EdgeMemo[]
+}
+
+/**
+ * The extra surface a core-built synthetic destination wallet exposes on top
+ * of the `EdgeCurrencyWallet` members swap plugins normally read. Real
+ * wallets do not implement `getMemos`; plugins that support destination
+ * memos should detect it at runtime, such as:
+ * `const { getMemos } = toWallet as Partial<EdgeSyntheticDestinationWallet>`
+ */
+export interface EdgeSyntheticDestinationWallet extends EdgeCurrencyWallet {
+  readonly getMemos: () => Promise<EdgeMemo[]>
+}
+
 export interface EdgeSwapRequest {
   // Where?
   fromWallet: EdgeCurrencyWallet
-  toWallet: EdgeCurrencyWallet
+
+  /**
+   * The destination wallet for a normal wallet-to-wallet swap.
+   * Provide exactly one of `toWallet` or `toAddressInfo`.
+   */
+  toWallet?: EdgeCurrencyWallet
+
+  /**
+   * An address-only destination, as an alternative to `toWallet`.
+   * Provide exactly one of `toWallet` or `toAddressInfo`.
+   */
+  toAddressInfo?: EdgeSwapToAddressInfo
 
   // What?
   fromTokenId: EdgeTokenId

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -274,6 +274,22 @@ export interface EdgeFiatAmount {
   fiatAmount: string
 }
 
+/**
+ * How a swap was initiated, when it was not a plain swap between two of the
+ * user's own wallets. These flows all settle through a swap provider and keep
+ * every other field of `EdgeTxActionSwap`, so they stay swaps to existing
+ * consumers; what differs is how the user reached them and, for the private
+ * flavors, how much of the destination a UI may reveal.
+ *
+ * - `swapSend`: cross-asset send to an address the user entered.
+ * - `stealthSend`: same-asset send routed privately through the provider.
+ * - `stealthSwapSend`: cross-asset send routed privately.
+ */
+export type EdgeTxActionSwapType =
+  | 'swapSend'
+  | 'stealthSend'
+  | 'stealthSwapSend'
+
 export interface EdgeTxActionSwap {
   actionType: 'swap'
   swapInfo: EdgeSwapInfo
@@ -284,6 +300,13 @@ export interface EdgeTxActionSwap {
   fromAsset: EdgeAssetAmount
   toAsset: EdgeAssetAmount
   payoutAddress: string
+
+  /**
+   * Names a send-shaped swap flow. Absent for a normal wallet-to-wallet swap.
+   * A UI keyed on this can title the transaction for the flow the user
+   * actually ran, instead of inferring it from the presence of other fields.
+   */
+  swapType?: EdgeTxActionSwapType
 
   /**
    * The wallet that received the payout, for a normal wallet-to-wallet swap.

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1603,6 +1603,15 @@ export interface EdgeSwapRequest {
   // How much?
   nativeAmount: string
   quoteFor: 'from' | 'max' | 'to'
+
+  /**
+   * Route privacy requirement. `'required'` means the quote must come from a
+   * route that keeps the sender unlinkable to the recipient. A plugin that
+   * cannot offer one must decline the request rather than answer with a
+   * transparent route, since a caller asking for privacy would otherwise get
+   * a downgrade it has no way to detect. Omitted means any route will do.
+   */
+  privacy?: 'required'
 }
 
 /**
@@ -1827,6 +1836,15 @@ export interface EdgeSwapRequestOptions {
   preferType?: EdgeSwapPluginType
   disabled?: EdgePluginMap<true>
   promoCodes?: EdgePluginMap<string>
+
+  /**
+   * Plugins to query even when the user has switched them off in their swap
+   * settings. For a feature that is powered by one specific provider rather
+   * than by the swap aggregator, the provider toggle is not the user's answer
+   * about that feature, so the caller can opt out of it for a single request.
+   * `disabled` still wins: an explicitly disabled plugin stays disabled.
+   */
+  forceEnabled?: EdgePluginMap<true>
 
   /**
    * If we have some quotes already, how long should we wait

--- a/test/core/currency/wallet/currency-wallet.test.ts
+++ b/test/core/currency/wallet/currency-wallet.test.ts
@@ -610,7 +610,10 @@ describe('currency wallets', function () {
       }
     ])
     expect(txs[0].assetAction).deep.equals(assetAction)
-    expect(txs[0].savedAction).deep.equals(savedAction)
+    expect(txs[0].savedAction).deep.equals({
+      swapType: undefined,
+      ...savedAction
+    })
     expect(txs[0].swapData).deep.equals({
       orderUri: undefined,
       refundAddress: undefined,

--- a/test/core/swap-quote-close.test.ts
+++ b/test/core/swap-quote-close.test.ts
@@ -1,0 +1,63 @@
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+
+import { wrapQuote } from '../../src/core/swap/swap-api'
+import {
+  EdgePluginMap,
+  EdgeSwapPlugin,
+  EdgeSwapQuote,
+  EdgeSwapRequest
+} from '../../src/types/types'
+
+const swapInfo = { pluginId: 'fake', displayName: 'Fake', isDex: false }
+const swapPlugins = {
+  fake: { swapInfo }
+} as unknown as EdgePluginMap<EdgeSwapPlugin>
+
+const makeQuote = (): EdgeSwapQuote =>
+  ({
+    pluginId: 'fake',
+    swapInfo,
+    fromNativeAmount: '1',
+    toNativeAmount: '1',
+    isEstimate: false,
+    async approve() {
+      throw new Error('not used')
+    },
+    async close() {}
+  }) as unknown as EdgeSwapQuote
+
+const request = {} as unknown as EdgeSwapRequest
+
+describe('wrapQuote close', function () {
+  it('releases the shared destination once every quote is closed', async function () {
+    // The synthetic destination wallet is shared by every quote one
+    // `fetchSwapQuotes` call returns, so it may only be released after the
+    // last of them is closed.
+    let released = 0
+    const release = (): void => {
+      released++
+    }
+    const wrapped = [makeQuote(), makeQuote()].map(quote =>
+      wrapQuote(swapPlugins, request, quote, release)
+    )
+
+    await wrapped[0].close()
+    expect(released).equals(1)
+    await wrapped[1].close()
+    expect(released).equals(2)
+  })
+
+  it('releases once per quote, however many times it is closed', async function () {
+    // The release is reference-counted, so a caller that closes the same quote
+    // twice must not decrement twice and free the shared wallet early.
+    let released = 0
+    const wrapped = wrapQuote(swapPlugins, request, makeQuote(), () => {
+      released++
+    })
+
+    await wrapped.close()
+    await wrapped.close()
+    expect(released).equals(1)
+  })
+})

--- a/test/core/swap.test.ts
+++ b/test/core/swap.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { describe, it } from 'mocha'
 
-import { sortQuotes } from '../../src/core/swap/swap-api'
+import { isSwapPluginQueryable, sortQuotes } from '../../src/core/swap/swap-api'
 import { EdgeSwapInfo, EdgeSwapQuote, EdgeSwapRequest } from '../../src/index'
 
 const typeHack: any = {}
@@ -108,4 +108,36 @@ describe('swap', function () {
     })
     expect(getIds(sorted)).equals('switchain, changenow, godex, thorchain')
   })
+})
+
+describe('swap plugin selection', function () {
+  // The whole truth table, because the interesting cases are the corners: a
+  // caller must be able to reach a provider the user switched off, and must
+  // never be able to reach one it disabled itself in the same call.
+  const cases: Array<{
+    enabled: boolean
+    forceEnabled: boolean
+    disabled: boolean
+    queryable: boolean
+  }> = [
+    { enabled: true, forceEnabled: false, disabled: false, queryable: true },
+    { enabled: true, forceEnabled: true, disabled: false, queryable: true },
+    { enabled: false, forceEnabled: false, disabled: false, queryable: false },
+    // The send scene's stealth path: Houdini powers the feature, so the swap
+    // setting does not get to switch the feature off.
+    { enabled: false, forceEnabled: true, disabled: false, queryable: true },
+    { enabled: true, forceEnabled: false, disabled: true, queryable: false },
+    // `disabled` beats `forceEnabled`. Stealth sends disable every other
+    // plugin and force-enable Houdini in the same call, so a bug here would
+    // let the aggregator answer a request that demanded one provider.
+    { enabled: true, forceEnabled: true, disabled: true, queryable: false },
+    { enabled: false, forceEnabled: false, disabled: true, queryable: false },
+    { enabled: false, forceEnabled: true, disabled: true, queryable: false }
+  ]
+
+  for (const { queryable, ...flags } of cases) {
+    it(`${JSON.stringify(flags)} -> ${String(queryable)}`, function () {
+      expect(isSwapPluginQueryable(flags)).equals(queryable)
+    })
+  }
 })

--- a/test/core/synthetic-wallet.test.ts
+++ b/test/core/synthetic-wallet.test.ts
@@ -1,0 +1,183 @@
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+import { Bridgeable, bridgifyObject, makeLocalBridge } from 'yaob'
+
+import {
+  makeSyntheticDestinationWallet,
+  SYNTHETIC_WALLET_ID_PREFIX
+} from '../../src/core/swap/synthetic-wallet'
+import {
+  EdgeCurrencyConfig,
+  EdgeCurrencyInfo,
+  EdgeCurrencyWallet,
+  EdgeMemo,
+  EdgeSwapToAddressInfo,
+  EdgeSyntheticDestinationWallet,
+  EdgeToken,
+  EdgeTokenId,
+  EdgeTokenMap
+} from '../../src/index'
+
+// A real destination address the GUI would paste in:
+const PAYOUT_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678'
+const USDC_TOKEN_ID = 'a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+
+const usdcToken: EdgeToken = {
+  currencyCode: 'USDC',
+  displayName: 'USD Coin',
+  denominations: [{ name: 'USDC', multiplier: '1000000' }],
+  networkLocation: { contractAddress: `0x${USDC_TOKEN_ID}` }
+}
+const allTokens: EdgeTokenMap = { [USDC_TOKEN_ID]: usdcToken }
+
+const currencyInfo: EdgeCurrencyInfo = {
+  pluginId: 'ethereum',
+  currencyCode: 'ETH',
+  walletType: 'wallet:ethereum',
+  displayName: 'Ethereum',
+  denominations: [{ name: 'ETH', multiplier: '1000000000000000000' }]
+} as unknown as EdgeCurrencyInfo
+
+// Stand-in for the real, bridgeable `currencyConfig` the core already holds for
+// the destination plugin. Only the surface the synthetic wallet reads is needed.
+const currencyConfig = bridgifyObject({
+  currencyInfo,
+  allTokens
+}) as unknown as EdgeCurrencyConfig
+
+/**
+ * The shape the GUI sees across the bridge. It accepts ONLY the descriptor
+ * (plain data) and returns what a plugin-faithful consumer read off the
+ * core-built synthetic destination, plus the synthetic itself.
+ */
+interface ConsumerReads {
+  address: string
+  receiveAddress: string
+  tokenCurrencyCode: string | undefined
+  parentCurrencyCode: string
+  walletType: string
+  walletId: string
+}
+interface DestinationProof {
+  consumer: ConsumerReads
+  toWallet: EdgeCurrencyWallet
+}
+interface CoreSwapApi {
+  buildDestination: (
+    toAddressInfo: EdgeSwapToAddressInfo,
+    toTokenId: EdgeTokenId
+  ) => Promise<DestinationProof>
+}
+
+/**
+ * Mirrors the core side of the production GUI<->core bridge: it receives the
+ * descriptor plus the request's `toTokenId`, builds the synthetic destination,
+ * and runs a consumer that makes exactly the reads swap plugins make on
+ * `toWallet`. The destination token comes from the request, not the descriptor.
+ */
+class FakeCoreSwapApi extends Bridgeable<CoreSwapApi> implements CoreSwapApi {
+  async buildDestination(
+    toAddressInfo: EdgeSwapToAddressInfo,
+    toTokenId: EdgeTokenId
+  ): Promise<DestinationProof> {
+    const synthetic = makeSyntheticDestinationWallet(
+      currencyConfig,
+      toAddressInfo.toAddress,
+      toAddressInfo.toMemos
+    )
+
+    // Plugin-faithful consumer (runs core-side, by reference): the same reads
+    // `getAddress`, `getReceiveAddress`, `denominationToNative`, and the central
+    // plugins make on a destination wallet.
+    const addresses = await synthetic.getAddresses({ tokenId: null })
+    const receiveAddress = await synthetic.getReceiveAddress({ tokenId: null })
+    const token =
+      toTokenId != null
+        ? synthetic.currencyConfig.allTokens[toTokenId]
+        : undefined
+
+    const consumer: ConsumerReads = {
+      address: addresses[0].publicAddress,
+      receiveAddress: receiveAddress.publicAddress,
+      tokenCurrencyCode: token?.currencyCode,
+      parentCurrencyCode: synthetic.currencyInfo.currencyCode,
+      walletType: synthetic.type,
+      walletId: synthetic.id
+    }
+    return { consumer, toWallet: synthetic }
+  }
+}
+
+describe('synthetic destination wallet', function () {
+  // Same wire format edge-core-js uses in production (index.ts): a JSON
+  // round-trip on every message.
+  const guiApi: CoreSwapApi = makeLocalBridge(new FakeCoreSwapApi(), {
+    cloneMessage: message => JSON.parse(JSON.stringify(message))
+  })
+
+  it('builds a working destination from a descriptor across the bridge', async function () {
+    // The GUI passes ONLY the descriptor (plain data) — the exact thing that
+    // crosses the bridge cleanly, unlike the Phase 1 GUI-built fake wallet.
+    const toAddressInfo: EdgeSwapToAddressInfo = {
+      toPluginId: 'ethereum',
+      toAddress: PAYOUT_ADDRESS
+    }
+    const proof = await guiApi.buildDestination(toAddressInfo, USDC_TOKEN_ID)
+
+    // The core-side consumer got a fully working destination:
+    expect(proof.consumer.address).equals(PAYOUT_ADDRESS)
+    expect(proof.consumer.receiveAddress).equals(PAYOUT_ADDRESS)
+    expect(proof.consumer.tokenCurrencyCode).equals('USDC')
+    expect(proof.consumer.parentCurrencyCode).equals('ETH')
+    expect(proof.consumer.walletType).equals('wallet:ethereum')
+    expect(proof.consumer.walletId).equals(
+      `${SYNTHETIC_WALLET_ID_PREFIX}ethereum`
+    )
+
+    // And the bridgified synthetic survives the trip back GUI-ward and is
+    // callable across the wire — the direct inverse of the Phase 1 failure,
+    // where the fake's function properties threw on argument unpack.
+    const guiAddresses = await proof.toWallet.getAddresses({ tokenId: null })
+    expect(guiAddresses[0].publicAddress).equals(PAYOUT_ADDRESS)
+  })
+
+  it('builds a parent-currency destination when toTokenId is null', async function () {
+    const proof = await guiApi.buildDestination(
+      {
+        toPluginId: 'ethereum',
+        toAddress: PAYOUT_ADDRESS
+      },
+      null
+    )
+
+    expect(proof.consumer.address).equals(PAYOUT_ADDRESS)
+    expect(proof.consumer.tokenCurrencyCode).equals(undefined)
+    expect(proof.consumer.parentCurrencyCode).equals('ETH')
+  })
+
+  it('exposes destination memos through getMemos across the bridge', async function () {
+    const toMemos: EdgeMemo[] = [{ type: 'number', value: '8675309' }]
+    const proof = await guiApi.buildDestination(
+      {
+        toPluginId: 'ethereum',
+        toAddress: PAYOUT_ADDRESS,
+        toMemos
+      },
+      null
+    )
+
+    // The synthetic exposes the descriptor's memos to plugin-side readers,
+    // and the method still works across the yaob wire format:
+    const synthetic = proof.toWallet as EdgeSyntheticDestinationWallet
+    expect(await synthetic.getMemos()).deep.equals(toMemos)
+  })
+
+  it('returns no memos when the descriptor has none', async function () {
+    const proof = await guiApi.buildDestination(
+      { toPluginId: 'ethereum', toAddress: PAYOUT_ADDRESS },
+      null
+    )
+    const synthetic = proof.toWallet as EdgeSyntheticDestinationWallet
+    expect(await synthetic.getMemos()).deep.equals([])
+  })
+})

--- a/test/core/synthetic-wallet.test.ts
+++ b/test/core/synthetic-wallet.test.ts
@@ -1,0 +1,183 @@
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+import { Bridgeable, bridgifyObject, makeLocalBridge } from 'yaob'
+
+import {
+  makeSyntheticDestinationWallet,
+  SYNTHETIC_WALLET_ID_PREFIX
+} from '../../src/core/swap/synthetic-wallet'
+import {
+  EdgeCurrencyConfig,
+  EdgeCurrencyInfo,
+  EdgeCurrencyWallet,
+  EdgeMemo,
+  EdgeSwapToAddressInfo,
+  EdgeSyntheticDestinationWallet,
+  EdgeToken,
+  EdgeTokenId,
+  EdgeTokenMap
+} from '../../src/index'
+
+// A real destination address the GUI would paste in:
+const PAYOUT_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678'
+const USDC_TOKEN_ID = 'a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+
+const usdcToken: EdgeToken = {
+  currencyCode: 'USDC',
+  displayName: 'USD Coin',
+  denominations: [{ name: 'USDC', multiplier: '1000000' }],
+  networkLocation: { contractAddress: `0x${USDC_TOKEN_ID}` }
+}
+const allTokens: EdgeTokenMap = { [USDC_TOKEN_ID]: usdcToken }
+
+const currencyInfo: EdgeCurrencyInfo = {
+  pluginId: 'ethereum',
+  currencyCode: 'ETH',
+  walletType: 'wallet:ethereum',
+  displayName: 'Ethereum',
+  denominations: [{ name: 'ETH', multiplier: '1000000000000000000' }]
+} as unknown as EdgeCurrencyInfo
+
+// Stand-in for the real, bridgeable `currencyConfig` the core already holds for
+// the destination plugin. Only the surface the synthetic wallet reads is needed.
+const currencyConfig = bridgifyObject({
+  currencyInfo,
+  allTokens
+}) as unknown as EdgeCurrencyConfig
+
+/**
+ * The shape the GUI sees across the bridge. It accepts ONLY the descriptor
+ * (plain data) and returns what a plugin-faithful consumer read off the
+ * core-built synthetic destination, plus the synthetic itself.
+ */
+interface ConsumerReads {
+  address: string
+  receiveAddress: string
+  tokenCurrencyCode: string | undefined
+  parentCurrencyCode: string
+  walletType: string
+  walletId: string
+}
+interface DestinationProof {
+  consumer: ConsumerReads
+  toWallet: EdgeCurrencyWallet
+}
+interface CoreSwapApi {
+  buildDestination: (
+    toAddressInfo: EdgeSwapToAddressInfo,
+    toTokenId: EdgeTokenId
+  ) => Promise<DestinationProof>
+}
+
+/**
+ * Mirrors the core side of the production GUI<->core bridge: it receives the
+ * descriptor plus the request's `toTokenId`, builds the synthetic destination,
+ * and runs a consumer that makes exactly the reads swap plugins make on
+ * `toWallet`. The destination token comes from the request, not the descriptor.
+ */
+class FakeCoreSwapApi extends Bridgeable<CoreSwapApi> implements CoreSwapApi {
+  async buildDestination(
+    toAddressInfo: EdgeSwapToAddressInfo,
+    toTokenId: EdgeTokenId
+  ): Promise<DestinationProof> {
+    const synthetic = makeSyntheticDestinationWallet(
+      currencyConfig,
+      toAddressInfo.toAddress,
+      toAddressInfo.toMemos
+    )
+
+    // Plugin-faithful consumer (runs core-side, by reference): the same reads
+    // `getAddress`, `getReceiveAddress`, `denominationToNative`, and the central
+    // plugins make on a destination wallet.
+    const addresses = await synthetic.getAddresses({ tokenId: null })
+    const receiveAddress = await synthetic.getReceiveAddress({ tokenId: null })
+    const token =
+      toTokenId != null
+        ? synthetic.currencyConfig.allTokens[toTokenId]
+        : undefined
+
+    const consumer: ConsumerReads = {
+      address: addresses[0].publicAddress,
+      receiveAddress: receiveAddress.publicAddress,
+      tokenCurrencyCode: token?.currencyCode,
+      parentCurrencyCode: synthetic.currencyInfo.currencyCode,
+      walletType: synthetic.type,
+      walletId: synthetic.id
+    }
+    return { consumer, toWallet: synthetic }
+  }
+}
+
+describe('synthetic destination wallet', function () {
+  // Same wire format edge-core-js uses in production (index.ts): a JSON
+  // round-trip on every message.
+  const guiApi: CoreSwapApi = makeLocalBridge(new FakeCoreSwapApi(), {
+    cloneMessage: message => JSON.parse(JSON.stringify(message))
+  })
+
+  it('builds a working destination from a descriptor across the bridge', async function () {
+    // The GUI passes ONLY the descriptor (plain data), the exact thing that
+    // crosses the bridge cleanly, unlike the Phase 1 GUI-built fake wallet.
+    const toAddressInfo: EdgeSwapToAddressInfo = {
+      toPluginId: 'ethereum',
+      toAddress: PAYOUT_ADDRESS
+    }
+    const proof = await guiApi.buildDestination(toAddressInfo, USDC_TOKEN_ID)
+
+    // The core-side consumer got a fully working destination:
+    expect(proof.consumer.address).equals(PAYOUT_ADDRESS)
+    expect(proof.consumer.receiveAddress).equals(PAYOUT_ADDRESS)
+    expect(proof.consumer.tokenCurrencyCode).equals('USDC')
+    expect(proof.consumer.parentCurrencyCode).equals('ETH')
+    expect(proof.consumer.walletType).equals('wallet:ethereum')
+    expect(proof.consumer.walletId).equals(
+      `${SYNTHETIC_WALLET_ID_PREFIX}ethereum`
+    )
+
+    // And the bridgified synthetic survives the trip back GUI-ward and is
+    // callable across the wire, the direct inverse of the Phase 1 failure,
+    // where the fake's function properties threw on argument unpack.
+    const guiAddresses = await proof.toWallet.getAddresses({ tokenId: null })
+    expect(guiAddresses[0].publicAddress).equals(PAYOUT_ADDRESS)
+  })
+
+  it('builds a parent-currency destination when toTokenId is null', async function () {
+    const proof = await guiApi.buildDestination(
+      {
+        toPluginId: 'ethereum',
+        toAddress: PAYOUT_ADDRESS
+      },
+      null
+    )
+
+    expect(proof.consumer.address).equals(PAYOUT_ADDRESS)
+    expect(proof.consumer.tokenCurrencyCode).equals(undefined)
+    expect(proof.consumer.parentCurrencyCode).equals('ETH')
+  })
+
+  it('exposes destination memos through getMemos across the bridge', async function () {
+    const toMemos: EdgeMemo[] = [{ type: 'number', value: '8675309' }]
+    const proof = await guiApi.buildDestination(
+      {
+        toPluginId: 'ethereum',
+        toAddress: PAYOUT_ADDRESS,
+        toMemos
+      },
+      null
+    )
+
+    // The synthetic exposes the descriptor's memos to plugin-side readers,
+    // and the method still works across the yaob wire format:
+    const synthetic = proof.toWallet as EdgeSyntheticDestinationWallet
+    expect(await synthetic.getMemos()).deep.equals(toMemos)
+  })
+
+  it('returns no memos when the descriptor has none', async function () {
+    const proof = await guiApi.buildDestination(
+      { toPluginId: 'ethereum', toAddress: PAYOUT_ADDRESS },
+      null
+    )
+    const synthetic = proof.toWallet as EdgeSyntheticDestinationWallet
+    expect(await synthetic.getMemos()).deep.equals([])
+  })
+})


### PR DESCRIPTION
### Technical Design Document

[stealth-send-swap.md](https://github.com/EdgeApp/edge-react-gui/blob/jon/stealth-send-swap/src/docs/stealth-send-swap.md)

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1216251688512498/f)

The core half of swap-to-address, which is what lets a swap target a pasted destination instead of a wallet the user holds. `EdgeSwapRequest` accepts an optional `toAddressInfo` descriptor as an alternative to `toWallet`, exactly one of the two required; the core builds a synthetic, bridgified destination wallet from it, backed by the real `currencyConfig`, so swap plugins receive an `EdgeCurrencyWallet` unchanged. Nothing Houdini-specific lives here: the same mechanism powers provider-agnostic send-to-any-asset, verified in-app with a ChangeNOW-routed cross-chain send.

Judgement calls, with their alternates:

- **Slim descriptor.** `EdgeSwapToAddressInfo` carries only `toPluginId`, `toAddress`, and optional `toMemos`. `toPluginId` selects the `currencyConfig` and is not derivable from the request; `toAddress` is the payload; the destination token comes from the request's own `toTokenId`. A descriptor also carrying `toTokenId` was rejected as a two-sources-of-truth hazard.
- **Destination memos ride `getMemos` on the synthetic wallet.** For memo-required payout chains such as an XRP destination tag, the descriptor's `toMemos` is only the GUI-to-core transport; plugins never read the descriptor. The synthetic wallet exposes `getMemos()` (`EdgeSyntheticDestinationWallet`), so the plugin-facing mechanism stays wallet-shaped and plugins keep one code path. Plugins reading a tag field off the descriptor was rejected to keep the plugin interface generic. A no-descriptor design is not available: the value has to cross the GUI-core bridge somewhere, and the descriptor is the plain-data channel that crosses yaob cleanly.
- **`EdgeTxActionSwap.payoutWalletId` and `EdgeTxSwap.payoutWalletId` are both optional.** A swap-to-address destination has no payout wallet; `payoutAddress` carries the destination. Making only the action type optional left a latent inconsistency in `EdgeTxSwap`. Keeping them required and writing the `synthetic://<pluginId>` id was rejected: it embeds fake wallet ids in persistent transaction metadata.
- **`EdgeTxActionSwap.swapType`** (`swapSend`, `stealthSend`, `stealthSwapSend`) names the send-shaped flows so a UI can title a transaction by the flow the user ran instead of inferring it. These stay swaps to every existing consumer, which a separate `actionType` would not; absent for a normal wallet-to-wallet swap.
- **`EdgeSwapRequest.privacy`.** `'required'` restricts a quote to routes that keep the sender unlinkable from the recipient, and a plugin that cannot offer one must decline rather than answer with a transparent route. A quote carries no route type back to the caller, so a silent downgrade would be undetectable; making the caller state its requirement puts the decision where the intent lives.
- **`EdgeSwapRequestOptions.forceEnabled`** lets a caller query named plugins the user switched off in their swap settings, because a private send is a send feature that happens to be powered by a swap provider. An explicit `disabled` entry still wins, so a caller that disables everything except one provider cannot have that restriction defeated.
- **Log privacy.** Both swap-quote logging paths redact the pasted destination address and the memo values, since a deposit tag can identify the recipient's exchange account.
- **The synthetic wallet is released by reference count.** It is bridgified, so yaob holds it in the account's object table until something closes it, and the caller reaches it through `quote.request.toWallet`. One wallet is built per `fetchSwapQuotes` call and shared by every quote that call returns, so it closes when the last of them closes, and immediately when none survives or all reject. Without that, every quote refresh on a swap-to-address screen left another wallet in the table for the life of the account. Closing it with the first quote was rejected: the other quotes from the same call still carry it.

The plugin-selection rule that `forceEnabled` and `disabled` encode is a named predicate (`isSwapPluginQueryable`) rather than an inline condition inside `fetchSwapQuotes`, with its full truth table under test. The corner that matters is exactly what a stealth send does in one call: every other plugin disabled, this one force-enabled.

**Testing.** 182 mocha tests pass (1 pending) on the branch rebased onto current master, `tsc` and eslint clean, `verify-repo.sh` PASSED. 12 of those tests are new: the yaob bridge-crossing proof covers descriptor-only construction, plugin-faithful reads, memo round-trip through `getMemos`, and the synthetic wallet surviving the wire format back to the GUI; the plugin-selection truth table covers all eight flag combinations; two more cover the synthetic wallet's release, including a double-close that must not free it twice. In-app, linked into edge-react-gui with the Stealth Send UI: a real cross-chain send-to-address executed on the iOS simulator through this mechanism, deposit broadcast on chain, swap success scene reached.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public swap request shape and payout metadata (optional `payoutWalletId`), and introduces synthetic wallets on the quote path; swap plugins are unchanged but GUIs must handle new fields and redacted logging expectations.
> 
> **Overview**
> Adds **swap-to-address**: `EdgeSwapRequest` can use `toAddressInfo` (`toPluginId`, pasted `toAddress`, optional `toMemos`) instead of `toWallet`, with exactly one required. `fetchSwapQuotes` resolves this via `resolveSwapRequest`, building a **bridgified synthetic destination wallet** (`makeSyntheticDestinationWallet`) backed by the account’s real `currencyConfig` so swap plugins still see a normal `toWallet` (including optional `getMemos` on `EdgeSyntheticDestinationWallet`).
> 
> **Quote aggregation** gains `EdgeSwapRequestOptions.forceEnabled` and `isSwapPluginQueryable` (`disabled` beats `forceEnabled`). Swap quote logging **redacts** pasted addresses and memo values. `EdgeSwapRequest.privacy: 'required'` is typed for callers that must not get a silent transparent route.
> 
> **Transaction metadata types** add optional `swapType` on `EdgeTxActionSwap` (`swapSend`, `stealthSend`, `stealthSwapSend`) and make `payoutWalletId` optional on `EdgeTxActionSwap` and `EdgeTxSwap` when the payout is address-only. On-disk cleaners and `SwapCurrencyError` are updated for optional `toWallet` / `toAddressInfo`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c914c859caac4e3d57f2dcd86bdb0479256a308e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- agent-test-evidence:start -->
### Test evidence

<table>
<tr>
<td rowspan="1" width="170" valign="top"><a href="https://github.com/EdgeApp/edge-core-js/pull/730/commits/24613ad19d7d8debf4598653679fecfb05ee839e"><code>24613ad</code></a><br><sub>Add swap route-privacy and force-enabled request options</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-core-js/pr-730/20260702-200724-agent-proof-1216251688512498-03-send-to-any-quote.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-core-js/pr-730/20260702-200724-agent-proof-1216251688512498-03-send-to-any-quote.png" width="200"></a><br><sub>agent proof 1216251688512498 03 send to any quote</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-core-js/pr-730/20260702-200724-agent-proof-1216251688512498-04-send-to-any-success.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-core-js/pr-730/20260702-200724-agent-proof-1216251688512498-04-send-to-any-success.png" width="200"></a><br><sub>agent proof 1216251688512498 04 send to any success</sub></td>
<td width="210"></td>
</tr>
</table>
<!-- agent-test-evidence:end -->