### PR TITLE
Log NYM mixFetch request lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - added: Log the lifecycle of every NYM mixnet request (method, host, path, duration, HTTP status or error, and in-flight count), plus mixFetch setup timing. A request that logs a start with no terminal line identifies the host whose request never returned, which the previous logging could not attribute. These log at `warn` so they survive the default `warn` log level and appear in a log export without the user first enabling verbose logging.
+- changed: Bound NYM mixnet requests to 6 concurrent overall and 2 per host. A single Avalanche wallet was measured opening 12 concurrent mixnet requests during one sync, and a full wallet list multiplies that; mix-fetch v1 has a history of serving one request per host at a time.
+- fixed: Reduce the NYM per-request timeout from 300 seconds to 60. At five minutes, a request the mixnet never answered held the send screen on "Calculating Fee" long enough to read as a permanent hang rather than an error.
 
 ## 2.47.1 (2026-07-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: Log the lifecycle of every NYM mixnet request (method, host, path, duration, HTTP status or error, and in-flight count), plus mixFetch setup timing. A request that logs a start with no terminal line identifies the host whose request never returned, which the previous logging could not attribute. These log at `warn` so they survive the default `warn` log level and appear in a log export without the user first enabling verbose logging.
+
 ## 2.47.1 (2026-07-17)
 
 - fixed: Revert `@nymproject/mix-fetch` to v1 (1.4.4), restoring the pinned gateway and network requester. The v2 stack shipped in 2.47.0 fails to complete small HTTPS JSON-RPC requests through most exit nodes and its exit-node auto-discovery rarely converges, which left wallets with NYM privacy enabled unable to sync or send.

--- a/src/io/browser/browser-io.ts
+++ b/src/io/browser/browser-io.ts
@@ -3,7 +3,7 @@ import { makeLocalStorageDisklet } from 'disklet'
 import { LogBackend, makeLog } from '../../core/log/log'
 import { EdgeFetchOptions, EdgeFetchResponse, EdgeIo } from '../../types/types'
 import { scrypt } from '../../util/crypto/scrypt'
-import { initMixFetch, mixFetchOptions } from '../../util/nym'
+import { nymFetch } from '../../util/nym'
 import { fetchCorsProxy } from './fetch-cors-proxy'
 
 // Only try CORS proxy/bridge techniques up to 5 times
@@ -49,15 +49,7 @@ export function makeBrowserIo(logBackend: LogBackend): EdgeIo {
       const { corsBypass = 'auto', privacy = 'none' } = opts ?? {}
 
       if (privacy === 'nym') {
-        const nymFetch = await initMixFetch(log)
-        return await nymFetch(
-          uri,
-          {
-            ...opts,
-            mode: 'unsafe-ignore-cors' as RequestMode
-          },
-          mixFetchOptions
-        )
+        return await nymFetch(uri, opts ?? {}, log)
       }
       if (corsBypass === 'always') {
         return await fetchCorsProxy(uri, opts)

--- a/src/io/react-native/react-native-worker.ts
+++ b/src/io/react-native/react-native-worker.ts
@@ -17,7 +17,7 @@ import {
   EdgeFetchResponse,
   EdgeIo
 } from '../../types/types'
-import { initMixFetch, mixFetchOptions } from '../../util/nym'
+import { nymFetch } from '../../util/nym'
 import { hideProperties } from '../hidden-properties'
 import { makeNativeBridge } from './native-bridge'
 import { WorkerApi, YAOB_THROTTLE_MS } from './react-native-types'
@@ -176,16 +176,7 @@ async function makeIo(logBackend: LogBackend): Promise<EdgeIo> {
       const { corsBypass = 'auto', privacy = 'none' } = opts ?? {}
 
       if (privacy === 'nym') {
-        const nymFetch = await initMixFetch(log)
-        const response = await nymFetch(
-          uri,
-          {
-            ...opts,
-            mode: 'unsafe-ignore-cors' as RequestMode
-          },
-          mixFetchOptions
-        )
-        return response
+        return await nymFetch(uri, opts ?? {}, log)
       }
       if (corsBypass === 'always') {
         return await nativeFetch(uri, opts)

--- a/src/util/nym.ts
+++ b/src/util/nym.ts
@@ -18,9 +18,39 @@ export const mixFetchOptions: SetupMixFetchOps = {
     '5x6q9UfVHs5AohKMUqeivj7a556kVVy7QwoKige8xHxh.6CFoB3kJaDbYz6oafPJxNxNjzahpT2NtgtytcSyN9EvF@5rXcNe2a44vXisK3uqLHCzpzvEwcnsijDMU7hg4fcYk8',
   forceTls: true, // force WSS
   mixFetchOverride: {
-    requestTimeoutMs: 300000
+    // A healthy mixnet request measures 2-4 seconds. The previous 300000 (5
+    // minutes) meant any request the mixnet never answered held its caller for
+    // five minutes, which on the send screen reads as a permanently stuck
+    // "Calculating Fee" spinner rather than an error.
+    requestTimeoutMs: 60000
   }
 }
+
+/**
+ * Ceilings on how many requests are in the mixnet at once.
+ *
+ * mix-fetch v1 historically served one request per host at a time, which this
+ * module used to work around with a per-host queue. That queue was removed in
+ * 5916d9d2 on the understanding that 1.4.2 had fixed the limitation. Measured
+ * on an Android emulator, a single Avalanche wallet still opens 12 concurrent
+ * requests during one sync, and a wallet list the size of a real user's
+ * multiplies that. Bounding it keeps the tunnel inside a regime we have
+ * actually observed working, at a negligible cost given each request already
+ * takes seconds.
+ */
+const MAX_IN_FLIGHT_TOTAL = 6
+const MAX_IN_FLIGHT_PER_HOST = 2
+
+/**
+ * How long a request will wait for a slot before going anyway.
+ *
+ * The ceilings above are smoothing, not an invariant worth stalling on. If
+ * every slot is held by a request that will not answer, an unbounded queue
+ * would add its own multi-minute delay on top of the per-request timeout and
+ * recreate exactly the stuck "Calculating Fee" this change exists to prevent.
+ * Past this deadline the request proceeds and the log says it did.
+ */
+const MAX_QUEUE_WAIT_MS = 10000
 
 /**
  * Budget for `createMixFetch` itself (client start + gateway handshake).
@@ -43,13 +73,102 @@ let inFlightCount = 0
 // Distinguishes concurrent requests to the same host in the log.
 let requestCounter = 0
 
+// Requests waiting on a concurrency slot, oldest first.
+const waiting: Array<() => void> = []
+
+// In-flight count per host key, for the per-host ceiling.
+const hostInFlight = new Map<string, number>()
+
 /**
- * A path segment that is long and unbroken enough to be an identifier rather
- * than a route: an address, a txid, a public key, or an API key. Real route
- * segments in the endpoints we call (`ext`, `bc`, `C`, `rpc`, `v2`, `api`,
- * `get_address_info`) are short, or contain separators, or both.
+ * The `host:port` a request will actually open, used to key the per-host
+ * ceiling. Falls back to the raw uri so an unparsable one still gets queued
+ * rather than bypassing the limit.
  */
-const IDENTIFIER_SEGMENT = /^(0x)?[0-9a-zA-Z]{20,}$/
+function getHostKey(uri: string): string {
+  try {
+    const url = new URL(uri)
+    const port =
+      url.port !== '' ? url.port : url.protocol === 'https:' ? '443' : '80'
+    return `${url.hostname}:${port}`
+  } catch (error: unknown) {
+    return uri
+  }
+}
+
+function hasSlot(hostKey: string): boolean {
+  return (
+    inFlightCount < MAX_IN_FLIGHT_TOTAL &&
+    (hostInFlight.get(hostKey) ?? 0) < MAX_IN_FLIGHT_PER_HOST
+  )
+}
+
+/**
+ * Wait until this request is allowed into the mixnet, then reserve its slot.
+ *
+ * Returns true when the slot was granted by the ceilings, false when the
+ * deadline elapsed first and the request is proceeding regardless. The slot is
+ * reserved either way, so the counters stay honest.
+ */
+async function acquireSlot(hostKey: string): Promise<boolean> {
+  const deadline = Date.now() + MAX_QUEUE_WAIT_MS
+  let granted = true
+
+  while (!hasSlot(hostKey)) {
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) {
+      granted = false
+      break
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let wake: () => void = () => {}
+    await new Promise<void>(resolve => {
+      wake = resolve
+      waiting.push(resolve)
+      timer = setTimeout(resolve, remaining)
+    })
+    clearTimeout(timer)
+    // Drop our own resolver. `releaseSlot` drains the whole array, so this
+    // only matters when the deadline fired instead: without it, a stretch
+    // where nothing settles (exactly the case being diagnosed) would grow
+    // `waiting` without bound, since nothing else ever clears it.
+    const index = waiting.indexOf(wake)
+    if (index !== -1) waiting.splice(index, 1)
+  }
+
+  inFlightCount += 1
+  hostInFlight.set(hostKey, (hostInFlight.get(hostKey) ?? 0) + 1)
+  return granted
+}
+
+/**
+ * Release this request's slot and wake everyone waiting.
+ *
+ * Every waiter re-checks its own host ceiling in `acquireSlot`, so waking all
+ * of them is correct: the ones still blocked simply queue again. Waking only
+ * the head would stall the queue whenever the head is blocked on a busy host
+ * while a slot for some other host just came free.
+ */
+function releaseSlot(hostKey: string): void {
+  inFlightCount -= 1
+  const remaining = (hostInFlight.get(hostKey) ?? 1) - 1
+  if (remaining <= 0) hostInFlight.delete(hostKey)
+  else hostInFlight.set(hostKey, remaining)
+
+  const woken = waiting.splice(0, waiting.length)
+  for (const wake of woken) wake()
+}
+
+/**
+ * A path segment long enough to be an identifier rather than a route: an
+ * address, a txid, a public key, or an API key.
+ *
+ * Length is what separates the two, not character set. Route segments in the
+ * endpoints we call are short (`ext`, `bc`, `C`, `rpc`, `v2`, `api`, the
+ * 16-character `get_address_info`), while identifiers run 26 characters and up.
+ * The separator classes matter: hyphens for UUIDs, a colon for cashaddr-style
+ * `prefix:address`, underscores and dots for the rest.
+ */
+const IDENTIFIER_SEGMENT = /^[0-9a-zA-Z][0-9a-zA-Z._:-]{19,}$/
 
 /**
  * Reduce a request URI to the part that is safe to write to a user's log.
@@ -78,20 +197,40 @@ function describeUri(uri: string): string {
 }
 
 /**
+ * Reduce any URL embedded in free text the same way `describeUri` reduces the
+ * request target.
+ *
+ * Error messages from the fetch and Go layers routinely quote the whole
+ * request URL (`Post "https://host/tx/<txid>?apikey=...": context deadline
+ * exceeded`). Running them through the same reducer keeps one rule for what
+ * may reach a support log, so an identifier masked in the request label cannot
+ * reappear intact in the error text on the very same line.
+ */
+function redactUrlsInText(text: string): string {
+  return text.replace(/https?:\/\/[^\s"'<>]+/g, url => {
+    // Trailing punctuation belongs to the sentence, not the URL.
+    const trimmed = url.replace(/[.,:;!?)\]}]+$/, '')
+    return describeUri(trimmed) + url.slice(trimmed.length)
+  })
+}
+
+/**
  * Render an error for the log, preferring the raw message.
  *
  * The mix-fetch v1 Go layer surfaces failures as opaque strings such as
  * `panic:todo: extract error message`, where the real reason is discarded
  * inside the library. Keeping the message verbatim is what makes those
- * reports attributable to a specific host.
+ * reports attributable to a specific host, so the text is preserved apart
+ * from query strings, which are the part that carries credentials.
  */
 function describeError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.name === 'Error'
-      ? error.message
-      : `${error.name}: ${error.message}`
-  }
-  return String(error)
+  const text =
+    error instanceof Error
+      ? error.name === 'Error'
+        ? error.message
+        : `${error.name}: ${error.message}`
+      : String(error)
+  return redactUrlsInText(text)
 }
 
 /**
@@ -176,8 +315,26 @@ export async function nymFetch(
   const method = opts.method ?? 'GET'
   const label = `mixFetch #${id} ${method} ${target}`
 
+  const hostKey = getHostKey(uri)
+  const queuedAt = Date.now()
+  const granted = await acquireSlot(hostKey)
+  const queuedMs = Date.now() - queuedAt
+
   const start = Date.now()
-  log.warn(`${label} start (${++inFlightCount} in flight)`)
+  const queueNote =
+    queuedMs === 0
+      ? ''
+      : granted
+      ? `, queued ${queuedMs}ms`
+      : `, queued ${queuedMs}ms then went over the limit`
+  log.warn(`${label} start (${inFlightCount} in flight${queueNote})`)
+  let released = false
+  const release = (): void => {
+    if (released) return
+    released = true
+    releaseSlot(hostKey)
+  }
+
   try {
     const response = await mixFetch(
       uri,
@@ -187,17 +344,19 @@ export async function nymFetch(
       },
       mixFetchOptions
     )
+    release()
     log.warn(
       `${label} -> ${response.status} in ${
         Date.now() - start
-      }ms (${--inFlightCount} in flight)`
+      }ms (${inFlightCount} in flight)`
     )
     return response
   } catch (error: unknown) {
+    release()
     log.error(
       `${label} failed after ${
         Date.now() - start
-      }ms (${--inFlightCount} in flight): ${describeError(error)}`
+      }ms (${inFlightCount} in flight): ${describeError(error)}`
     )
     throw error
   }

--- a/src/util/nym.ts
+++ b/src/util/nym.ts
@@ -6,7 +6,7 @@ import {
   SetupMixFetchOps
 } from '@nymproject/mix-fetch'
 
-import { EdgeLog } from '../types/types'
+import { EdgeFetchOptions, EdgeFetchResponse, EdgeLog } from '../types/types'
 
 /**
  * Configuration options for the NYM mixFetch client.
@@ -35,13 +35,73 @@ const SETUP_TIMEOUT_MS = 60000
 // MixFetch initialization state
 let mixFetchInitPromise: Promise<IMixFetch> | null = null
 
+// Number of mixnet requests currently awaiting a response. Reported on every
+// request line, since a request that never settles is only visible as a count
+// that never comes back down.
+let inFlightCount = 0
+
+// Distinguishes concurrent requests to the same host in the log.
+let requestCounter = 0
+
+/**
+ * A path segment that is long and unbroken enough to be an identifier rather
+ * than a route: an address, a txid, a public key, or an API key. Real route
+ * segments in the endpoints we call (`ext`, `bc`, `C`, `rpc`, `v2`, `api`,
+ * `get_address_info`) are short, or contain separators, or both.
+ */
+const IDENTIFIER_SEGMENT = /^(0x)?[0-9a-zA-Z]{20,}$/
+
+/**
+ * Reduce a request URI to the part that is safe to write to a user's log.
+ *
+ * Query strings are dropped entirely because RPC endpoints carry API keys
+ * there. The path is kept, because two endpoints on one host are often
+ * different routes and telling them apart is the point of this logging, but
+ * any segment that looks like an identifier is masked: several chains put a
+ * wallet address or txid directly in the path, and these lines end up in
+ * user-uploaded support logs.
+ */
+function describeUri(uri: string): string {
+  try {
+    const { host, pathname } = new URL(uri)
+    if (pathname === '/') return host
+    const safePath = pathname
+      .split('/')
+      .map(segment =>
+        IDENTIFIER_SEGMENT.test(segment) ? '<redacted>' : segment
+      )
+      .join('/')
+    return `${host}${safePath}`
+  } catch (error: unknown) {
+    return '<unparsable uri>'
+  }
+}
+
+/**
+ * Render an error for the log, preferring the raw message.
+ *
+ * The mix-fetch v1 Go layer surfaces failures as opaque strings such as
+ * `panic:todo: extract error message`, where the real reason is discarded
+ * inside the library. Keeping the message verbatim is what makes those
+ * reports attributable to a specific host.
+ */
+function describeError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.name === 'Error'
+      ? error.message
+      : `${error.name}: ${error.message}`
+  }
+  return String(error)
+}
+
 /**
  * Initialize the NYM mixFetch client. Must be called before using mixFetch.
  * Safe to call multiple times - subsequent calls return the same promise.
  */
 export async function initMixFetch(log: EdgeLog): Promise<IMixFetchFn> {
   if (mixFetchInitPromise == null) {
-    log('Initializing mixFetch...')
+    log.warn('Initializing mixFetch...')
+    const setupStart = Date.now()
     const pending = createMixFetch(mixFetchOptions)
     // The timeout below can abandon this setup while it is still in flight.
     // Deliberately do NOT tear it down on late completion: `createMixFetch`
@@ -60,7 +120,9 @@ export async function initMixFetch(log: EdgeLog): Promise<IMixFetchFn> {
     })
     mixFetchInitPromise = Promise.race([pending, timeout])
       .then(mixFetchModule => {
-        log('mixFetch initialized successfully')
+        log.warn(
+          `mixFetch initialized successfully in ${Date.now() - setupStart}ms`
+        )
         return mixFetchModule
       })
       .catch(async error => {
@@ -73,7 +135,11 @@ export async function initMixFetch(log: EdgeLog): Promise<IMixFetchFn> {
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
         delete (window as any).__mixFetchGlobal
         mixFetchInitPromise = null
-        log.error('mixFetch initialization failed:', error)
+        log.error(
+          `mixFetch initialization failed after ${
+            Date.now() - setupStart
+          }ms: ${describeError(error)}`
+        )
         throw error
       })
       .finally(() => {
@@ -82,4 +148,57 @@ export async function initMixFetch(log: EdgeLog): Promise<IMixFetchFn> {
   }
   const mixFetchModule = await mixFetchInitPromise
   return mixFetchModule.mixFetch
+}
+
+/**
+ * Perform a single request over the NYM mixnet, logging its lifecycle.
+ *
+ * Every request writes a `start` line before it goes out and exactly one
+ * terminal line when it settles. A request that produces a `start` with no
+ * terminal line is one that never came back, which is the shape we cannot
+ * currently attribute to a host, and the reason this instrumentation exists.
+ *
+ * These go out at `warn` rather than `info` deliberately. The app configures
+ * the core with `defaultLogLevel: 'warn'`, so `info` is dropped unless the
+ * user has turned on Verbose Logging, and a QA log export would arrive with
+ * none of this in it. NYM is opt-in and low volume, so the extra lines only
+ * appear for the users whose reports we are trying to diagnose.
+ */
+export async function nymFetch(
+  uri: string,
+  opts: EdgeFetchOptions,
+  log: EdgeLog
+): Promise<EdgeFetchResponse> {
+  const mixFetch = await initMixFetch(log)
+
+  const id = ++requestCounter
+  const target = describeUri(uri)
+  const method = opts.method ?? 'GET'
+  const label = `mixFetch #${id} ${method} ${target}`
+
+  const start = Date.now()
+  log.warn(`${label} start (${++inFlightCount} in flight)`)
+  try {
+    const response = await mixFetch(
+      uri,
+      {
+        ...opts,
+        mode: 'unsafe-ignore-cors' as RequestMode
+      },
+      mixFetchOptions
+    )
+    log.warn(
+      `${label} -> ${response.status} in ${
+        Date.now() - start
+      }ms (${--inFlightCount} in flight)`
+    )
+    return response
+  } catch (error: unknown) {
+    log.error(
+      `${label} failed after ${
+        Date.now() - start
+      }ms (${--inFlightCount} in flight): ${describeError(error)}`
+    )
+    throw error
+  }
 }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Asana: https://app.asana.com/1/9976422036640/project/1215088146871429/task/1216729024836433

QA reported on 2026-07-20 (staging 26071707, Android) that with NYM privacy on,
Coreum and Avalanche sends sit on "Calculating Fee" indefinitely. That report is
*after* the v1 revert landed, so the revert did not resolve it.

The exported logs attached to the QA task show the failure but not its cause:

```
avalanche-me: syncNetwork failed with unknown error: Error panic:todo: extract error message
coreum-U/:    queryTransactions error: Error: panic:todo: extract error message
<every EVM chain>: Error fetching fees from Info Server
```

`panic:todo: extract error message` is a placeholder emitted by mix-fetch v1's Go
layer, which discards the real reason. Our own logging covered only mixFetch
*setup*, so there was no way to tie a wedged request to a host or endpoint.

This adds per-request instrumentation. Each mixnet request writes one line on the
way out and exactly one when it settles:

```
mixFetch #1411 POST api.avax.network/ext/bc/C/rpc start (20 in flight)
mixFetch #1411 POST api.avax.network/ext/bc/C/rpc -> 200 in 2442ms (15 in flight)
mixFetch #1407 POST lb.drpc.org/ogrpc -> 403 in 3829ms (14 in flight)
```

A `start` line with no matching terminal line is now the signature of a request
that never returned, and it names the host.

These lines end up in user-uploaded support logs, so the URI is reduced first:
the query string is dropped entirely (RPC endpoints carry API keys there), and
any path segment that looks like an identifier is masked. Route paths survive
(`api.avax.network/ext/bc/C/rpc`, `monerolws1.edge.app/get_address_info`) while
addresses and txids do not (`blockbook.example.com/api/v2/address/<redacted>`).

Two details worth calling out:

- **These log at `warn`, not `info`.** The app configures the core with
  `defaultLogLevel: 'warn'`, and `filterLogs` drops `info` at that level, so an
  `info` line would be missing from a QA log export unless the tester had first
  enabled Verbose Logging. `warn` is what makes this reach the export by default.
  NYM is opt-in and low volume, so the extra lines only appear for the users whose
  reports we are diagnosing.
- Both io backends now share one wrapper, so the browser A/B harness and the app
  produce the same log shape.

No mixnet behavior changes: no timeout, pinning, or transport changes. This is
instrumentation for the next QA retest.

#### Verified

Driven on the iOS sim with NYM enabled for Avalanche and Base, against the live
mixnet, with this core `updot`-linked into the app. Captured from the running
app's console pipeline:

```
mixFetch #1397 POST lb.drpc.org/ogrpc -> 403 in 2977ms (18 in flight)
mixFetch #1410 POST base-rpc.publicnode.com start (19 in flight)
mixFetch #1387 POST base.api.pocket.network -> 200 in 4510ms (19 in flight)
mixFetch #1393 POST api.avax.network/ext/bc/C/rpc -> 200 in 4130ms (17 in flight)
mixFetch #1403 GET  api.etherscan.io/v2/api -> 200 in 3174ms (14 in flight)
```

`verify-repo.sh` passed (prepare, eslint, jest).

#### Already surfacing something

The in-flight counter reached **20 concurrent mixnet requests**, including four
simultaneous requests to the same host (`base-rpc.publicnode.com`). mix-fetch v1
carried a one-request-per-host limitation that this repo used to work around with
a per-host queue, removed in 5916d9d2 on the grounds that 1.4.2 fixed it. That
saturation is worth a look as a candidate mechanism for the Android wedge, on a
slower device with more wallets enabled. Not addressed here.

Avalanche completed normally over NYM on iOS throughout (2-4s per request), which
matches QA's own iOS result and is why the Android-only report needs logs from an
Android build to go further.

---

## Update: Android emulator findings, and a fix

Ran this on a deliberately throttled Android emulator (2 cores, 2 GB, `-netdelay umts`,
API 36) with a fresh account and one Avalanche wallet, against the live mixnet. The logging
above localized the failure on its first run.

#### The panic is host-specific, not random

3 of 3 requests to `api.avascan.info` panicked in ~1s. Every other host settled normally:

```
mixFetch #10 GET api.avascan.info/v2/network/mainnet/evm/43114/etherscan/api failed after 938ms: panic:todo: extract error message
mixFetch #12 GET api.avascan.info/... failed after 1102ms: panic:todo: extract error message
mixFetch #18 GET api.avascan.info/... failed after 1011ms: panic:todo: extract error message
```

Across 32 requests: 29 settled OK (p50 2666ms), 3 failed, **0 never settled**. `api.avascan.info`
is the etherscan-compatible transaction-history endpoint for Avalanche, which matches QA's
`avalanche-me: syncNetwork failed ... panic:todo` exactly. The panic originates inside NYM's Go
layer and is not something this wrapper can fix; it is now at least attributable to a host.

#### "Error fetching fees from Info Server" is a red herring

```
mixFetch #4 GET info1.edge.app/v1/networkFees/avalanche -> 404 in 2868ms
mixFetch #1 GET info2.edge.app/v1/networkFees/avalanche -> 404 in 3120ms
```

Those are plain 404s from the info server, not a NYM failure. That log line appears on every EVM
chain in QA's report and is unrelated to the mixnet.

#### What this commit changes

A single Avalanche wallet peaked at **12 concurrent** mixnet requests. A real user's wallet list
multiplies that, and the app already warns that enabling NYM on multiple assets slows sends. So:

- cap the mixnet at 6 concurrent overall, 2 per host, queueing the rest
- drop the per-request timeout from 300s to 60s, since a 5-minute ceiling is what turns an
  unanswered request into an apparently permanent "Calculating Fee" spinner

Measured before/after on the same emulator, live mixnet:

| | before | after |
|---|---|---|
| peak in-flight | 12 | 6 |
| p50 latency | 2666ms | 2669ms |
| never-settled | 0 | 0 |

Queue waits up to 2.1s are now logged (`queued 2106ms`) so throttling is distinguishable from
network time. `verify-repo.sh` passes (prepare, eslint, jest 162 passing).

#### Honest scope

The QA wedge itself did **not** reproduce here: with one wallet, every request settled and
in-flight always drained to zero. These two changes are targeted mitigation for the mechanisms
that can produce the reported symptom, not a confirmed fix for it. The logging is retained
precisely so the next QA build says which host wedges if it happens again.

#### Review hardening

Four rounds of reviewer-bot findings were taken (one rejected, see below). Beyond the two
changes above, this PR now also:

- bounds the queue itself at 10s (`MAX_QUEUE_WAIT_MS`), past which a request proceeds anyway.
  Without it, a starved queue would have added its own multi-minute delay on top of the request
  timeout and recreated the very hang this targets
- removes each waiter's resolver after its race settles, so a stretch where nothing settles
  cannot grow the wait list without bound
- routes error text through the same URI reducer as the request label, so a URL quoted inside an
  error (`Post "https://host/tx/<txid>?apikey=..."`) cannot reintroduce an identifier or key that
  was masked a few characters earlier on the same line
- broadens identifier masking to cover separator-bearing forms (UUIDs, cashaddr)

Final state on device, same emulator, running exactly this commit:

```
mixFetch #10 GET api.avascan.info/v2/network/mainnet/evm/43114/etherscan/api failed after 905ms (5 in flight): panic:todo: extract error message
```

peak in-flight 6, p50 2718ms, 0 never-settled, 162 unit tests passing.
