### PR TITLE
Save a transaction secret reported after the file exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Save a transaction secret an engine reports after the transaction's metadata file already exists. The secret was only ever written when a transaction was first seen, so a key an engine learned later was dropped, and there was no way to restore one for a transaction already on file.
+
 ## 2.47.1 (2026-07-17)
 
 - fixed: Revert `@nymproject/mix-fetch` to v1 (1.4.4), restoring the pinned gateway and network requester. The v2 stack shipped in 2.47.0 fails to complete small HTTPS JSON-RPC requests through most exit nodes and its exit-node auto-discovery rarely converges, which left wallets with NYM privacy enabled unable to sync or send.

--- a/src/core/currency/wallet/currency-wallet-callbacks.ts
+++ b/src/core/currency/wallet/currency-wallet-callbacks.ts
@@ -28,6 +28,7 @@ import { asIntegerString } from './currency-wallet-cleaners'
 import {
   reloadWalletFiles,
   saveSeenTxCheckpointFile,
+  saveTxSecret,
   setupNewTxMetadata
 } from './currency-wallet-files'
 import {
@@ -377,16 +378,37 @@ export function makeCurrencyWalletCallbacks(
       const txidHashes: TxidHashes = {}
       const changed: EdgeTransaction[] = []
       const created: EdgeTransaction[] = []
+      const secretSaves: Array<Promise<EdgeTransaction | undefined>> = []
       for (const txEvent of txEvents) {
         const { isNew, transaction: tx } = txEvent
         const { txid } = tx
+        const txidHash = hashStorageWalletFilename(state, walletId, txid)
+        const reduxTx = mergeTx(tx, reduxTxs[txid])
+
+        // Save a secret the engine only learned after the transaction's file
+        // was written. This runs ahead of the change check below because the
+        // merged transaction carries no secret, so a transaction that gained
+        // one still compares as unchanged, and it reports the saved secret
+        // itself for the same reason: the change check would drop it. Each
+        // save catches its own failure, so one bad write cannot swallow the
+        // reports of the ones that worked:
+        if (tx.txSecret != null) {
+          secretSaves.push(
+            saveTxSecret(input, txidHash, tx.txSecret)
+              .then(txFile =>
+                txFile == null
+                  ? undefined
+                  : combineTxWithFile(input, reduxTx, txFile, tx.tokenId)
+              )
+              .catch(error => {
+                input.props.onError(error)
+                return undefined
+              })
+          )
+        }
 
         // Verify that something has changed:
-        const reduxTx = mergeTx(tx, reduxTxs[txid])
         if (compare(reduxTx, reduxTxs[txid]) && tx.metadata == null) continue
-
-        // Ensure the transaction has metadata:
-        const txidHash = hashStorageWalletFilename(state, walletId, txid)
 
         // Setup the metadata in memory only if we don't have if for the
         // transaction. Transaction metadata share a single file with the core,
@@ -424,6 +446,16 @@ export function makeCurrencyWalletCallbacks(
       })
       if (changed.length > 0) throttledOnTxChanged(changed)
       if (created.length > 0) throttledOnNewTx(created)
+
+      // Report the transactions that gained a secret. These are skipped above,
+      // so without this a listener would hold a transaction with no secret
+      // until something else about it changed:
+      if (secretSaves.length > 0) {
+        Promise.all(secretSaves).then(txs => {
+          const saved = txs.filter((tx): tx is EdgeTransaction => tx != null)
+          if (saved.length > 0) throttledOnTxChanged(saved)
+        }, input.props.onError)
+      }
     },
     onTransactionsChanged(txs: EdgeTransaction[]) {
       out.onTransactions(

--- a/src/core/currency/wallet/currency-wallet-files.ts
+++ b/src/core/currency/wallet/currency-wallet-files.ts
@@ -492,6 +492,32 @@ export async function loadAddressFiles(
 }
 
 /**
+ * Serializes the read-modify-write cycles over one transaction file.
+ *
+ * Several writers load a transaction file, change one part of it, and save the
+ * whole thing back. Interleaved, the later save writes a copy that predates the
+ * earlier one and silently drops its change, which for a transaction secret
+ * means losing a key that cannot be recovered.
+ */
+const txFileQueues = new Map<string, Promise<unknown>>()
+
+async function withTxFile<T>(
+  walletId: string,
+  fileName: string,
+  task: () => Promise<T>
+): Promise<T> {
+  const key = `${walletId}:${fileName}`
+  const queued = (txFileQueues.get(key) ?? Promise.resolve()).then(task, task)
+  // Keep the queue itself alive when a task rejects, but let the caller see
+  // the rejection:
+  txFileQueues.set(
+    key,
+    queued.catch(() => {})
+  )
+  return await queued
+}
+
+/**
  * Changes a wallet's metadata.
  */
 export async function updateCurrencyWalletTxMetadata(
@@ -525,41 +551,58 @@ export async function updateCurrencyWalletTxMetadata(
     tx.date
   )
 
-  // Get the old file data if it exists:
-  const oldFile = await transactionFile.load(disklet, `transaction/${fileName}`)
+  const newFile = await withTxFile(walletId, fileName, async () => {
+    // Get the old file data if it exists:
+    const oldFile = await transactionFile.load(
+      disklet,
+      `transaction/${fileName}`
+    )
 
-  // Merge with old file
-  const newFile: TransactionFile = {
-    ...oldFile,
-    creationDate,
-    currencies: new Map(oldFile?.currencies ?? []),
-    internal: true,
-    tokens: new Map(oldFile?.tokens ?? []),
-    txid
-  }
+    // Merge with old file
+    const newFile: TransactionFile = {
+      ...oldFile,
+      creationDate,
+      currencies: new Map(oldFile?.currencies ?? []),
+      internal: true,
+      tokens: new Map(oldFile?.tokens ?? []),
+      txid
+    }
 
-  // Migrate the asset data from currencyCode to tokenId:
-  const assetData: TransactionAsset = {
-    metadata: {},
-    ...newFile.currencies.get(currencyCode),
-    ...newFile.tokens.get(tokenId)
-  }
-  newFile.tokens.set(tokenId, assetData)
-  newFile.currencies.delete(currencyCode)
+    // Migrate the asset data from currencyCode to tokenId:
+    const assetData: TransactionAsset = {
+      metadata: {},
+      ...newFile.currencies.get(currencyCode),
+      ...newFile.tokens.get(tokenId)
+    }
+    newFile.tokens.set(tokenId, assetData)
+    newFile.currencies.delete(currencyCode)
 
-  // Make the change:
-  if (metadataChange != null) {
-    assetData.metadata = mergeMetadata(assetData.metadata ?? {}, metadataChange)
-  }
-  if (assetAction != null) assetData.assetAction = assetAction
-  if (savedAction != null) newFile.savedAction = savedAction
+    // Make the change:
+    if (metadataChange != null) {
+      assetData.metadata = mergeMetadata(
+        assetData.metadata ?? {},
+        metadataChange
+      )
+    }
+    if (assetAction != null) assetData.assetAction = assetAction
+    if (savedAction != null) newFile.savedAction = savedAction
 
-  // Save the new file:
-  dispatch({
-    type: 'CURRENCY_WALLET_FILE_CHANGED',
-    payload: { creationDate, fileName, json: newFile, txid, txidHash, walletId }
+    // Save the new file:
+    dispatch({
+      type: 'CURRENCY_WALLET_FILE_CHANGED',
+      payload: {
+        creationDate,
+        fileName,
+        json: newFile,
+        txid,
+        txidHash,
+        walletId
+      }
+    })
+    await transactionFile.save(disklet, 'transaction/' + fileName, newFile)
+    return newFile
   })
-  await transactionFile.save(disklet, 'transaction/' + fileName, newFile)
+
   const callbackTx = combineTxWithFile(input, tx, newFile, tokenId)
   fakeCallbacks.onTransactions([
     // This method is used to update metadata for existing/seen transactions,
@@ -639,6 +682,66 @@ export async function setupNewTxMetadata(
   })
 
   return { fileName, txFile }
+}
+
+/**
+ * Fills in a transaction secret an engine reported after the transaction's
+ * metadata file already existed.
+ *
+ * That file is the only place the core keeps a secret, and it is written once,
+ * when the transaction is first seen. An engine can learn a secret later than
+ * that: a Monero wallet only knows a transaction key once it has built the
+ * transaction, and can report keys for transactions the core saved back when
+ * the engine reported none. Losing the key loses the sender's only proof of
+ * the payment, so save a late one instead of dropping it.
+ *
+ * An existing secret is never replaced. Only the wallet that built a
+ * transaction can produce its secret, so a disagreement means the stored one is
+ * no less trustworthy, and overwriting it would let a re-sync of bad data
+ * destroy a good key.
+ *
+ * Returns the saved file, or `undefined` when there was nothing to save, so the
+ * caller can report the change.
+ */
+export async function saveTxSecret(
+  input: CurrencyWalletInput,
+  txidHash: string,
+  secret: string
+): Promise<TransactionFile | undefined> {
+  const { dispatch, walletId } = input.props
+
+  const fileName = input.props.walletState.fileNames[txidHash]?.fileName
+  if (fileName == null) return
+
+  return await withTxFile(walletId, fileName, async () => {
+    // Transaction files load lazily, so a transaction that has been on disk
+    // since before this session usually has no file in memory. Read it rather
+    // than treating it as absent, which would drop the secret again, and the
+    // transactions this runs for are exactly the old ones nobody has opened.
+    const oldFile =
+      input.props.walletState.files[txidHash] ??
+      (await loadTxFiles(input, [txidHash]))[txidHash]
+    if (oldFile == null || oldFile.secret != null) return
+
+    // Write before reporting the file as changed. The never-replace rule above
+    // reads the in-memory copy, so a failed write that had already updated
+    // memory would make every later report skip this transaction:
+    const txFile: TransactionFile = { ...oldFile, secret }
+    const { creationDate, txid } = txFile
+    await saveTxMetadataFile(input, fileName, txFile)
+    dispatch({
+      type: 'CURRENCY_WALLET_FILE_CHANGED',
+      payload: {
+        creationDate,
+        fileName,
+        json: txFile,
+        txid,
+        txidHash,
+        walletId
+      }
+    })
+    return txFile
+  })
 }
 
 /**

--- a/test/core/currency/wallet/currency-wallet.test.ts
+++ b/test/core/currency/wallet/currency-wallet.test.ts
@@ -733,6 +733,91 @@ describe('currency wallets', function () {
     })
   })
 
+  it('can save a transaction secret reported after the fact', async function () {
+    const log = makeAssertLog()
+    const { wallet, config } = await makeFakeCurrencyWallet()
+    wallet.on('transactionsChanged', txs => {
+      log(
+        'changed',
+        txs.map(tx => `${tx.txid}:${String(tx.txSecret)}`).join(' ')
+      )
+    })
+
+    // The engine has no secret for this transaction yet:
+    await config.changeUserSettings({ txs: { a: { nativeAmount: '25' } } })
+    const txs = await wallet.getTransactions({ tokenId: null })
+    expect(txs.length).equals(1)
+    expect(txs[0].txSecret).equals(undefined)
+
+    // Reporting the secret saves it, even though nothing else changed, and
+    // reports the transaction so listeners do not keep the secret-less one:
+    await config.changeUserSettings({
+      txs: { a: { nativeAmount: '25', txSecret: 'open sesame' } }
+    })
+    await log.waitFor(1).assert('changed a:open sesame')
+    const txs2 = await wallet.getTransactions({ tokenId: null })
+    expect(txs2.length).equals(1)
+    expect(txs2[0].txSecret).equals('open sesame')
+
+    // A secret we already have is never replaced, and reports nothing:
+    await config.changeUserSettings({
+      txs: { a: { nativeAmount: '25', txSecret: 'abracadabra' } }
+    })
+    const txs3 = await wallet.getTransactions({ tokenId: null })
+    expect(txs3.length).equals(1)
+    expect(txs3[0].txSecret).equals('open sesame')
+    log.assert()
+  })
+
+  it('can save a transaction secret onto a file from an earlier session', async function () {
+    const world = await makeFakeEdgeWorld([fakeUser], quiet)
+    const plugins = { 'broken-engine': true, fakecoin: true }
+    const sentTx: EdgeTransaction = {
+      blockHeight: 0,
+      currencyCode: 'FAKE',
+      date: 1,
+      isSend: true,
+      memos: [],
+      nativeAmount: '-50',
+      networkFee: '0',
+      networkFees: [],
+      ourReceiveAddresses: [],
+      signedTx: '',
+      tokenId: null,
+      txid: 'sent',
+      walletId: ''
+    }
+
+    // Session one saves a send, which is what puts a transaction file on disk.
+    // This one has no secret, the way every Monero send did before the engine
+    // started reporting transaction keys:
+    const context = await world.makeEdgeContext({ ...contextOptions, plugins })
+    const account = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
+    const walletInfo = account.getFirstWalletInfo('wallet:fakecoin')
+    if (walletInfo == null) throw new Error('Broken test account')
+    const wallet = await account.waitForCurrencyWallet(walletInfo.id)
+    await wallet.saveTx({ ...sentTx, walletId: wallet.id })
+    await account.logout()
+
+    // Session two knows the file's name but has not read the file, which is
+    // the state a late secret normally arrives in, since transaction files
+    // only load when somebody asks for the transactions:
+    const log = makeAssertLog()
+    const account2 = await context.loginWithPIN(fakeUser.username, fakeUser.pin)
+    const wallet2 = await account2.waitForCurrencyWallet(walletInfo.id)
+    wallet2.on('transactionsChanged', txs => {
+      log('changed', txs.map(tx => String(tx.txSecret)).join(' '))
+    })
+    await account2.currencyConfig.fakecoin.changeUserSettings({
+      txs: { sent: { nativeAmount: '-50', txSecret: 'open sesame' } }
+    })
+    await log.waitFor(1).assert('changed open sesame')
+
+    const txs = await wallet2.getTransactions({ tokenId: null })
+    expect(txs.length).equals(1)
+    expect(txs[0].txSecret).equals('open sesame')
+  })
+
   it('can be paused and un-paused', async function () {
     const { wallet, context } = await makeFakeCurrencyWallet(true)
     const isEngineRunning = async (): Promise<boolean> => {


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

A transaction's secret lives in its metadata file and nowhere else: `setupNewTxMetadata` writes `txFile.secret`, and `combineTxWithFile` reads `txSecret` back from `file.secret` alone. That file is written once, the first time the core sees a transaction, so a secret an engine learns any later than that was simply dropped, and a transaction already on file could never gain one.

Monero is where this bites. A Monero wallet only knows a transaction key once it has built the transaction, and it can report keys for transactions the core saved back when the engine reported none. The key is the sender's only proof of a payment, and it cannot be recovered from the seed, so dropping it is permanent.

`saveTxSecret` saves such a secret onto the existing file:

- It runs ahead of the unchanged-transaction check, because `mergeTx` does not carry the secret: a transaction that gained one still compares as unchanged and would be skipped. For the same reason it reports the transactions it saved itself, so a listener does not keep holding one with no secret.
- It reads the file from disk when `fileNames` lists it but `files` does not. Transaction files only load when somebody asks for the transactions, so the old transactions this exists for normally have no file in memory.
- It writes to disk before reporting the file as changed, so a failed write cannot leave the in-memory copy claiming a secret that never landed, which would make every later report skip the transaction.
- An existing secret is never replaced. Only the wallet that built a transaction can produce its secret, so a disagreement means the stored one is no less trustworthy, and overwriting would let a re-sync of bad data destroy a good key.

`withTxFile` serializes the load-modify-write cycles over a single transaction file, shared with `updateCurrencyWalletTxMetadata`. Both writers rewrite the whole file from a snapshot, so interleaved they could each drop the other's change.

Companion fix in the Monero engine: [EdgeApp/edge-currency-accountbased#1086](https://github.com/EdgeApp/edge-currency-accountbased/pull/1086)

Asana: https://app.asana.com/0/1215088146871429/1216965258637021
