### PR TITLE
Rerandomize the NYM mixnet client id on each connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Rerandomize the NYM mixnet client id on each connect, so a client registration that goes bad is abandoned instead of being reloaded from storage by every later connect and every later app launch.
+
 ## 2.47.1 (2026-07-17)
 
 - fixed: Revert `@nymproject/mix-fetch` to v1 (1.4.4), restoring the pinned gateway and network requester. The v2 stack shipped in 2.47.0 fails to complete small HTTPS JSON-RPC requests through most exit nodes and its exit-node auto-discovery rarely converges, which left wallets with NYM privacy enabled unable to sync or send.

--- a/src/io/browser/browser-io.ts
+++ b/src/io/browser/browser-io.ts
@@ -3,7 +3,7 @@ import { makeLocalStorageDisklet } from 'disklet'
 import { LogBackend, makeLog } from '../../core/log/log'
 import { EdgeFetchOptions, EdgeFetchResponse, EdgeIo } from '../../types/types'
 import { scrypt } from '../../util/crypto/scrypt'
-import { initMixFetch, mixFetchOptions } from '../../util/nym'
+import { initMixFetch } from '../../util/nym'
 import { fetchCorsProxy } from './fetch-cors-proxy'
 
 // Only try CORS proxy/bridge techniques up to 5 times
@@ -50,14 +50,10 @@ export function makeBrowserIo(logBackend: LogBackend): EdgeIo {
 
       if (privacy === 'nym') {
         const nymFetch = await initMixFetch(log)
-        return await nymFetch(
-          uri,
-          {
-            ...opts,
-            mode: 'unsafe-ignore-cors' as RequestMode
-          },
-          mixFetchOptions
-        )
+        return await nymFetch(uri, {
+          ...opts,
+          mode: 'unsafe-ignore-cors' as RequestMode
+        })
       }
       if (corsBypass === 'always') {
         return await fetchCorsProxy(uri, opts)

--- a/src/io/react-native/react-native-worker.ts
+++ b/src/io/react-native/react-native-worker.ts
@@ -17,7 +17,7 @@ import {
   EdgeFetchResponse,
   EdgeIo
 } from '../../types/types'
-import { initMixFetch, mixFetchOptions } from '../../util/nym'
+import { initMixFetch } from '../../util/nym'
 import { hideProperties } from '../hidden-properties'
 import { makeNativeBridge } from './native-bridge'
 import { WorkerApi, YAOB_THROTTLE_MS } from './react-native-types'
@@ -177,14 +177,10 @@ async function makeIo(logBackend: LogBackend): Promise<EdgeIo> {
 
       if (privacy === 'nym') {
         const nymFetch = await initMixFetch(log)
-        const response = await nymFetch(
-          uri,
-          {
-            ...opts,
-            mode: 'unsafe-ignore-cors' as RequestMode
-          },
-          mixFetchOptions
-        )
+        const response = await nymFetch(uri, {
+          ...opts,
+          mode: 'unsafe-ignore-cors' as RequestMode
+        })
         return response
       }
       if (corsBypass === 'always') {

--- a/src/util/nym.ts
+++ b/src/util/nym.ts
@@ -9,10 +9,37 @@ import {
 import { EdgeLog } from '../types/types'
 
 /**
- * Configuration options for the NYM mixFetch client.
+ * Mint the client id for one mixnet client.
+ *
+ * `clientId` names the client's persistent key storage, so every setup that
+ * passes the same id adopts whatever registration the previous one left
+ * behind. A registration that went bad therefore stays bad for every later
+ * connect, including across app launches, which surfaces as a wallet that
+ * never syncs and never recovers. Nym's guidance is to rerandomise on
+ * connect: a fresh id simply abandons the poisoned storage.
+ *
+ * The cost is a fresh gateway registration per setup, which the measured
+ * ~10s handshake already covers.
  */
-export const mixFetchOptions: SetupMixFetchOps = {
-  clientId: 'edge-core-js-2026-03-10',
+const makeClientId = (): string => {
+  const bytes = new Uint8Array(16)
+  const { crypto } = globalThis
+  if (crypto?.getRandomValues != null) {
+    crypto.getRandomValues(bytes)
+  } else {
+    for (let i = 0; i < bytes.length; ++i) {
+      bytes[i] = Math.floor(Math.random() * 256)
+    }
+  }
+  const hex = Array.from(bytes, byte => byte.toString(16).padStart(2, '0'))
+  return `edge-core-js-${hex.join('')}`
+}
+
+/**
+ * Configuration options for the NYM mixFetch client, minus the per-setup
+ * `clientId` that `initMixFetch` adds.
+ */
+const mixFetchOptions: Omit<SetupMixFetchOps, 'clientId'> = {
   preferredGateway: '5rXcNe2a44vXisK3uqLHCzpzvEwcnsijDMU7hg4fcYk8', // with WSS
   preferredNetworkRequester:
     '5x6q9UfVHs5AohKMUqeivj7a556kVVy7QwoKige8xHxh.6CFoB3kJaDbYz6oafPJxNxNjzahpT2NtgtytcSyN9EvF@5rXcNe2a44vXisK3uqLHCzpzvEwcnsijDMU7hg4fcYk8',
@@ -42,7 +69,10 @@ let mixFetchInitPromise: Promise<IMixFetch> | null = null
 export async function initMixFetch(log: EdgeLog): Promise<IMixFetchFn> {
   if (mixFetchInitPromise == null) {
     log('Initializing mixFetch...')
-    const pending = createMixFetch(mixFetchOptions)
+    const pending = createMixFetch({
+      ...mixFetchOptions,
+      clientId: makeClientId()
+    })
     // The timeout below can abandon this setup while it is still in flight.
     // Deliberately do NOT tear it down on late completion: `createMixFetch`
     // resolves to a healthy global singleton, and disconnecting it (a


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1217537315710871/f)

`clientId` names the mixnet client's persistent key storage, and `src/util/nym.ts` passed the same hardcoded `'edge-core-js-2026-03-10'` on every setup. A client whose registration went bad therefore reloaded that same bad storage on every later connect, and across app restarts, so a wallet that got stuck stayed stuck until the app was reinstalled. This mints a fresh 16-byte random id per connect instead, which is what the Nym team recommends for exactly this failure mode.

The change also drops the third argument at both `fetch` call sites. `initMixFetch` has already created the instance, and the instance-bound `mixFetch` takes only `(url, args)`, so the options object was being silently discarded. That removes the last consumer of the exported options object, which is now private to `nym.ts`.

**Verified on the iOS sim** (Nym mixnet ON for Ethereum, Avalanche, Coreum and Monero on a throwaway account):

- Two launches minted `edge-core-js-a260f91f…` and `edge-core-js-33ca108a…`; across the whole session 11 distinct random ids were written. Every file still containing the old constant has an mtime from July, so it survives only as residue from earlier builds.
- `com.apple.WebKit.Networking` (the core WebView's network process) held an established WSS connection to `nym-exit.tha1.craftdome.app:9001`, a Nym entry/exit gateway, throughout.
- **A real ETH send completed through the mixnet**: 0.0010499 ETH ($2.08, fee 0.000043 ETH) reached Transaction Success. Fee calculation resolved in about 90s. Both prior runs on this feature recorded "no successful send was reached" as a testing gap, so this closes it.

This PR carries the code change only. The task it belongs to is an evaluation of re-upgrading to `@nymproject/mix-fetch` v2; that verdict is **do not upgrade yet**, and the measurements behind it are attached to the Asana task rather than repeated here. The short version: 2.0.1 cannot connect at all (its WASM panics in `nym_http_api_client` calling `std::time::Instant::now`, which is unsupported on `wasm32-unknown-unknown`), and 2.0.0 was 4-in-10 clean against v1's 9-in-10 over ten paired harness runs, with the same in-app send hanging at `tunnel error: IPR connect timed out` where v1 succeeded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes NYM mixnet client identity and registration on each setup (extra ~10s handshake tradeoff), but scope is limited to privacy fetch initialization and call wiring.
> 
> **Overview**
> Fixes NYM mixnet wallets that **never recover** after a bad gateway registration by **minting a fresh `clientId` on each `initMixFetch` setup** instead of reusing the hardcoded `edge-core-js-2026-03-10`. Because `clientId` keys persistent registration storage, a poisoned registration was reused on every connect and across app launches until reinstall.
> 
> `makeClientId()` in `nym.ts` generates a 16-byte random `edge-core-js-…` id (with `crypto.getRandomValues` when available). Static mixnet options stay the same but **`mixFetchOptions` is no longer exported**; `clientId` is injected only when calling `createMixFetch`.
> 
> Browser and React Native **`privacy: 'nym'` fetch paths** now call the instance `nymFetch` with **only URL and request options**, dropping a third argument that was ignored after init anyway.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87dffc63842cb21eb03c7501e6dfee88f7ba15da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->