### PR TITLE
Restore per-request and handshake timeouts for NYM mixnet fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Impose the NYM per-request timeout in our own wrapper as well as mix-fetch's, so a mixnet request whose exit connection stalls rejects and fails over to the next server instead of leaving a wallet stuck on "Calculating Fee" when mix-fetch's own `requestTimeoutMs` does not fire.
+
 ## 2.47.1 (2026-07-17)
 
 - fixed: Revert `@nymproject/mix-fetch` to v1 (1.4.4), restoring the pinned gateway and network requester. The v2 stack shipped in 2.47.0 fails to complete small HTTPS JSON-RPC requests through most exit nodes and its exit-node auto-discovery rarely converges, which left wallets with NYM privacy enabled unable to sync or send.

--- a/src/util/nym.ts
+++ b/src/util/nym.ts
@@ -9,6 +9,20 @@ import {
 import { EdgeLog } from '../types/types'
 
 /**
+ * Per-request budget for a NYM mixnet fetch.
+ *
+ * mix-fetch's own `requestTimeoutMs` (below) is meant to bound each request,
+ * but a request whose exit connection stalls (a blocked port, an unresponsive
+ * host, a half-open TCP stream) has been observed hanging past it: David Coen's
+ * 2026-07-20 staging report showed Coreum/Avalanche sends sitting on
+ * "Calculating Fee" indefinitely with NYM on, even after the v1 revert. So we
+ * also impose the same budget ourselves in `fetchWithTimeout`, which guarantees
+ * the promise rejects on our side and lets an engine fail over to its next
+ * server instead of awaiting the request forever.
+ */
+const REQUEST_TIMEOUT_MS = 300000
+
+/**
  * Configuration options for the NYM mixFetch client.
  */
 export const mixFetchOptions: SetupMixFetchOps = {
@@ -18,7 +32,43 @@ export const mixFetchOptions: SetupMixFetchOps = {
     '5x6q9UfVHs5AohKMUqeivj7a556kVVy7QwoKige8xHxh.6CFoB3kJaDbYz6oafPJxNxNjzahpT2NtgtytcSyN9EvF@5rXcNe2a44vXisK3uqLHCzpzvEwcnsijDMU7hg4fcYk8',
   forceTls: true, // force WSS
   mixFetchOverride: {
-    requestTimeoutMs: 300000
+    requestTimeoutMs: REQUEST_TIMEOUT_MS
+  }
+}
+
+/**
+ * Impose `REQUEST_TIMEOUT_MS` on a single mixFetch call.
+ *
+ * This bounds how long *we* wait; it cannot cancel the in-flight wasm request,
+ * which takes no abort signal. That is enough for the caller: a rejected fetch
+ * lets an engine mark the server bad and move to the next one, which is what a
+ * working `requestTimeoutMs` would have bought us. Keeps v1's 3-arg
+ * `IMixFetchFn` signature so callers are unchanged.
+ */
+async function fetchWithTimeout(
+  mixFetch: IMixFetchFn,
+  url: string,
+  args: any,
+  opts?: SetupMixFetchOps
+): Promise<Response> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new Error(`mixFetch request timed out after ${REQUEST_TIMEOUT_MS}ms`)
+      )
+    }, REQUEST_TIMEOUT_MS)
+  })
+  const request = mixFetch(url, args, opts)
+  // Once the timer wins the race nothing is awaiting `request` any more, so a
+  // late rejection would surface as an unhandled rejection in the worker. The
+  // caller already has its timeout error and the response is worthless by now,
+  // so swallowing it here is the whole handling this needs.
+  request.catch(() => {})
+  try {
+    return await Promise.race([request, timeout])
+  } finally {
+    clearTimeout(timer)
   }
 }
 
@@ -81,5 +131,7 @@ export async function initMixFetch(log: EdgeLog): Promise<IMixFetchFn> {
       })
   }
   const mixFetchModule = await mixFetchInitPromise
-  return mixFetchModule.mixFetch
+  const { mixFetch } = mixFetchModule
+  return async (url, args, opts) =>
+    await fetchWithTimeout(mixFetch, url, args, opts)
 }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Asana: https://app.asana.com/1/9976422036640/project/1215088146871429/task/1216608079766867

Restores an explicit per-request timeout on NYM mixnet fetches, re-expressed on the v1 (`@nymproject/mix-fetch@1.4.4`) stack that `master` reverted to in 2.47.1.

#### Background

This PR was originally authored against the v2 mix-fetch upgrade (base 2.47.0). That upgrade was reverted to v1 in [#732](https://github.com/EdgeApp/edge-core-js/pull/732), so the branch has been reset onto the current v1 `master` and the change re-expressed for the v1 API. The v1 revert already re-applied the 60s handshake bound (`SETUP_TIMEOUT_MS`, commit `a323e15f`), so the remaining piece is the per-request side.

#### What this changes

`mixFetchOptions.mixFetchOverride.requestTimeoutMs` (300000) asks mix-fetch to bound each request, but a request whose exit connection stalls has been observed hanging past it. David Coen's 2026-07-20 staging report (26071707, Android) showed Coreum/Avalanche sends sitting on "Calculating Fee" indefinitely with NYM on, *after* the v1 revert landed. This wraps each `mixFetch` call in our own `REQUEST_TIMEOUT_MS` race (`fetchWithTimeout`), so the promise rejects on **our** side once the budget elapses and an engine can fail over to its next server instead of awaiting the request forever. The wrapper keeps v1's 3-arg `IMixFetchFn` signature, so call sites are unchanged, and swallows the abandoned request's late rejection so it does not surface as an unhandled rejection in the worker.

The value stays at 300000 to match the native `requestTimeoutMs` it backstops. Reducing that budget (5 minutes still reads as a stuck spinner) is separate scope handled in [#734](https://github.com/EdgeApp/edge-core-js/pull/734) (task 1216729024836433), which also adds concurrency bounds and per-request logging; the two touch the same file and whichever lands second reconciles.

#### Testing

- `tsc --noEmit` clean; `mocha` suite green (162 passing).
- Built the change into the RN worker bundle, `updot`-linked into edge-react-gui, and force-rebuilt the iOS sim app (verified the installed `edge-core-js.bundle/edge-core.js` carries the wrapper).
- In-app on the iOS sim (edge-funds): with NYM enabled (Avalanche + Base), the core log shows `mixFetch initialized successfully` through the wrapped `initMixFetch` on every launch; drove a live Ethereum NYM toggle (`Network privacy for ethereum: nym`) and reverted it. Wallets sync normally through the wrapper with no spurious timeout and no regression.
- Not reproducible here: an actual per-request timeout firing needs a stalled/dead exit connection on demand. The wrapper is transparent on the success path; the rejection path is covered by logic + the suite's `fuzzyTimeout` tests. Screenshots attached.
