### PR TITLE
Back off NYM mixFetch setup after a failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Stop rebuilding the NYM mixFetch client on every request while its gateway is failing. Each attempt spawns a web worker holding megabytes of WASM that the library gives no way to terminate, so a poll loop retrying every few seconds exhausted the host's memory and killed the JS context, which on iOS reads to the user as being logged out. A failed setup now starts a cooldown that doubles up to five minutes.
+
 ## 2.48.0 (2026-08-20)
 
 - added: `EdgeContext.setAttestationToken` to attach an `x-attestation-token` header on login-server requests.

--- a/src/util/nym.ts
+++ b/src/util/nym.ts
@@ -32,54 +32,148 @@ export const mixFetchOptions: SetupMixFetchOps = {
  */
 const SETUP_TIMEOUT_MS = 60000
 
-// MixFetch initialization state
-let mixFetchInitPromise: Promise<IMixFetch> | null = null
+/**
+ * How long to refuse new setups after one fails, and the ceiling that wait
+ * doubles up to.
+ *
+ * Every `createMixFetch` spawns a web worker holding megabytes of WASM before
+ * it ever contacts the gateway, and the library exposes no way to terminate
+ * that worker, so a failed setup leaves one behind. Retrying on each request
+ * therefore costs memory per attempt: with a dead gateway and a poll loop
+ * driving requests every few seconds, the workers accumulate until the host
+ * kills the whole JS context. On iOS that reads to the user as being logged
+ * out, since the core's WebView is what gets killed and reloaded.
+ *
+ * A cooldown bounds the cost to one worker per window, and the doubling keeps
+ * a long outage from spending any meaningful memory at all.
+ */
+const RETRY_BASE_MS = 30000
+const RETRY_MAX_MS = 300000
 
 /**
- * Initialize the NYM mixFetch client. Must be called before using mixFetch.
- * Safe to call multiple times - subsequent calls return the same promise.
+ * Builds the mixFetch setup routine over its own cooldown state.
+ *
+ * The returned function initializes the NYM mixFetch client, and must be
+ * called before using mixFetch. It is safe to call multiple times: subsequent
+ * calls return the same promise.
+ *
+ * A failed setup starts a cooldown: calls made before it expires fail
+ * immediately with the error that started it, instead of building another
+ * client.
+ *
+ * Tests build their own instance over a clock they control, which also gives
+ * them fresh state per case.
+ *
+ * The cooldown state is per instance, but the client, its worker and
+ * `window.__mixFetchGlobal` are process-global, so two live instances would
+ * each hold a cooldown of their own while spawning workers into the same
+ * process. The single instance exported below is the only supported
+ * arrangement.
  */
-export async function initMixFetch(log: EdgeLog): Promise<IMixFetchFn> {
-  if (mixFetchInitPromise == null) {
-    log('Initializing mixFetch...')
-    const pending = createMixFetch(mixFetchOptions)
-    // The timeout below can abandon this setup while it is still in flight.
-    // Deliberately do NOT tear it down on late completion: `createMixFetch`
-    // resolves to a healthy global singleton, and disconnecting it (a
-    // process-wide operation) would race a newer init that has taken over.
-    // A late completion just repopulates `__mixFetchGlobal`, which the next
-    // init reuses. Swallow a late rejection so it is not unhandled.
-    pending.catch(() => {})
-    let timer: ReturnType<typeof setTimeout> | undefined
-    const timeout = new Promise<never>((resolve, reject) => {
-      timer = setTimeout(() => {
-        reject(
-          new Error(`mixFetch setup timed out after ${SETUP_TIMEOUT_MS}ms`)
+export function makeMixFetchSetup(
+  now: () => number = () => Date.now()
+): (log: EdgeLog) => Promise<IMixFetchFn> {
+  let mixFetchInitPromise: Promise<IMixFetch> | null = null
+
+  /** When a new setup may be attempted, and the wait that produced it. */
+  let retryAfter: number = 0
+  let retryDelay: number = RETRY_BASE_MS
+
+  /** The failure to re-throw for callers that arrive during the cooldown. */
+  let lastError: unknown
+
+  return async function initMixFetch(log: EdgeLog): Promise<IMixFetchFn> {
+    if (mixFetchInitPromise == null) {
+      if (now() < retryAfter) {
+        // Re-throwing `lastError` itself would hand the caller a stack and a
+        // message from a setup that ended minutes ago, so a cooldown
+        // rejection reads in a crash report as a fresh 60-second timeout. It
+        // is also not necessarily an `Error`: the library rejects with a raw
+        // `MessageEvent` on a worker error, so `.message` can be undefined
+        // downstream.
+        //
+        // Nothing is logged here. This runs once per refused caller, and the
+        // breadcrumb that makes the quiet window visible is emitted once per
+        // window where the cooldown is armed.
+        const remainingMs = retryAfter - now()
+        const error: Error & { cause?: unknown } = new Error(
+          `mixFetch setup is cooling down for another ${Math.round(
+            remainingMs / 1000
+          )}s`
         )
-      }, SETUP_TIMEOUT_MS)
-    })
-    mixFetchInitPromise = Promise.race([pending, timeout])
-      .then(mixFetchModule => {
-        log('mixFetch initialized successfully')
-        return mixFetchModule
-      })
-      .catch(async error => {
-        // Clean up stale global state left by the failed init so the
-        // next createMixFetch call starts fresh instead of reusing a
-        // broken singleton.
-        try {
-          await disconnectMixFetch()
-        } catch {}
-        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-        delete (window as any).__mixFetchGlobal
-        mixFetchInitPromise = null
-        log.error('mixFetch initialization failed:', error)
+        error.cause = lastError
         throw error
+      }
+
+      log('Initializing mixFetch...')
+      const pending = createMixFetch(mixFetchOptions)
+      // The timeout below can abandon this setup while it is still in flight.
+      // `createMixFetch` publishes `window.__mixFetchGlobal` as soon as the
+      // worker exists and only then awaits the gateway handshake
+      // (`@nymproject/mix-fetch/index.js:446-449`), so the failure path
+      // usually deletes a global whose owner is already past that assignment:
+      // the abandoned worker stays alive and unreachable, and the next setup
+      // builds a fresh one. A delete that lands before the assignment lets the
+      // late completion re-publish instead, and the line right after it
+      // configures that client, so the next setup finds a working global
+      // rather than an unconfigured one. Either way the cost is one worker per
+      // cooldown window, against a ceiling of RETRY_MAX_MS. Swallow the late
+      // rejection so it is not unhandled.
+      pending.catch(() => {})
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const timeout = new Promise<never>((resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new Error(`mixFetch setup timed out after ${SETUP_TIMEOUT_MS}ms`)
+          )
+        }, SETUP_TIMEOUT_MS)
       })
-      .finally(() => {
-        clearTimeout(timer)
-      })
+      mixFetchInitPromise = Promise.race([pending, timeout])
+        .then(mixFetchModule => {
+          log('mixFetch initialized successfully')
+          return mixFetchModule
+        })
+        .catch(error => {
+          // Arm the cooldown before any cleanup. The timeout fires while the
+          // setup is still running, so the disconnect below is an RPC into a
+          // worker that is still busy and has no bounded completion; awaiting
+          // it would leave `mixFetchInitPromise` pending forever, and every
+          // later caller would await that instead of failing fast.
+          mixFetchInitPromise = null
+          lastError = error
+          retryAfter = now() + retryDelay
+          log.error(
+            `mixFetch initialization failed (no retry for ${Math.round(
+              retryDelay / 1000
+            )}s):`,
+            error
+          )
+          // One breadcrumb per cooldown window, not one per refused caller.
+          // The app caps Sentry at 25 breadcrumbs, so a poll loop retrying
+          // every few seconds would evict the whole history in about a
+          // minute, blinding the crash report this failure most needs to
+          // appear in. Emitted before the doubling below, so it names the
+          // window actually armed.
+          log.breadcrumb('mixFetch setup failed, cooling down', {
+            cooldownMs: retryDelay
+          })
+          retryDelay = Math.min(retryDelay * 2, RETRY_MAX_MS)
+
+          // Best-effort: clear the library's singleton so the next setup starts
+          // fresh instead of reusing a broken one. Not awaited, per above.
+          disconnectMixFetch().catch(() => {})
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+          delete (window as any).__mixFetchGlobal
+
+          throw error
+        })
+        .finally(() => {
+          clearTimeout(timer)
+        })
+    }
+    const mixFetchModule = await mixFetchInitPromise
+    return mixFetchModule.mixFetch
   }
-  const mixFetchModule = await mixFetchInitPromise
-  return mixFetchModule.mixFetch
 }
+
+export const initMixFetch = makeMixFetchSetup()

--- a/test/util/nym.test.ts
+++ b/test/util/nym.test.ts
@@ -1,0 +1,143 @@
+import { expect } from 'chai'
+import { afterEach, beforeEach, describe, it } from 'mocha'
+
+import { EdgeLog } from '../../src/types/types'
+import { expectRejection } from '../expect-rejection'
+
+/**
+ * `nym.ts` imports `@nymproject/mix-fetch`, whose entry point is browser-only
+ * WASM. These tests replace it in the module cache with a fake that counts how
+ * many clients get built, which is the number the cooldown exists to bound:
+ * every `createMixFetch` spawns a worker holding megabytes of WASM that the
+ * library never lets us terminate.
+ */
+let setupCount = 0
+let setupFails = true
+let disconnectHangs = false
+
+const mixFetchPath = require.resolve('@nymproject/mix-fetch')
+require.cache[mixFetchPath] = {
+  id: mixFetchPath,
+  filename: mixFetchPath,
+  loaded: true,
+  exports: {
+    async createMixFetch() {
+      ++setupCount
+      if (setupFails) throw new Error('gateway client error')
+      return { mixFetch: async () => new Response('') }
+    },
+    async disconnectMixFetch() {
+      // The real one is a Comlink RPC into the WASM worker, so it does not
+      // complete while that worker is still busy connecting.
+      if (disconnectHangs) await new Promise(() => {})
+    }
+  }
+} as unknown as NodeModule
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { makeMixFetchSetup } = require('../../src/util/nym')
+
+const breadcrumbs: string[] = []
+const fakeLog: EdgeLog = Object.assign(() => {}, {
+  breadcrumb: (message: string) => breadcrumbs.push(message),
+  crash: () => {},
+  warn: () => {},
+  error: () => {}
+})
+
+describe('nym mixFetch setup', function () {
+  let clock = 0
+  let initMixFetch: (log: EdgeLog) => Promise<unknown>
+
+  beforeEach(function () {
+    setupCount = 0
+    setupFails = true
+    disconnectHangs = false
+    breadcrumbs.length = 0
+    clock = 1_000_000
+    ;(global as any).window = {}
+    initMixFetch = makeMixFetchSetup(() => clock)
+  })
+
+  afterEach(function () {
+    delete (global as any).window
+  })
+
+  it('builds one client per cooldown window, not one per request', async function () {
+    await expectRejection(initMixFetch(fakeLog))
+    expect(setupCount).equals(1)
+
+    // Every caller during the cooldown fails without building a client. This
+    // is the leak the app hit: a poll loop drove a new WASM worker every few
+    // seconds until the host killed the JS context.
+    for (let i = 0; i < 10; ++i) {
+      clock += 2500
+      await expectRejection(initMixFetch(fakeLog))
+    }
+    expect(setupCount).equals(1)
+  })
+
+  it('rejects a cooling-down caller with its own error', async function () {
+    await expectRejection(initMixFetch(fakeLog))
+
+    // Not the original failure re-thrown: that reports a stale timeout in
+    // crash reports, and is not guaranteed to be an `Error` at all.
+    clock += 2500
+    const error = await initMixFetch(fakeLog).then(
+      () => undefined,
+      (error: Error & { cause?: unknown }) => error
+    )
+    expect(error?.message).contains('cooling down')
+    expect((error?.cause as Error)?.message).equals('gateway client error')
+  })
+
+  it('breadcrumbs once per cooldown window, not once per refused caller', async function () {
+    // The app caps Sentry at 25 breadcrumbs. One per refused caller would
+    // evict the app's whole crash-report history within a minute of polling.
+    await expectRejection(initMixFetch(fakeLog))
+    expect(breadcrumbs).deep.equals(['mixFetch setup failed, cooling down'])
+
+    for (let i = 0; i < 10; ++i) {
+      clock += 2500
+      await expectRejection(initMixFetch(fakeLog))
+    }
+    expect(breadcrumbs.length).equals(1)
+
+    // A fresh window is worth its own breadcrumb:
+    clock += 30000
+    await expectRejection(initMixFetch(fakeLog))
+    expect(breadcrumbs.length).equals(2)
+  })
+
+  it('retries once the cooldown expires, and backs off further', async function () {
+    await expectRejection(initMixFetch(fakeLog))
+    expect(setupCount).equals(1)
+
+    clock += 30000
+    await expectRejection(initMixFetch(fakeLog))
+    expect(setupCount).equals(2)
+
+    // The second failure doubles the wait, so the old 30s is not enough:
+    clock += 30000
+    await expectRejection(initMixFetch(fakeLog))
+    expect(setupCount).equals(2)
+
+    clock += 30000
+    await expectRejection(initMixFetch(fakeLog))
+    expect(setupCount).equals(3)
+  })
+
+  it('arms the cooldown even when the cleanup disconnect never settles', async function () {
+    // Awaiting the disconnect inside the failure path would leave the setup
+    // promise pending forever, so callers would hang instead of failing fast
+    // and the cooldown would never arm.
+    disconnectHangs = true
+
+    await expectRejection(initMixFetch(fakeLog))
+    expect(setupCount).equals(1)
+
+    clock += 2500
+    await expectRejection(initMixFetch(fakeLog))
+    expect(setupCount).equals(1)
+  })
+})


### PR DESCRIPTION
### Technical Design Document

[zano-migration-off-module-queue.md](https://github.com/EdgeApp/react-native-zano/blob/jon/zano-migration-tdd/src/docs/zano-migration-off-module-queue.md)

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

QA reported an iOS test account logging itself out every minute or so with auto-logout set to one hour. The attached logs show it is not the logout timer: each re-login is preceded by `EdgeContext closed` and then `EdgeContext opened` about a second later, with no JS bundle relaunch. That is `EdgeCoreWebView.webViewWebContentProcessDidTerminate` calling `visitPage()`, so iOS killed the core WebView's WebContent process for memory and the core reloaded itself, dropping the session.

What exhausts the memory is the NYM mixFetch setup path. `initMixFetch` sets its cached promise back to null whenever a setup fails, so the next privacy fetch immediately builds another client. `createMixFetch` spawns a web worker that loads about 13 MB of WASM before it ever contacts the gateway, and the library exposes no way to terminate that worker, so each failed attempt leaves one behind. With an engine poll loop driving a request every few seconds against a gateway that is refusing the client, roughly thirty workers accumulate inside a minute and the WebContent process is killed.

In the reported logs every crash-looping session carries `Initializing mixFetch...` about every 2.5 seconds, each ending in `gateway client error (5rXcNe2a...)`; the one long healthy session in the same file has no mixFetch lines at all.

This change gives a failed setup a cooldown, starting at 30 seconds and doubling to a 5 minute ceiling. Callers arriving during the cooldown reject immediately instead of building another client, so a dead gateway costs one worker per window instead of one per request.

The reported symptom needs both an account with NYM privacy enabled and a failing gateway, which is why it does not appear on a default account.

### What review changed

Four rounds with @peachbits reshaped the details, and the notes are worth carrying here because each one is load-bearing:

- **The cooldown is armed before the library is touched.** The failure handler is no longer `async`: it nulls the cached promise, records the error and sets `retryAfter` first, then fires `disconnectMixFetch().catch(() => {})` without awaiting it. Comlink's request path (`index.js:342-351`) builds a promise with no reject and no timeout, so a disconnect issued against a worker the OS already killed never settles. Awaiting it stranded every line below, the cooldown included, which is the freeze this PR exists to prevent. A test makes the fake disconnect hang forever and fails against the awaited form.
- **A cooling-down caller gets its own error, not the stored instance.** Re-throwing `lastError` handed callers a stack from a setup that ended minutes ago, so a 0 ms rejection read in a crash report as a fresh 60 second timeout. The rejection now names the remaining wait and carries the original as `cause`, which also drops the assumption that `lastError` is an `Error` at all: the library rejects with a raw `MessageEvent` on a worker error.
- **One breadcrumb per cooldown window, not one per refused caller.** The GUI caps Sentry at `maxBreadcrumbs: 25` (`src/app.ts:45`), so a poll loop refusing every few seconds would evict the app's whole breadcrumb history inside a minute, blinding the crash report this fix exists to inform. The breadcrumb moved to the arming site and names the window actually armed. A test asserts the cardinality, since the failure mode is silent.
- **The setup routine is built by a factory.** `makeMixFetchSetup(now = () => Date.now())` closes over the cooldown state, and `export const initMixFetch = makeMixFetchSetup()` keeps both io call sites unchanged. That removed a `resetMixFetchForTests` export and a mutable module clock from the shipped surface, and gives each test fresh state for free. Its one caveat is documented on the function: the cooldown state is per instance while the client, its worker and `window.__mixFetchGlobal` are process-global, so the single exported instance is the only supported arrangement.
- **Dropped: clearing the cooldown on success.** Those resets were unreachable. The cached promise is only nulled in the failure handler, so after a success the guard at the top of the routine is false forever and nothing reads the cooldown state again. The test that appeared to cover them went with them.

### Testing

`test/util/nym.test.ts` drives the module against a controlled clock and counts how many clients get built. Five cases: twenty-five seconds of requests after a failure build exactly one client; a cooling-down caller is rejected with the naming error and the preserved `cause`; the breadcrumb fires once per window across eleven refusals and again on the next window; a retry happens once the window expires and the wait doubles after the second failure; and the cooldown still arms when the cleanup disconnect never settles. Each case was checked against the pre-fix code it guards.

The full suite reports 168 passing, `npm run types` is clean, and `verify-repo.sh` passed.

Driven in the app on an iOS simulator, with `edge-core-js` linked into `edge-react-gui` via updot and Ethereum's Network Privacy set to Nym Mixnet. The gateway failure is forced with a temporary uncommitted edit that rejects the setup after 2s, while still building the real client so each attempt still spawns its worker. Over 3m56s the engine's poll loop produced 82 privacy fetches, and the cooldown answered them with 4 client builds and 4 breadcrumbs, at 30s, 60s, 120s and 240s. The same drive with `RETRY_BASE_MS` set to 0 produced 47 builds and 47 breadcrumbs in 1m55s, one every ~2.4s, which is the cadence the QA logs carried. Screenshots are in the test-evidence comment below; both edits are reverted.

Still not verified: that WebContent memory stays flat across a long outage on a real device. The build rate is what this change controls and it is now measured, but the resulting memory ceiling was not observed on hardware.

Asana: https://app.asana.com/0/1215088146871429/1217733586839287
Parent: https://app.asana.com/0/1215088146871429/1217559756673909

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes NYM privacy fetch initialization on failure paths; mis-tuned backoff could delay recovery when the gateway returns, but the behavior only affects accounts with NYM privacy and a failing setup.
> 
> **Overview**
> Fixes an iOS symptom where NYM privacy with a **failing gateway** looked like repeated logouts: each failed **`createMixFetch`** left a WASM web worker alive, and **`initMixFetch`** cleared its cached promise on failure so poll-driven privacy fetches spawned a new worker every few seconds until the WebView process was killed for memory.
> 
> **`makeMixFetchSetup`** now owns per-instance cooldown state; production still uses **`export const initMixFetch = makeMixFetchSetup()`**. After a failed setup (including the existing 60s timeout), new attempts are **refused until a backoff window** passes—**30s initially, doubling up to 5 minutes**—instead of calling **`createMixFetch`** again. Callers during cooldown get a **fresh “cooling down” error** with the original failure on **`cause`**, not a re-thrown stale error. The cooldown is **armed before** best-effort **`disconnectMixFetch`** / global cleanup, which are **not awaited** so a hanging disconnect cannot block later callers. **One Sentry breadcrumb** is emitted per cooldown window. **`test/util/nym.test.ts`** covers client count, errors, breadcrumbs, backoff, and hang behavior with a fake mix-fetch module and injectable clock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eec286f7556166d17f1f9f6410880f55f3cec23e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->